### PR TITLE
Remove --dev param from the rust crate

### DIFF
--- a/crate/build.rs
+++ b/crate/build.rs
@@ -46,7 +46,7 @@ fn build_ui() -> io::Result<ExitStatus> {
     if !Path::new(STATIC_DIR).exists() || Path::new(STATIC_DIR).read_dir()?.next().is_none() {
         println!("Building UI...");
         Command::new(NPM_CMD)
-            .args(["run", "build", "--dev"])
+            .args(["run", "build"])
             .current_dir(UI_DIR)
             .status()
     } else {


### PR DESCRIPTION
Resolves https://github.com/trustification/trustify-ui/issues/19 and https://github.com/trustification/trustify-ui/issues/16

The UI is always build in prod mode (minified and compressed JS files).

If we want the UI to be seen in dev mode, then we have the `npm run start:dev` which is used for developers to start the UI