### PR TITLE
fix: fix docker build

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -34,6 +34,10 @@
   "ts-node": {
     "compilerOptions": {
       "module": "commonjs" // node16 == commonjs or es2020 depending on package.json/type
-    }
+    },
+    "ignore": [
+      "(?:^|/)node_modules/",
+      "(?:^|/)node_modules.*/"
+    ]
   }
 }


### PR DESCRIPTION
I see this as a temporary workaround since ts-node that is called by webpack is 'scanning' whatever contains .js inside docker and then trying to compile the things found.

We can see in the issue it is trying to compile a module from node-core (node_modules_20 directory)

Related to #14 


<details>
<summary>build output</summary>

```
➜  trustify-ui git:(fix-docker-build) ✗ podman build --network host . -f Containerfile.f40
STEP 1/6: FROM docker.io/library/fedora:40 AS builder
STEP 2/6: RUN dnf install -y npm nodejs
--> Using cache ba3396d724a9b7174645905ea7aa80f833dc95dc3cf71a38ef35d3b5ee83cdc8
--> ba3396d724a9
STEP 3/6: COPY . /usr/src
--> Using cache 751777072c492b44c708204706c85b0c272e3da21a50923b0c30331c62bfe421
--> 751777072c49
STEP 4/6: WORKDIR /usr/src
--> Using cache a3ca5f27edb81295e0fcce1a0e09d2a70da7b0da4b30948ce23826cee3a5ca92
--> a3ca5f27edb8
STEP 5/6: RUN npm clean-install --ignore-scripts --fetch-timeout=600000
npm WARN deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
npm WARN deprecated abab@2.0.6: Use your platform's native atob() and btoa() methods instead
npm WARN deprecated domexception@4.0.0: Use your platform's native DOMException instead

added 1498 packages, and audited 1503 packages in 1m

384 packages are looking for funding
  run `npm fund` for details

5 vulnerabilities (4 moderate, 1 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
npm notice
npm notice New minor version of npm available! 10.5.0 -> 10.8.0
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.8.0>
npm notice Run `npm install -g npm@10.8.0` to update!
npm notice
--> 79d51229f912
STEP 6/6: RUN npm run build --dev
npm WARN config dev Please use --include=dev instead.

> @trustify-ui/root@1.0.0 build
> npm run build -ws --if-present


> @trustify-ui/common@0.1.0 prebuild
> npm run clean


> @trustify-ui/common@0.1.0 clean
> rimraf ./dist


> @trustify-ui/common@0.1.0 build
> NODE_ENV=production rollup -c

Using branding assets from: /usr/src/branding

src/index.ts → dist/index.mjs, dist/index.cjs...
created dist/index.mjs, dist/index.cjs in 1.6s

> @trustify-ui/client@0.1.0 prebuild
> npm run clean && npm run tsc -- --noEmit


> @trustify-ui/client@0.1.0 clean
> rimraf ./dist


> @trustify-ui/client@0.1.0 tsc
> tsc -p ./tsconfig.json --noEmit


> @trustify-ui/client@0.1.0 build
> NODE_ENV=production webpack --config ./config/webpack.prod.ts

assets by info 4.05 MiB [immutable] 54 assets
assets by path fonts/*.woff2 577 KiB
  asset fonts/fa-solid-900.woff2 77.2 KiB [emitted] [from: ../node_modules/@patternfly/patternfly/assets/fonts/webfonts/fa-solid-900.woff2]
  asset fonts/RedHatDisplayVF-Italic.woff2 40.6 KiB [emitted] [from: ../node_modules/@patternfly/patternfly/assets/fonts/RedHatDisplay/RedHatDisplayVF-Italic.woff2]
  + 16 assets
assets by path branding/ 101 KiB 11 assets
assets by path monaco/*.js 6.66 MiB
  asset monaco/ts.worker.js 4.6 MiB [emitted] [minimized] [big] 2 related assets
  asset monaco/css.worker.js 956 KiB [emitted] [minimized] [big] 2 related assets
  + 3 assets
asset favicon.ico 15 KiB [emitted]
asset index.html.ejs 935 bytes [emitted]
asset manifest.json 308 bytes [emitted] [from: ../common/dist/branding/manifest.json] [copied]
Entrypoint app [big] 2.2 MiB (1.06 MiB) = app.349b1bd9.css 1.64 MiB app.81db4fbc.min.js 573 KiB 2 auxiliary assets
orphan modules 17.8 MiB (javascript) 402 KiB (css/mini-extract) 91.6 KiB (runtime) [orphan] 9441 modules
runtime modules 12.6 KiB 15 modules
cacheable modules 4.39 MiB (javascript) 3.04 MiB (css/mini-extract)
  javascript modules 4.39 MiB
    modules by path ../node_modules/ 3.78 MiB 772 modules
    modules by path ./src/ 616 KiB 43 modules
    crypto (ignored) 15 bytes [optional] [built] [code generated]
  css modules 3.04 MiB
    modules by path ../node_modules/@patternfly/react-styles/css/components/ 1010 KiB 55 modules
    modules by path ../node_modules/@patternfly/react-styles/css/layouts/ 106 KiB 5 modules
    modules by path ./src/ 697 bytes 2 modules
    modules by path ../node_modules/@patternfly/patternfly/*.css 1.86 MiB 2 modules
    + 1 module
  ../node_modules/axios/package.json 1.92 KiB [built] [code generated]

WARNING in chunk 106 [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ../node_modules/css-loader/dist/cjs.js!../node_modules/@patternfly/react-styles/css/layouts/Split/split.css
despite it was not able to fulfill desired ordering with these modules:
 * css ../node_modules/css-loader/dist/cjs.js!../node_modules/@patternfly/react-styles/css/layouts/Stack/stack.css
   - couldn't fulfill desired order of chunk group(s)
   - while fulfilling desired order of chunk group(s) , ,

WARNING in chunk 106 [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ../node_modules/css-loader/dist/cjs.js!../node_modules/@patternfly/react-styles/css/components/Tabs/tabs.css
despite it was not able to fulfill desired ordering with these modules:
 * css ../node_modules/css-loader/dist/cjs.js!../node_modules/@patternfly/react-styles/css/layouts/Stack/stack.css
   - couldn't fulfill desired order of chunk group(s)
   - while fulfilling desired order of chunk group(s) , ,

WARNING in chunk 106 [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ../node_modules/css-loader/dist/cjs.js!../node_modules/@patternfly/react-styles/css/components/TabContent/tab-content.css
despite it was not able to fulfill desired ordering with these modules:
 * css ../node_modules/css-loader/dist/cjs.js!../node_modules/@patternfly/react-styles/css/layouts/Stack/stack.css
   - couldn't fulfill desired order of chunk group(s)
   - while fulfilling desired order of chunk group(s) , ,

WARNING in chunk 663 [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ../node_modules/css-loader/dist/cjs.js!../node_modules/@patternfly/react-styles/css/utilities/Spacing/spacing.css
despite it was not able to fulfill desired ordering with these modules:
 * css ../node_modules/css-loader/dist/cjs.js!../node_modules/@patternfly/react-styles/css/components/EmptyState/empty-state.css
   - couldn't fulfill desired order of chunk group(s) , , ,
   - while fulfilling desired order of chunk group(s) , , , ,

WARNING in chunk 663 [mini-css-extract-plugin]
Conflicting order. Following module has been added:
 * css ../node_modules/css-loader/dist/cjs.js!../node_modules/@patternfly/react-styles/css/components/Pagination/pagination.css
despite it was not able to fulfill desired ordering with these modules:
 * css ../node_modules/css-loader/dist/cjs.js!../node_modules/@patternfly/react-styles/css/components/EmptyState/empty-state.css
   - couldn't fulfill desired order of chunk group(s) , , ,
   - while fulfilling desired order of chunk group(s) , , , ,

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets:
  monaco/json.worker.js (325 KiB)
  monaco/html.worker.js (627 KiB)
  monaco/css.worker.js (956 KiB)
  monaco/ts.worker.js (4.6 MiB)
  css/663.814fc742.min.css (287 KiB)
  js/879.53df74b5.min.js (270 KiB)
  js/638.c1ea35ed.min.js (365 KiB)
  app.349b1bd9.css (1.64 MiB)
  app.81db4fbc.min.js (573 KiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  app (2.2 MiB)
      app.349b1bd9.css
      app.81db4fbc.min.js

webpack 5.90.3 compiled with 7 warnings in 46479 ms

> @trustify-ui/server@0.1.0 build
> NODE_ENV=production rollup -c


src/index.js → dist/index.js...
created dist/index.js in 2.2s
COMMIT
--> 5860851dccdc
5860851dccdc579723220e627b8d22a159b2aecb3c1f0a5b548f66d0a29010d3
```
</details>
