### PR TITLE
Add average severity to advisory list

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -65,7 +65,7 @@ export interface SBOMBase {
 
 export interface AdvisoryBase {
   identifier: string;
-  severity: Severity;
+  average_severity: Severity;
   published: string;
   modified: string;
   title: string;

--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -65,7 +65,7 @@ export interface SBOMBase {
 
 export interface AdvisoryBase {
   identifier: string;
-  average_severity: Severity;
+  average_severity?: Severity;
   published: string;
   modified: string;
   title: string;

--- a/client/src/app/pages/advisory-list/advisory-list.tsx
+++ b/client/src/app/pages/advisory-list/advisory-list.tsx
@@ -44,6 +44,7 @@ import { useDownload } from "@app/hooks/useDownload";
 import { useSelectionState } from "@app/hooks/useSelectionState";
 import { useFetchAdvisories, useUploadAdvisory } from "@app/queries/advisories";
 
+import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
 import { VulnerabilitiesGalleryCount } from "./components/VulnerabilitiesGaleryCount";
 
 export const AdvisoryList: React.FC = () => {
@@ -199,10 +200,7 @@ export const AdvisoryList: React.FC = () => {
                         modifier="truncate"
                         {...getTdProps({ columnKey: "severity" })}
                       >
-                        {/* <SeverityShieldAndText
-                          value={item.severity}
-                        /> */}
-                        <p style={{ color: "red" }}>issue-277</p>
+                        <SeverityShieldAndText value={item.average_severity} />
                       </Td>
                       <Td
                         width={10}
@@ -226,7 +224,6 @@ export const AdvisoryList: React.FC = () => {
                         <VulnerabilitiesGalleryCount
                           vulnerabilities={item.vulnerabilities}
                         />
-                        <p style={{ color: "orange" }}>issue-278</p>
                       </Td>
                       <Td isActionCell>
                         <ActionsColumn

--- a/client/src/app/pages/advisory-list/advisory-list.tsx
+++ b/client/src/app/pages/advisory-list/advisory-list.tsx
@@ -200,7 +200,11 @@ export const AdvisoryList: React.FC = () => {
                         modifier="truncate"
                         {...getTdProps({ columnKey: "severity" })}
                       >
-                        <SeverityShieldAndText value={item.average_severity} />
+                        {item.average_severity && (
+                          <SeverityShieldAndText
+                            value={item.average_severity}
+                          />
+                        )}
                       </Td>
                       <Td
                         width={10}

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { AxiosError } from "axios";
+import dayjs from "dayjs";
 
 import {
   Button,
@@ -23,8 +24,6 @@ import {
 import {
   ActionsColumn,
   ExpandableRowContent,
-  Td as PFTd,
-  Tr as PFTr,
   Table,
   Tbody,
   Td,
@@ -51,10 +50,9 @@ import {
 } from "@app/components/TableControls";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 
+import { RENDER_DATETIME_FORMAT } from "@app/Constants";
 import { ImporterForm } from "./components/importer-form";
 import { ImporterStatusIcon } from "./components/importer-status-icon";
-import dayjs from "dayjs";
-import { RENDER_DATETIME_FORMAT } from "@app/Constants";
 
 export const ImporterList: React.FC = () => {
   const { pushNotification } = React.useContext(NotificationsContext);
@@ -276,8 +274,8 @@ export const ImporterList: React.FC = () => {
                       </TableRowContentWithControls>
                     </Tr>
                     {isCellExpanded(item) ? (
-                      <PFTr isExpanded>
-                        <PFTd colSpan={7}>
+                      <Tr isExpanded>
+                        <Td colSpan={7}>
                           <ExpandableRowContent>
                             <div className="pf-v5-u-m-md">
                               <DescriptionList>
@@ -300,8 +298,8 @@ export const ImporterList: React.FC = () => {
                               </DescriptionList>
                             </div>
                           </ExpandableRowContent>
-                        </PFTd>
-                      </PFTr>
+                        </Td>
+                      </Tr>
                     ) : null}
                   </Tbody>
                 );

--- a/client/src/mocks/stub-new-work/advisories.ts
+++ b/client/src/mocks/stub-new-work/advisories.ts
@@ -6,7 +6,7 @@ import { Advisory } from "@app/api/models";
 export const mockAdvisoryArray: Advisory[] = [
   {
     identifier: "advisory-1",
-    severity: "critical",
+    average_severity: "critical",
     published: new Date().toString(),
     modified: new Date().toString(),
     title: "Title 1",


### PR DESCRIPTION
- https://github.com/trustification/trustify/issues/277 Has been resolved so I am applying the severity to the advisory list table
  - I have discovered a bug and reported it accordingly on https://github.com/trustification/trustify/issues/372
- https://github.com/trustification/trustify/issues/278 has been also resolved so I am removing the "yellow" span label
