### PR TITLE
Handle 401 token errors

### DIFF
--- a/client/src/app/axios-config/apiInit.ts
+++ b/client/src/app/axios-config/apiInit.ts
@@ -39,16 +39,14 @@ export const initInterceptors = () => {
         try {
           const refreshedUser = await userManager.signinSilent();
           const access_token = refreshedUser?.access_token;
-          if (access_token) {
-            const retryConfig = {
-              ...error.config,
-              headers: {
-                ...error.config.headers,
-                Authorization: `Bearer ${access_token}`,
-              },
-            };
-            return axios(retryConfig);
-          }
+          const retryConfig = {
+            ...error.config,
+            headers: {
+              ...error.config.headers,
+              Authorization: `Bearer ${access_token}`,
+            },
+          };
+          return axios(retryConfig);
         } catch (refreshError) {
           await userManager.signoutRedirect();
         }

--- a/client/src/app/axios-config/apiInit.ts
+++ b/client/src/app/axios-config/apiInit.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
-import { User } from "oidc-client-ts";
+import { User, UserManager } from "oidc-client-ts";
 
-import { OIDC_CLIENT_ID, OIDC_SERVER_URL } from "@app/oidc";
+import { OIDC_CLIENT_ID, OIDC_SERVER_URL, oidcClientSettings } from "@app/oidc";
 
 function getUser() {
   const oidcStorage = sessionStorage.getItem(
@@ -25,6 +25,35 @@ export const initInterceptors = () => {
       return config;
     },
     (error) => {
+      return Promise.reject(error);
+    }
+  );
+
+  axios.interceptors.response.use(
+    (response) => {
+      return response;
+    },
+    async (error) => {
+      if (error.response && error.response.status === 401) {
+        const userManager = new UserManager(oidcClientSettings);
+        try {
+          const refreshedUser = await userManager.signinSilent();
+          const access_token = refreshedUser?.access_token;
+          if (access_token) {
+            const retryConfig = {
+              ...error.config,
+              headers: {
+                ...error.config.headers,
+                Authorization: `Bearer ${access_token}`,
+              },
+            };
+            return axios(retryConfig);
+          }
+        } catch (refreshError) {
+          await userManager.signoutRedirect();
+        }
+      }
+
       return Promise.reject(error);
     }
   );


### PR DESCRIPTION
Fixes: https://github.com/trustification/trustify-ui/issues/40

If the access token sent to the backend is rejected with 401 then:
- Try to refresh the token
- If the token cannot be refreshed, then redirect to login page