### PR TITLE
feat: add sbom described_by

### DIFF
--- a/client/src/app/api/models.ts
+++ b/client/src/app/api/models.ts
@@ -102,11 +102,13 @@ export interface PackageWithinSBOM {
 
 export interface SBOM {
   id: string;
-  type: "CycloneDX" | "SPDX";
   name: string;
-  version: string;
   authors: string[];
   published: string;
+  described_by?: {
+    name: string
+    version: string
+  }[];
 }
 
 // Importer

--- a/client/src/app/pages/sbom-details/overview.tsx
+++ b/client/src/app/pages/sbom-details/overview.tsx
@@ -22,9 +22,6 @@ export const Overview: React.FC<InfoProps> = ({ sbom }) => {
   return (
     <Grid hasGutter>
       <GridItem md={6}>
-        {/* <CVEsChart
-          data={{ none: 1, low: 1, critical: 2, medium: 3, high: 4 }}
-        /> */}
         <p style={{ color: "red" }}>issue-285: we should have a chart of vulnerabilities here</p>
       </GridItem>
       <GridItem md={6}>

--- a/client/src/app/pages/sbom-details/overview.tsx
+++ b/client/src/app/pages/sbom-details/overview.tsx
@@ -22,9 +22,10 @@ export const Overview: React.FC<InfoProps> = ({ sbom }) => {
   return (
     <Grid hasGutter>
       <GridItem md={6}>
-        <CVEsChart
+        {/* <CVEsChart
           data={{ none: 1, low: 1, critical: 2, medium: 3, high: 4 }}
-        />
+        /> */}
+        <p style={{ color: "red" }}>issue-285: we should have a chart of vulnerabilities here</p>
       </GridItem>
       <GridItem md={6}>
         <DescriptionList
@@ -35,12 +36,6 @@ export const Overview: React.FC<InfoProps> = ({ sbom }) => {
           <DescriptionListGroup>
             <DescriptionListTerm>Name</DescriptionListTerm>
             <DescriptionListDescription>{sbom.name}</DescriptionListDescription>
-          </DescriptionListGroup>
-          <DescriptionListGroup>
-            <DescriptionListTerm>Version</DescriptionListTerm>
-            <DescriptionListDescription>
-              {sbom.version}
-            </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>Supplier</DescriptionListTerm>

--- a/client/src/app/pages/sbom-details/sbom-details.tsx
+++ b/client/src/app/pages/sbom-details/sbom-details.tsx
@@ -41,13 +41,13 @@ export const SbomDetails: React.FC = () => {
           }
           pageHeading={{
             title: sbom?.name ?? sbomId ?? "",
-            label: sbom
-              ? {
-                children: sbom.type,
-                isCompact: true,
-                color: "blue",
-              }
-              : undefined,
+            // label: sbom
+            //   ? {
+            //     children: "sbom.type",
+            //     isCompact: true,
+            //     color: "blue",
+            //   }
+            //   : undefined,
           }}
           actionButtons={[
             {
@@ -84,7 +84,8 @@ export const SbomDetails: React.FC = () => {
               title: "CVEs",
               children: (
                 <div className="pf-v5-u-m-md">
-                  {sbomId && <CVEs sbomId={sbomId} />}
+                  {/* {sbomId && <CVEs sbomId={sbomId} />} */}
+                  <p style={{ color: "red" }}>issue-285 we should have a list of vulnerabilities here</p>
                 </div>
               ),
             },

--- a/client/src/app/pages/sbom-details/sbom-details.tsx
+++ b/client/src/app/pages/sbom-details/sbom-details.tsx
@@ -41,13 +41,6 @@ export const SbomDetails: React.FC = () => {
           }
           pageHeading={{
             title: sbom?.name ?? sbomId ?? "",
-            // label: sbom
-            //   ? {
-            //     children: "sbom.type",
-            //     isCompact: true,
-            //     color: "blue",
-            //   }
-            //   : undefined,
           }}
           actionButtons={[
             {
@@ -84,7 +77,6 @@ export const SbomDetails: React.FC = () => {
               title: "CVEs",
               children: (
                 <div className="pf-v5-u-m-md">
-                  {/* {sbomId && <CVEs sbomId={sbomId} />} */}
                   <p style={{ color: "red" }}>issue-285 we should have a list of vulnerabilities here</p>
                 </div>
               ),

--- a/client/src/app/pages/sbom-list/sbom-list.tsx
+++ b/client/src/app/pages/sbom-list/sbom-list.tsx
@@ -207,7 +207,6 @@ export const SbomList: React.FC = () => {
                           width={20}
                           {...getTdProps({ columnKey: "vulnerabilities" })}
                         >
-                          {/* <VulnerabilityGallery severities={item.related_cves} /> */}
                           <p style={{ color: "red" }}>issue-285</p>
                         </Td>
                         <Td isActionCell>

--- a/client/src/app/pages/vulnerability-details/related-sboms.tsx
+++ b/client/src/app/pages/vulnerability-details/related-sboms.tsx
@@ -115,7 +115,7 @@ export const RelatedSBOMs: React.FC<RelatedSBOMsProps> = ({ sboms }) => {
                     modifier="truncate"
                     {...getTdProps({ columnKey: "version" })}
                   >
-                    {item?.version}
+                    {/* {item?.version} */}
                   </Td>
                   <Td
                     width={15}

--- a/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
@@ -115,7 +115,7 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({ sbom
                     modifier="truncate"
                     {...getTdProps({ columnKey: "version" })}
                   >
-                    {/* {item?.version} */}
+                    TODO: extract version
                   </Td>
                   <Td
                     width={15}


### PR DESCRIPTION
Based on https://github.com/trustification/trustify/issues/284#issuecomment-2193993777

![image](https://github.com/trustification/trustify-ui/assets/2582866/9f8f00fb-f4ce-443a-b7c5-b51af63b7fbe)

I don't really think this is the way of showing data, but at this point I have no clue how to render the `described_by` field. So I am just rendering it to have something to show and then on a future iteration let UX and PM decide how useful/correct the `described_by` data is  and how to render it.