### PR TITLE
fix: Fix stale index page by reporting the timestamp.

### DIFF
--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-static-files = "0.2.1"
-serde_json = "1.0.117"
-tera = "1.19.1"
+anyhow = "1"
 base64 = "0.22.1"
 serde = { version = "1.0.201", features = ["derive"] }
+serde_json = "1.0.117"
+static-files = "0.2.1"
+tera = "1.19.1"
 
 [build-dependencies]
 static-files = "0.2.1"


### PR DESCRIPTION
Instead of using zero as the timestamp, use the actual timestamp. This should fix the issue of a stale page, when updating the UI. In that case the index page is not fetched, and it tries to load the old resources with the (no longer existing) cache busting markers. Resulting in a 404, and resulting in a blank page.

Also, report error through result

Instead of rendering one error into the page and reporting the others through a panic, report all through a result.