### PR TITLE
fix: Importer reports: use API order

### DIFF
--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -539,10 +539,6 @@ export const ImporterExpandedArea: React.FC<ImporterExpandedAreaProps> = ({
     initialItemsPerPage: 5,
     isSortEnabled: true,
     sortableColumns: ["startDate", "endDate"],
-    getSortValues: (report) => ({
-      startDate: dayjs(report.report.startDate).millisecond(),
-      endDate: dayjs(report.report.startDate).millisecond(),
-    }),
     isFilterEnabled: false,
     isExpansionEnabled: false,
   });

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -541,7 +541,7 @@ export const ImporterExpandedArea: React.FC<ImporterExpandedAreaProps> = ({
     sortableColumns: ["startDate", "endDate"],
     getSortValues: (report) => ({
       startDate: dayjs(report.report.startDate).valueOf(),
-      endDate: dayjs(report.report.startDate).valueOf(),
+      endDate: dayjs(report.report.endDate).valueOf(),
     }),
     isFilterEnabled: false,
     isExpansionEnabled: false,

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -539,6 +539,10 @@ export const ImporterExpandedArea: React.FC<ImporterExpandedAreaProps> = ({
     initialItemsPerPage: 5,
     isSortEnabled: true,
     sortableColumns: ["startDate", "endDate"],
+    getSortValues: (report) => ({
+      startDate: dayjs(report.report.startDate).valueOf(),
+      endDate: dayjs(report.report.startDate).valueOf(),
+    }),
     isFilterEnabled: false,
     isExpansionEnabled: false,
   });


### PR DESCRIPTION
Remove unnecessary sorting importers reports when managing the items in `useLocalTableControls`.
Although sorting out reports using only the `startDate` should be enough and using both start and end dates are likely to break the original order therefore as the API is already providing the reports in timely fashioned order then there is no need to reorder the items.

Before: 
![image](https://github.com/user-attachments/assets/9a911c5a-f86f-4ef6-bde1-c00183c7c390)

After: 
![image](https://github.com/user-attachments/assets/7ff86b5b-e1a6-4154-9ef2-585309b519d0)

Fix https://github.com/trustification/trustify-ui/issues/104