### PR TITLE
fix: Importer type - new vs edit

### DIFF
--- a/client/src/app/pages/importer-list/components/importer-form.tsx
+++ b/client/src/app/pages/importer-list/components/importer-form.tsx
@@ -100,7 +100,7 @@ type FormValues = {
 export const myImporters = ["sbom", "csaf", "osv", "cve", ""] as const;
 
 export interface IImporterFormProps {
-  importer?: Importer;
+  importer: Importer | null;
   onClose: () => void;
 }
 
@@ -143,7 +143,7 @@ export const ImporterForm: React.FC<IImporterFormProps> = ({
     defaultValues: {
       name: importer?.name || "",
       description: importerConfiguration?.description || "",
-      type: "",
+      type: importer ? importerType : "",
       source: importerConfiguration?.source || "",
       periodValue: periodValue || 60,
       periodUnit: periodUnit || "s",

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -474,7 +474,7 @@ export const ImporterList: React.FC = () => {
         onClose={closeCreateUpdateModal}
       >
         <ImporterForm
-          importer={entityToUpdate ? entityToUpdate : undefined}
+          importer={entityToUpdate}
           onClose={closeCreateUpdateModal}
         />
       </Modal>


### PR DESCRIPTION
When editing an importer the type should be the existing one and on creation the type will be empty (null).

fix https://github.com/trustification/trustify-ui/issues/100