### PR TITLE
Avoid nesting objects definition

### DIFF
--- a/client/src/app/pages/package-details/vulnerabilities-by-package.tsx
+++ b/client/src/app/pages/package-details/vulnerabilities-by-package.tsx
@@ -16,7 +16,7 @@ import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import {
   AdvisoryWithinPackage,
-  StatusType,
+  SbomStatus,
   Vulnerability,
 } from "@app/api/models";
 import { getVulnerabilityById } from "@app/api/rest";
@@ -37,7 +37,7 @@ import { useWithUiId } from "@app/utils/query-utils";
 interface TableData {
   vulnerabilityId: string;
   advisory: AdvisoryWithinPackage;
-  status: StatusType;
+  status: SbomStatus;
   context: { cpe: string };
   vulnerability?: Vulnerability;
 }
@@ -72,7 +72,7 @@ export const VulnerabilitiesByPackage: React.FC<
     React.useState(false);
 
   const [allAdvisoryStatus, setAllAdvisoryStatus] = React.useState<
-    Set<StatusType>
+    Set<SbomStatus>
   >(new Set());
 
   React.useEffect(() => {
@@ -99,7 +99,7 @@ export const VulnerabilitiesByPackage: React.FC<
         }
       }, [] as TableData[]);
 
-    const allUniqueStatus = new Set<StatusType>();
+    const allUniqueStatus = new Set<SbomStatus>();
     vulnerabilities.forEach((item) => allUniqueStatus.add(item.status));
 
     setAllVulnerabilities(vulnerabilities);

--- a/client/src/app/pages/vulnerability-details/packages-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/packages-by-vulnerability.tsx
@@ -24,7 +24,7 @@ import {
 import {
   AdvisoryWithinVulnerability,
   DecomposedPurl,
-  StatusType,
+  SbomStatus,
 } from "@app/api/models";
 import { AdvisoryInDrawerInfo } from "@app/components/AdvisoryInDrawerInfo";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
@@ -46,7 +46,7 @@ interface TableData {
     purl: string;
   };
   versionRange: string;
-  status: StatusType;
+  status: SbomStatus;
   context: { cpe: string };
   advisory: AdvisoryWithinVulnerability;
   decomposedPurl?: DecomposedPurl;
@@ -72,26 +72,27 @@ export const PackagesByVulnerability: React.FC<
   };
 
   //
-  const tableData = React.useMemo(() => {
-    return advisories.flatMap((advisory) => {
-      return Object.entries(advisory.purls ?? {}).flatMap(
-        ([status, packagesByStatus]) => {
-          return packagesByStatus.map((affectedPackage) => {
-            const basePurl = affectedPackage.base_purl;
-            const result: TableData = {
-              basePurl: { ...basePurl },
-              advisory: { ...advisory },
-              status: status as StatusType,
-              context: { ...affectedPackage.context },
-              versionRange: affectedPackage.version,
-              decomposedPurl: decomposePurl(basePurl.purl),
-            };
-            return result;
-          });
-        }
-      );
-    });
-  }, [advisories]);
+  const tableData = React.useMemo(
+    () =>
+      advisories.flatMap((advisory) =>
+        Object.entries(advisory.purls ?? {}).flatMap(
+          ([status, packagesByStatus]) =>
+            packagesByStatus.map((affectedPackage) => {
+              const basePurl = affectedPackage.base_purl;
+              const result: TableData = {
+                basePurl: { ...basePurl },
+                advisory: { ...advisory },
+                status: status as SbomStatus,
+                context: { ...affectedPackage.context },
+                versionRange: affectedPackage.version,
+                decomposedPurl: decomposePurl(basePurl.purl),
+              };
+              return result;
+            })
+        )
+      ),
+    [advisories]
+  );
 
   const tableDataWithUiId = useWithUiId(
     tableData,
@@ -99,7 +100,7 @@ export const PackagesByVulnerability: React.FC<
   );
 
   const allAdvisoryStatus = React.useMemo(() => {
-    const allUniqueStatus = new Set<StatusType>();
+    const allUniqueStatus = new Set<SbomStatus>();
 
     tableData.forEach((item) => allUniqueStatus.add(item.status));
     return allUniqueStatus;

--- a/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
@@ -33,7 +33,7 @@ import {
   AdvisoryWithinVulnerability,
   DecomposedPurl,
   SBOM,
-  StatusType,
+  SbomStatus,
 } from "@app/api/models";
 import { getSBOMById } from "@app/api/rest";
 import { AdvisoryInDrawerInfo } from "@app/components/AdvisoryInDrawerInfo";
@@ -59,7 +59,7 @@ interface SbomPackage {
 interface TableData {
   sbomId: string;
   sbom?: SBOM;
-  status: StatusType;
+  status: SbomStatus;
   advisory: AdvisoryWithinVulnerability;
 }
 
@@ -89,7 +89,7 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
   );
   const [isFetchingSboms, setIsFetchingSboms] = React.useState(false);
 
-  const [allStatuses, setAllStatuses] = React.useState<Set<StatusType>>(
+  const [allStatuses, setAllStatuses] = React.useState<Set<SbomStatus>>(
     new Set()
   );
 
@@ -121,7 +121,7 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
         }
       }, [] as TableData[]);
 
-    const allUniqueStatus = new Set<StatusType>();
+    const allUniqueStatus = new Set<SbomStatus>();
     sboms.forEach((item) => allUniqueStatus.add(item.status));
 
     setAllSboms(sboms);


### PR DESCRIPTION
To make the code easier to understand lets avoid nesting object definitions.

Using a non primitive type (or through an interface) helps for code clarity and not necessarily only when that nested definition is reused.
In both cases a meaningful name is desirable as much as possible (but not always an easy find).

Also replace `StatusType` type to `SbomStatus` because it offers a more description of the object and avoid overloading the name with its type.