### PR TITLE
fix: remove "view source" in modal, from advisory list

### DIFF
--- a/client/src/app/pages/advisory-list/advisory-list.tsx
+++ b/client/src/app/pages/advisory-list/advisory-list.tsx
@@ -10,7 +10,6 @@ import {
   CardTitle,
   Grid,
   GridItem,
-  Modal,
   PageSection,
   PageSectionVariants,
   Stack,
@@ -19,7 +18,7 @@ import {
   TextContent,
   Toolbar,
   ToolbarContent,
-  ToolbarItem,
+  ToolbarItem
 } from "@patternfly/react-core";
 import {
   ActionsColumn,
@@ -60,7 +59,6 @@ import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
 import { AdvisoryIndex } from "@app/api/models";
 import { EditLabelsModal } from "@app/components/EditLabelsModal";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import { AdvisorySourceViewer } from "@app/components/SourceViewer";
 
 import { AdvisoryGeneralView } from "@app/components/AdvisoryGeneralView";
 import { AdvisoryIssuer } from "@app/components/AdvisoryIssuer";
@@ -74,10 +72,12 @@ export const AdvisoryList: React.FC = () => {
   const { uploads, handleUpload, handleRemoveUpload } = useUploadAdvisory();
 
   // Actions that each row can trigger
-  type RowAction = "editLabels" | "viewSource";
+  type RowAction = "editLabels";
   const [selectedRowAction, setSelectedRowAction] =
     React.useState<RowAction | null>(null);
-  const [selectedRow, setSelectedRow] = React.useState<AdvisoryIndex | null>(null);
+  const [selectedRow, setSelectedRow] = React.useState<AdvisoryIndex | null>(
+    null
+  );
 
   const prepareActionOnRow = (action: RowAction, row: AdvisoryIndex) => {
     setSelectedRowAction(action);
@@ -96,7 +96,10 @@ export const AdvisoryList: React.FC = () => {
     onUpdateLabelsError
   );
 
-  const execSaveLabels = (row: AdvisoryIndex, labels: { [key: string]: string }) => {
+  const execSaveLabels = (
+    row: AdvisoryIndex,
+    labels: { [key: string]: string }
+  ) => {
     updateAdvisoryLabels({ ...row, labels });
   };
 
@@ -320,12 +323,6 @@ export const AdvisoryList: React.FC = () => {
                                 },
                               },
                               {
-                                title: "View source",
-                                onClick: () => {
-                                  prepareActionOnRow("viewSource", item);
-                                },
-                              },
-                              {
                                 title: "Download",
                                 onClick: () => {
                                   downloadAdvisory(
@@ -439,27 +436,6 @@ export const AdvisoryList: React.FC = () => {
           }}
           onClose={() => setSelectedRowAction(null)}
         />
-      )}
-
-      {selectedRowAction === "viewSource" && selectedRow && (
-        <Modal
-          title={selectedRow?.identifier}
-          isOpen
-          onClose={() => setSelectedRowAction(null)}
-          actions={[
-            <Button
-              key="cancel"
-              variant="link"
-              onClick={() => setSelectedRowAction(null)}
-            >
-              Close
-            </Button>,
-          ]}
-        >
-          {selectedRow && (
-            <AdvisorySourceViewer advisoryId={selectedRow.uuid} />
-          )}
-        </Modal>
       )}
     </>
   );

--- a/client/src/app/pages/advisory-list/advisory-list.tsx
+++ b/client/src/app/pages/advisory-list/advisory-list.tsx
@@ -18,7 +18,7 @@ import {
   TextContent,
   Toolbar,
   ToolbarContent,
-  ToolbarItem
+  ToolbarItem,
 } from "@patternfly/react-core";
 import {
   ActionsColumn,


### PR DESCRIPTION
#### Problem
Rendering the source of Advisory files when they are big frozen the browser. Watch the second 33 of the following recording.

We can verify it uploading this CSAF file (4MB). 
[CVE-2024-24783.json](https://github.com/user-attachments/files/16430134/CVE-2024-24783.json)


https://github.com/user-attachments/assets/310925d8-7fc4-4dc0-b0a7-94bdbbf6e030

- Removing the "Source viewer" from the advisory list will avoid this issues.
- Surprisingly the "Source viewer" works fine inside the tab (so leaving it there unless we find out it is a bad idea)

![image](https://github.com/user-attachments/assets/2def92fc-b87f-40a4-89d9-a816e585ee6c)
