### PR TITLE
ci: create a "publish" branch, keeping published commits

### DIFF
--- a/.github/workflows/tag-dist.yaml
+++ b/.github/workflows/tag-dist.yaml
@@ -7,27 +7,53 @@ on:
     tags:
       - "v*"
 
+concurrency:
+  group: tag-dist
+
 jobs:
   tag-dist:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: build
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Install
+        working-directory: build
         run: npm clean-install --ignore-scripts
       - name: Build
+        working-directory: build
         run: npm run build
-      - name: Commit and Tag the static dist dir
+      - name: Clone for publishing
         shell: bash
+        env:
+          SOURCE: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
         run: |
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${INPUT_ORGANIZATION_DOMAIN}"
-          git add -f client/dist
-          git commit -m "Checkin dist dir"
+          git clone "$SOURCE" publish
+          cd publish
           git fetch --tags
+          git checkout publish/${{ github.ref_name }} 2>/dev/null || git checkout -b publish/${{ github.ref_name }}
+          git merge ${{ github.ref_name }} -X theirs
+      - name: Copy dist folder
+        shell: bash
+        run: |
+          rm -Rf publish/client/dist
+          cp -a build/client/dist publish/client/
+      - name: Commit and Tag the static dist dir
+        working-directory: publish
+        shell: bash
+        run: |
+          git add -f client/dist
+          if [ -n "$(git diff --cached)" ]; then
+            git commit -m "Checkin dist dir"
+          else
+            echo "No changes detected"
+          fi
           git tag static-${{ github.ref_name }} --force
+          git push --set-upstream origin publish/${{ github.ref_name }}
           git push origin static-${{ github.ref_name }} --force
-


### PR DESCRIPTION
Right now we have the issue that the tag points to a dangling commit, as the commit itself doesn't belong to a branch. Once a new tag is pushed, that commit might go away. This leads to failing local builds and failing CI release builds.

The goal of this change is to create a "publish" branch per branch that we publish, keeping the commits there.