### PR TITLE
cleanup: useRouteParams now returns string or throws error

### DIFF
--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -80,5 +80,9 @@ export const AppRoutes = () => {
 
 export const useRouteParams = (pathParam: PathParam) => {
   const params = useParams();
-  return params[pathParam];
+  let value = params[pathParam];
+  if (value === undefined) {
+    throw new Error(`ASSERTION FAILURE: required path parameter not set: ${pathParam}`);
+  }
+  return value;
 };

--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -44,11 +44,10 @@ export const useFetchAdvisories = (
   };
 };
 
-export const useFetchAdvisoryById = (id?: number | string) => {
+export const useFetchAdvisoryById = (id: number | string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [AdvisoriesQueryKey, id],
-    queryFn: () =>
-      id === undefined ? Promise.resolve(undefined) : getAdvisoryById(id),
+    queryFn: () => getAdvisoryById(id),
     enabled: id !== undefined,
   });
 
@@ -72,11 +71,10 @@ export const useDeleteAdvisoryMutation = (
   });
 };
 
-export const useFetchAdvisorySourceById = (id?: number | string) => {
+export const useFetchAdvisorySourceById = (id: number | string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [AdvisoriesQueryKey, id, "source"],
-    queryFn: () =>
-      id === undefined ? Promise.resolve(undefined) : getAdvisorySourceById(id),
+    queryFn: () => getAdvisorySourceById(id),
     enabled: id !== undefined,
   });
 

--- a/client/src/app/queries/importers.ts
+++ b/client/src/app/queries/importers.ts
@@ -44,11 +44,10 @@ export const useCreateImporterMutation = (
   });
 };
 
-export const useFethImporterById = (id?: number | string) => {
+export const useFetchImporterById = (id: number | string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [ImportersQueryKey, id],
-    queryFn: () =>
-      id === undefined ? Promise.resolve(undefined) : getImporterById(id),
+    queryFn: () => getImporterById(id),
     enabled: id !== undefined,
   });
 

--- a/client/src/app/queries/organizations.ts
+++ b/client/src/app/queries/organizations.ts
@@ -27,11 +27,10 @@ export const useFetchOrganizations = (
   };
 };
 
-export const useFetchOrganizationById = (id?: number | string) => {
+export const useFetchOrganizationById = (id: number | string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [OrganizationsQueryKey, id],
-    queryFn: () =>
-      id === undefined ? Promise.resolve(undefined) : getOrganizationById(id),
+    queryFn: () => getOrganizationById(id),
     enabled: id !== undefined,
   });
 

--- a/client/src/app/queries/packages.ts
+++ b/client/src/app/queries/packages.ts
@@ -32,11 +32,10 @@ export const useFetchPackages = (
   };
 };
 
-export const useFetchPackageById = (id?: number | string) => {
+export const useFetchPackageById = (id: number | string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [PackagesQueryKey, id],
-    queryFn: () =>
-      id === undefined ? Promise.resolve(undefined) : getPackageById(id),
+    queryFn: () => getPackageById(id),
   });
 
   return {

--- a/client/src/app/queries/products.ts
+++ b/client/src/app/queries/products.ts
@@ -29,11 +29,10 @@ export const useFetchProducts = (
   };
 };
 
-export const useFetchProductById = (id?: number | string) => {
+export const useFetchProductById = (id: number | string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [ProductsQueryKey, id],
-    queryFn: () =>
-      id === undefined ? Promise.resolve(undefined) : getProductById(id),
+    queryFn: () => getProductById(id),
     enabled: id !== undefined,
   });
 

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -36,13 +36,10 @@ export const useFetchSBOMs = (
   };
 };
 
-export const useFetchSBOMById = (id?: string) => {
+export const useFetchSBOMById = (id: string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [SBOMsQueryKey, id],
-    queryFn: async () =>
-      id === undefined
-        ? undefined
-        : (await getSbom({ client, path: { id } })).data,
+    queryFn: async () => (await getSbom({ client, path: { id } })).data,
     enabled: id !== undefined,
   });
 
@@ -66,11 +63,10 @@ export const useDeleteSbomMutation = (
   });
 };
 
-export const useFetchSBOMSourceById = (id?: number | string) => {
+export const useFetchSBOMSourceById = (id: number | string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [SBOMsQueryKey, id, "source"],
-    queryFn: () =>
-      id === undefined ? Promise.resolve(undefined) : getSBOMSourceById(id),
+    queryFn: () => getSBOMSourceById(id),
     enabled: id !== undefined,
   });
 

--- a/client/src/app/queries/vulnerabilities.ts
+++ b/client/src/app/queries/vulnerabilities.ts
@@ -33,11 +33,10 @@ export const useFetchVulnerabilities = (
   };
 };
 
-export const useFetchVulnerabilityById = (id?: number | string) => {
+export const useFetchVulnerabilityById = (id: number | string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [VulnerabilitiesQueryKey, id],
-    queryFn: () =>
-      id === undefined ? Promise.resolve(undefined) : getVulnerabilityById(id),
+    queryFn: () => getVulnerabilityById(id),
     enabled: id !== undefined,
   });
 
@@ -61,13 +60,10 @@ export const useDeleteVulnerabilityMutation = (
   });
 };
 
-export const useFetchVulnerabilitySourceById = (id?: number | string) => {
+export const useFetchVulnerabilitySourceById = (id: number | string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [VulnerabilitiesQueryKey, id, "source"],
-    queryFn: () =>
-      id === undefined
-        ? Promise.resolve(undefined)
-        : getVulnerabilitySourceById(id),
+    queryFn: () => getVulnerabilitySourceById(id),
     enabled: id !== undefined,
   });
 


### PR DESCRIPTION
This simplifies the queries/*.ts function signatures and implementations.

This also provides a better error messages during dev.

If you use an invalid route param arg, UI screen only displays an empty result at the current time.  Example: 

![image](https://github.com/user-attachments/assets/21f297a7-66c2-4d19-82f6-c2f92f70ed8f)

With this change, if you use an invalid route param, you will see:

![image](https://github.com/user-attachments/assets/39ae2f02-e11e-44e7-91d2-5412df95405f)
