### PR TITLE
feat(search): add skeleton for v2 search

### DIFF
--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -18,6 +18,7 @@ const PackageList = lazy(() => import("./pages/package-list"));
 const PackageDetails = lazy(() => import("./pages/package-details"));
 const SBOMList = lazy(() => import("./pages/sbom-list"));
 const SBOMDetails = lazy(() => import("./pages/sbom-details"));
+const Search = lazy(() => import("./pages/search"));
 const ImporterList = lazy(() => import("./pages/importer-list"));
 
 export enum PathParam {
@@ -52,6 +53,7 @@ export const AppRoutes = () => {
       path: `/packages/:${PathParam.PACKAGE_ID}`,
       element: <PackageDetails />,
     },
+    { path: "/search", element: <Search /> },
     { path: "/sboms", element: <SBOMList /> },
     {
       path: `/sboms/:${PathParam.SBOM_ID}`,

--- a/client/src/app/layout/sidebar.tsx
+++ b/client/src/app/layout/sidebar.tsx
@@ -26,6 +26,16 @@ export const SidebarApp: React.FC = () => {
           </li>
           <li className="pf-v5-c-nav__item">
             <NavLink
+              to="/search"
+              className={({ isActive }) => {
+                return css(LINK_CLASS, isActive ? ACTIVE_LINK_CLASS : "");
+              }}
+            >
+              Search
+            </NavLink>
+          </li>
+          <li className="pf-v5-c-nav__item">
+            <NavLink
               to="/products"
               className={({ isActive }) => {
                 return css(LINK_CLASS, isActive ? ACTIVE_LINK_CLASS : "");

--- a/client/src/app/pages/advisory-list/advisory-list.tsx
+++ b/client/src/app/pages/advisory-list/advisory-list.tsx
@@ -196,11 +196,11 @@ export const AdvisoryList: React.FC = () => {
 
   return (
     <>
-      <PageSection variant={PageSectionVariants.light}>
-        <TextContent>
-          <Text component="h1">Advisories</Text>
-        </TextContent>
-      </PageSection>
+      {/*<PageSection variant={PageSectionVariants.light}>*/}
+      {/*  <TextContent>*/}
+      {/*    <Text component="h1">Advisories</Text>*/}
+      {/*  </TextContent>*/}
+      {/*</PageSection>*/}
       <PageSection>
         <div
           style={{

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -277,11 +277,11 @@ export const ImporterList: React.FC = () => {
 
   return (
     <>
-      <PageSection variant={PageSectionVariants.light}>
-        <TextContent>
-          <Text component="h1">Importers</Text>
-        </TextContent>
-      </PageSection>
+      {/*<PageSection variant={PageSectionVariants.light}>*/}
+      {/*  <TextContent>*/}
+      {/*    <Text component="h1">Importers</Text>*/}
+      {/*  </TextContent>*/}
+      {/*</PageSection>*/}
       <PageSection>
         <div
           style={{

--- a/client/src/app/pages/package-list/package-list.tsx
+++ b/client/src/app/pages/package-list/package-list.tsx
@@ -124,11 +124,11 @@ export const PackageList: React.FC = () => {
 
   return (
     <>
-      <PageSection variant={PageSectionVariants.light}>
-        <TextContent>
-          <Text component="h1">Packages</Text>
-        </TextContent>
-      </PageSection>
+      {/*<PageSection variant={PageSectionVariants.light}>*/}
+      {/*  <TextContent>*/}
+      {/*    <Text component="h1">Packages</Text>*/}
+      {/*  </TextContent>*/}
+      {/*</PageSection>*/}
       <PageSection>
         <div
           style={{

--- a/client/src/app/pages/product-list/product-list.tsx
+++ b/client/src/app/pages/product-list/product-list.tsx
@@ -131,6 +131,11 @@ export const ProductList: React.FC = () => {
 
   return (
     <>
+      {/*<PageSection variant={PageSectionVariants.light}>*/}
+      {/*  <TextContent>*/}
+      {/*    <Text component="h1">Products</Text>*/}
+      {/*  </TextContent>*/}
+      {/*</PageSection>*/}
       <PageSection>
         <div
           style={{

--- a/client/src/app/pages/product-list/product-list.tsx
+++ b/client/src/app/pages/product-list/product-list.tsx
@@ -131,11 +131,6 @@ export const ProductList: React.FC = () => {
 
   return (
     <>
-      <PageSection variant={PageSectionVariants.light}>
-        <TextContent>
-          <Text component="h1">Products</Text>
-        </TextContent>
-      </PageSection>
       <PageSection>
         <div
           style={{

--- a/client/src/app/pages/sbom-list/sbom-list.tsx
+++ b/client/src/app/pages/sbom-list/sbom-list.tsx
@@ -174,11 +174,11 @@ export const SbomList: React.FC = () => {
 
   return (
     <>
-      <PageSection variant={PageSectionVariants.light}>
-        <TextContent>
-          <Text component="h1">SBOMs</Text>
-        </TextContent>
-      </PageSection>
+      {/*<PageSection variant={PageSectionVariants.light}>*/}
+      {/*  <TextContent>*/}
+      {/*    <Text component="h1">SBOMs</Text>*/}
+      {/*  </TextContent>*/}
+      {/*</PageSection>*/}
       <PageSection>
         <div
           style={{

--- a/client/src/app/pages/search/index.ts
+++ b/client/src/app/pages/search/index.ts
@@ -1,0 +1,1 @@
+export { Search as default } from "./search";

--- a/client/src/app/pages/search/search.tsx
+++ b/client/src/app/pages/search/search.tsx
@@ -3,20 +3,20 @@ import ProductList from "@app/pages/product-list";
 import {
   PageSection,
   PageSectionVariants,
+  Popover,
+  Tab,
+  TabAction,
+  TabTitleText,
+  Tabs,
   Text,
   TextContent,
 } from "@patternfly/react-core";
-import {
-  Tabs,
-  Tab,
-  TabTitleText,
-  Checkbox,
-  Tooltip,
-} from "@patternfly/react-core";
+import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 
 export const Search: React.FC = () => {
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
   const [isBox, setIsBox] = React.useState<boolean>(false);
+  const ref = React.createRef<HTMLElement>();
 
   const handleTabClick = (
     event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
@@ -25,8 +25,14 @@ export const Search: React.FC = () => {
     setActiveTabKey(tabIndex);
   };
 
-  const tooltip = (
-    <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support." />
+  const sbomPopover = (popoverRef: React.RefObject<any>) => (
+    <Popover
+      bodyContent={
+        <div>Software Bill of Materials for Products and Containers.</div>
+      }
+      position={"right"}
+      triggerRef={popoverRef}
+    />
   );
 
   return (
@@ -50,7 +56,18 @@ export const Search: React.FC = () => {
         >
           Products
         </Tab>
-        <Tab eventKey={1} title={<TabTitleText>SBOMs</TabTitleText>}>
+        <Tab
+          eventKey={1}
+          title={<TabTitleText>SBOMs</TabTitleText>}
+          actions={
+            <>
+              <TabAction aria-label={`SBOM help popover`} ref={ref}>
+                <HelpIcon />
+              </TabAction>
+              {sbomPopover(ref)}
+            </>
+          }
+        >
           SBOMs
         </Tab>
         <Tab eventKey={2} title={<TabTitleText>Vulnerabilities</TabTitleText>}>
@@ -62,11 +79,7 @@ export const Search: React.FC = () => {
         <Tab eventKey={4} title={<TabTitleText>Advisories</TabTitleText>}>
           Advisories
         </Tab>
-        <Tab
-          tooltip={tooltip}
-          eventKey={5}
-          title={<TabTitleText>Importers</TabTitleText>}
-        >
+        <Tab eventKey={5} title={<TabTitleText>Importers</TabTitleText>}>
           Importers
         </Tab>
       </Tabs>

--- a/client/src/app/pages/search/search.tsx
+++ b/client/src/app/pages/search/search.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ProductList from "@app/pages/product-list";
 import {
+  Badge,
   PageSection,
   PageSectionVariants,
   Popover,
@@ -94,14 +95,28 @@ export const Search: React.FC = () => {
         >
           <Tab
             eventKey={0}
-            title={<TabTitleText>Products</TabTitleText>}
+            title={
+              <TabTitleText>
+                Products{"  "}
+                <Badge key={0} screenReaderText="Search Result Count">
+                  0
+                </Badge>
+              </TabTitleText>
+            }
             aria-label="Products"
           >
             <ProductList />
           </Tab>
           <Tab
             eventKey={1}
-            title={<TabTitleText>SBOMs</TabTitleText>}
+            title={
+              <TabTitleText>
+                SBOMs{"  "}
+                <Badge key={1} screenReaderText="Search Result Count">
+                  0
+                </Badge>
+              </TabTitleText>
+            }
             actions={
               <>
                 <TabAction aria-label={`SBOM help popover`} ref={ref}>
@@ -115,17 +130,54 @@ export const Search: React.FC = () => {
           </Tab>
           <Tab
             eventKey={2}
-            title={<TabTitleText>Vulnerabilities</TabTitleText>}
+            title={
+              <TabTitleText>
+                Vulnerabilities{"  "}
+                <Badge key={2} screenReaderText="Search Result Count">
+                  0
+                </Badge>
+              </TabTitleText>
+            }
           >
             <VulnerabilityList />
           </Tab>
-          <Tab eventKey={3} title={<TabTitleText>Packages</TabTitleText>}>
+          <Tab
+            eventKey={3}
+            title={
+              <TabTitleText>
+                Packages{"  "}
+                <Badge key={3} screenReaderText="Search Result Count">
+                  0
+                </Badge>
+              </TabTitleText>
+            }
+          >
             <PackageList />
           </Tab>
-          <Tab eventKey={4} title={<TabTitleText>Advisories</TabTitleText>}>
+          <Tab
+            eventKey={4}
+            title={
+              <TabTitleText>
+                Advisories{"  "}
+                <Badge key={4} screenReaderText="Search Result Count">
+                  0
+                </Badge>
+              </TabTitleText>
+            }
+          >
             <AdvisoryList />
           </Tab>
-          <Tab eventKey={5} title={<TabTitleText>Importers</TabTitleText>}>
+          <Tab
+            eventKey={5}
+            title={
+              <TabTitleText>
+                Importers{"  "}
+                <Badge key={5} screenReaderText="Search Result Count">
+                  {resultsCount}
+                </Badge>
+              </TabTitleText>
+            }
+          >
             <ImporterList />
           </Tab>
         </Tabs>

--- a/client/src/app/pages/search/search.tsx
+++ b/client/src/app/pages/search/search.tsx
@@ -10,6 +10,10 @@ import {
   Tabs,
   Text,
   TextContent,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
   SearchInput,
 } from "@patternfly/react-core";
 import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
@@ -55,57 +59,77 @@ export const Search: React.FC = () => {
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
-        <TextContent>
-          <Text component="h1">Search</Text>
-        </TextContent>
-        <SearchInput
-          placeholder="Search for an SBOM, advisory, or CVE"
-          value={searchValue}
-          onChange={(_event, value) => onChangeSearch(value)}
-          onClear={onClearSearch}
-          resultsCount={resultsCount}
-        />
+        <Toolbar isStatic>
+          <ToolbarContent>
+            <ToolbarGroup align={{ default: "alignLeft" }}>
+              <TextContent>
+                <Text component="h1">Search</Text>
+              </TextContent>
+            </ToolbarGroup>
+            <ToolbarGroup
+              variant="icon-button-group"
+              align={{ default: "alignRight" }}
+            >
+              <ToolbarGroup visibility={{ default: "hidden", lg: "visible" }}>
+                <ToolbarItem widths={{ default: "500px" }}>
+                  <SearchInput
+                    placeholder="Search for an SBOM, advisory, or CVE"
+                    value={searchValue}
+                    onChange={(_event, value) => onChangeSearch(value)}
+                    onClear={onClearSearch}
+                    resultsCount={resultsCount}
+                  />
+                </ToolbarItem>
+              </ToolbarGroup>
+            </ToolbarGroup>
+          </ToolbarContent>
+        </Toolbar>
       </PageSection>
-      <Tabs
-        activeKey={activeTabKey}
-        onSelect={handleTabClick}
-        aria-label="Tabs"
-        role="region"
-      >
-        <Tab
-          eventKey={0}
-          title={<TabTitleText>Products</TabTitleText>}
-          aria-label="Products"
+      <PageSection>
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={handleTabClick}
+          aria-label="Tabs"
+          role="region"
         >
-          <ProductList />
-        </Tab>
-        <Tab
-          eventKey={1}
-          title={<TabTitleText>SBOMs</TabTitleText>}
-          actions={
-            <>
-              <TabAction aria-label={`SBOM help popover`} ref={ref}>
-                <HelpIcon />
-              </TabAction>
-              {sbomPopover(ref)}
-            </>
-          }
-        >
-          <SbomList />
-        </Tab>
-        <Tab eventKey={2} title={<TabTitleText>Vulnerabilities</TabTitleText>}>
-          <VulnerabilityList />
-        </Tab>
-        <Tab eventKey={3} title={<TabTitleText>Packages</TabTitleText>}>
-          <PackageList />
-        </Tab>
-        <Tab eventKey={4} title={<TabTitleText>Advisories</TabTitleText>}>
-          <AdvisoryList />
-        </Tab>
-        <Tab eventKey={5} title={<TabTitleText>Importers</TabTitleText>}>
-          <ImporterList />
-        </Tab>
-      </Tabs>
+          <Tab
+            eventKey={0}
+            title={<TabTitleText>Products</TabTitleText>}
+            aria-label="Products"
+          >
+            <ProductList />
+          </Tab>
+          <Tab
+            eventKey={1}
+            title={<TabTitleText>SBOMs</TabTitleText>}
+            actions={
+              <>
+                <TabAction aria-label={`SBOM help popover`} ref={ref}>
+                  <HelpIcon />
+                </TabAction>
+                {sbomPopover(ref)}
+              </>
+            }
+          >
+            <SbomList />
+          </Tab>
+          <Tab
+            eventKey={2}
+            title={<TabTitleText>Vulnerabilities</TabTitleText>}
+          >
+            <VulnerabilityList />
+          </Tab>
+          <Tab eventKey={3} title={<TabTitleText>Packages</TabTitleText>}>
+            <PackageList />
+          </Tab>
+          <Tab eventKey={4} title={<TabTitleText>Advisories</TabTitleText>}>
+            <AdvisoryList />
+          </Tab>
+          <Tab eventKey={5} title={<TabTitleText>Importers</TabTitleText>}>
+            <ImporterList />
+          </Tab>
+        </Tabs>
+      </PageSection>
     </>
   );
 };

--- a/client/src/app/pages/search/search.tsx
+++ b/client/src/app/pages/search/search.tsx
@@ -10,19 +10,36 @@ import {
   Tabs,
   Text,
   TextContent,
+  SearchInput,
 } from "@patternfly/react-core";
 import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
+import SbomList from "@app/pages/sbom-list";
+import VulnerabilityList from "@app/pages/vulnerability-list";
+import PackageList from "@app/pages/package-list";
+import AdvisoryList from "@app/pages/advisory-list";
+import ImporterList from "@app/pages/importer-list";
 
 export const Search: React.FC = () => {
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
-  const [isBox, setIsBox] = React.useState<boolean>(false);
   const ref = React.createRef<HTMLElement>();
+  const [searchValue, setSearchValue] = React.useState("");
+  const [resultsCount, setResultsCount] = React.useState(0);
 
   const handleTabClick = (
     event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
     tabIndex: string | number
   ) => {
     setActiveTabKey(tabIndex);
+  };
+
+  const onChangeSearch = (value: string) => {
+    setSearchValue(value);
+    setResultsCount(3);
+  };
+
+  const onClearSearch = () => {
+    setSearchValue("");
+    setResultsCount(0);
   };
 
   const sbomPopover = (popoverRef: React.RefObject<any>) => (
@@ -41,11 +58,17 @@ export const Search: React.FC = () => {
         <TextContent>
           <Text component="h1">Search</Text>
         </TextContent>
+        <SearchInput
+          placeholder="Search for an SBOM, advisory, or CVE"
+          value={searchValue}
+          onChange={(_event, value) => onChangeSearch(value)}
+          onClear={onClearSearch}
+          resultsCount={resultsCount}
+        />
       </PageSection>
       <Tabs
         activeKey={activeTabKey}
         onSelect={handleTabClick}
-        isBox={isBox}
         aria-label="Tabs"
         role="region"
       >
@@ -54,7 +77,7 @@ export const Search: React.FC = () => {
           title={<TabTitleText>Products</TabTitleText>}
           aria-label="Products"
         >
-          Products
+          <ProductList />
         </Tab>
         <Tab
           eventKey={1}
@@ -68,19 +91,19 @@ export const Search: React.FC = () => {
             </>
           }
         >
-          SBOMs
+          <SbomList />
         </Tab>
         <Tab eventKey={2} title={<TabTitleText>Vulnerabilities</TabTitleText>}>
-          Vulnerabilities
+          <VulnerabilityList />
         </Tab>
         <Tab eventKey={3} title={<TabTitleText>Packages</TabTitleText>}>
-          Packages
+          <PackageList />
         </Tab>
         <Tab eventKey={4} title={<TabTitleText>Advisories</TabTitleText>}>
-          Advisories
+          <AdvisoryList />
         </Tab>
         <Tab eventKey={5} title={<TabTitleText>Importers</TabTitleText>}>
-          Importers
+          <ImporterList />
         </Tab>
       </Tabs>
     </>

--- a/client/src/app/pages/search/search.tsx
+++ b/client/src/app/pages/search/search.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import ProductList from "@app/pages/product-list";
+import {
+  PageSection,
+  PageSectionVariants,
+  Text,
+  TextContent,
+} from "@patternfly/react-core";
+import {
+  Tabs,
+  Tab,
+  TabTitleText,
+  Checkbox,
+  Tooltip,
+} from "@patternfly/react-core";
+
+export const Search: React.FC = () => {
+  const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
+  const [isBox, setIsBox] = React.useState<boolean>(false);
+
+  const handleTabClick = (
+    event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
+    tabIndex: string | number
+  ) => {
+    setActiveTabKey(tabIndex);
+  };
+
+  const tooltip = (
+    <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support." />
+  );
+
+  return (
+    <>
+      <PageSection variant={PageSectionVariants.light}>
+        <TextContent>
+          <Text component="h1">Search</Text>
+        </TextContent>
+      </PageSection>
+      <Tabs
+        activeKey={activeTabKey}
+        onSelect={handleTabClick}
+        isBox={isBox}
+        aria-label="Tabs"
+        role="region"
+      >
+        <Tab
+          eventKey={0}
+          title={<TabTitleText>Products</TabTitleText>}
+          aria-label="Products"
+        >
+          Products
+        </Tab>
+        <Tab eventKey={1} title={<TabTitleText>SBOMs</TabTitleText>}>
+          SBOMs
+        </Tab>
+        <Tab eventKey={2} title={<TabTitleText>Vulnerabilities</TabTitleText>}>
+          Vulnerabilities
+        </Tab>
+        <Tab eventKey={3} title={<TabTitleText>Packages</TabTitleText>}>
+          Packages
+        </Tab>
+        <Tab eventKey={4} title={<TabTitleText>Advisories</TabTitleText>}>
+          Advisories
+        </Tab>
+        <Tab
+          tooltip={tooltip}
+          eventKey={5}
+          title={<TabTitleText>Importers</TabTitleText>}
+        >
+          Importers
+        </Tab>
+      </Tabs>
+    </>
+  );
+};

--- a/client/src/app/pages/vulnerability-list/vulnerability-list.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-list.tsx
@@ -147,11 +147,11 @@ export const VulnerabilityList: React.FC = () => {
 
   return (
     <>
-      <PageSection variant={PageSectionVariants.light}>
-        <TextContent>
-          <Text component="h1">Vulnerabilities</Text>
-        </TextContent>
-      </PageSection>
+      {/*<PageSection variant={PageSectionVariants.light}>*/}
+      {/*  <TextContent>*/}
+      {/*    <Text component="h1">Vulnerabilities</Text>*/}
+      {/*  </TextContent>*/}
+      {/*</PageSection>*/}
       <PageSection>
         <div
           style={{


### PR DESCRIPTION
## Description
This PR introduces a skeleton page for v2 search (relates to #157). Note that this is a WIP and not feature complete.

![Screenshot 2024-09-19 at 1 54 46 PM](https://github.com/user-attachments/assets/f1ee8645-7bef-4514-a7b1-88fd1b800c06)

![Screenshot 2024-09-19 at 1 54 56 PM](https://github.com/user-attachments/assets/ab9787ea-7e0a-4e13-9d53-ef07d153076f)

## Changes
- Add new Search page component
- Add new route for `/search`

## TBD / To Do / In Progress
- Global search functionality for all components. Normally I might suggest using React context for global-style search, but if we're not sure whether we'll be going with dedicated pages or tabs for each searchable component, then I'll just leave it like this for now until we decide we need it. In this case, we will need to lift the state up to the common ancestral parent, `search.tsx`, and pass them down as props. @carlosthe19916 what do you think?
- Unit tests with mocks
- E2E tests