### PR TITLE
Remove product page&routing as it won't be included in the release of rhtpa

### DIFF
--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -6,8 +6,6 @@ import { Bullseye, Spinner } from "@patternfly/react-core";
 import { ErrorFallback } from "./components/ErrorFallback";
 
 const Home = lazy(() => import("./pages/home"));
-const ProductList = lazy(() => import("./pages/product-list"));
-const ProductDetails = lazy(() => import("./pages/product-details"));
 const AdvisoryList = lazy(() => import("./pages/advisory-list"));
 const AdvisoryDetails = lazy(() => import("./pages/advisory-details"));
 const VulnerabilityList = lazy(() => import("./pages/vulnerability-list"));
@@ -32,12 +30,7 @@ export enum PathParam {
 
 export const AppRoutes = () => {
   const allRoutes = useRoutes([
-    { path: "/", element: <Home /> },
-    { path: "/products", element: <ProductList /> },
-    {
-      path: `/products/:${PathParam.PRODUCT_ID}`,
-      element: <ProductDetails />,
-    },
+    { path: "/", element: <Home /> },   
     { path: "/advisories", element: <AdvisoryList /> },
     {
       path: `/advisories/:${PathParam.ADVISORY_ID}`,

--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -30,7 +30,7 @@ export enum PathParam {
 
 export const AppRoutes = () => {
   const allRoutes = useRoutes([
-    { path: "/", element: <Home /> },   
+    { path: "/", element: <Home /> },
     { path: "/advisories", element: <AdvisoryList /> },
     {
       path: `/advisories/:${PathParam.ADVISORY_ID}`,

--- a/client/src/app/layout/sidebar.tsx
+++ b/client/src/app/layout/sidebar.tsx
@@ -33,17 +33,7 @@ export const SidebarApp: React.FC = () => {
             >
               Search
             </NavLink>
-          </li>
-          <li className="pf-v5-c-nav__item">
-            <NavLink
-              to="/products"
-              className={({ isActive }) => {
-                return css(LINK_CLASS, isActive ? ACTIVE_LINK_CLASS : "");
-              }}
-            >
-              Products
-            </NavLink>
-          </li>
+          </li>         
           <li className="pf-v5-c-nav__item">
             <NavLink
               to="/sboms"

--- a/client/src/app/layout/sidebar.tsx
+++ b/client/src/app/layout/sidebar.tsx
@@ -33,7 +33,7 @@ export const SidebarApp: React.FC = () => {
             >
               Search
             </NavLink>
-          </li>         
+          </li>
           <li className="pf-v5-c-nav__item">
             <NavLink
               to="/sboms"


### PR DESCRIPTION
The next version of RHTPA won't include PRODUCTS as it is out of scope for the next official release. So removing it until the time to have it comes