### PR TITLE
feat(cve): details page v1 parity

### DIFF
--- a/client/src/app/pages/vulnerability-details/overview.tsx
+++ b/client/src/app/pages/vulnerability-details/overview.tsx
@@ -1,17 +1,12 @@
 import React from "react";
 
 import {
-  Card,
-  CardBody,
-  CardTitle,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  Grid,
-  GridItem,
-  Stack,
-  StackItem,
+  Text,
+  TextContent,
 } from "@patternfly/react-core";
 
 import { formatDate } from "@app/utils/utils";
@@ -24,76 +19,52 @@ interface OverviewProps {
 export const Overview: React.FC<OverviewProps> = ({ vulnerability }) => {
   return (
     <>
-      <Stack hasGutter>
-        <StackItem>
-          <Grid hasGutter>
-            <GridItem md={8}>
-              <Card isFullHeight>
-                <CardTitle>General view</CardTitle>
-                <CardBody>
-                  <DescriptionList
-                    columnModifier={{
-                      default: "2Col",
-                    }}
-                  >
-                    <DescriptionListGroup>
-                      <DescriptionListTerm>Title</DescriptionListTerm>
-                      <DescriptionListDescription>
-                        {vulnerability.title || vulnerability.description}
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                      <DescriptionListTerm>Published</DescriptionListTerm>
-                      <DescriptionListDescription>
-                        {formatDate(vulnerability.published)}
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                      <DescriptionListTerm>Modified</DescriptionListTerm>
-                      <DescriptionListDescription>
-                        {formatDate(vulnerability.modified)}
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                      <DescriptionListTerm>Released</DescriptionListTerm>
-                      <DescriptionListDescription>
-                        {formatDate(vulnerability.released)}
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                      <DescriptionListTerm>Withdrawn</DescriptionListTerm>
-                      <DescriptionListDescription>
-                        {formatDate(vulnerability.withdrawn)}
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                  </DescriptionList>
-                </CardBody>
-              </Card>
-            </GridItem>
-            <GridItem md={4}>
-              <Card isFullHeight>
-                <CardTitle>Additional info</CardTitle>
-                <CardBody>
-                  <DescriptionList>
-                    <DescriptionListGroup>
-                      <DescriptionListTerm>CWE</DescriptionListTerm>
-                      <DescriptionListDescription>
-                        {"vulnerability.cwe"}
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                      <DescriptionListTerm>Non normative</DescriptionListTerm>
-                      <DescriptionListDescription>
-                        {vulnerability.normative ? "Yes" : "No"}
-                      </DescriptionListDescription>
-                    </DescriptionListGroup>
-                  </DescriptionList>
-                </CardBody>
-              </Card>
-            </GridItem>
-          </Grid>
-        </StackItem>
-      </Stack>
+      <TextContent>
+        <Text>{vulnerability.title || vulnerability.description}</Text>
+      </TextContent>
+      <br />
+      <DescriptionList
+        columnModifier={{
+          default: "2Col",
+        }}
+      >
+        <DescriptionListGroup>
+          <DescriptionListTerm>Published</DescriptionListTerm>
+          <DescriptionListDescription>
+            {formatDate(vulnerability.published)}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Modified</DescriptionListTerm>
+          <DescriptionListDescription>
+            {formatDate(vulnerability.modified)}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Released</DescriptionListTerm>
+          <DescriptionListDescription>
+            {formatDate(vulnerability.released)}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Withdrawn</DescriptionListTerm>
+          <DescriptionListDescription>
+            {formatDate(vulnerability.withdrawn)}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>CWE</DescriptionListTerm>
+          <DescriptionListDescription>
+            {"vulnerability.cwe"}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Non normative</DescriptionListTerm>
+          <DescriptionListDescription>
+            {vulnerability.normative ? "Yes" : "No"}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
     </>
   );
 };

--- a/client/src/app/pages/vulnerability-details/overview.tsx
+++ b/client/src/app/pages/vulnerability-details/overview.tsx
@@ -53,9 +53,9 @@ export const Overview: React.FC<OverviewProps> = ({ vulnerability }) => {
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
-          <DescriptionListTerm>CWE</DescriptionListTerm>
+          <DescriptionListTerm>CWEs</DescriptionListTerm>
           <DescriptionListDescription>
-            {"vulnerability.cwe"}
+            {"vulnerability.cwes"}
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>

--- a/client/src/app/pages/vulnerability-details/vulnerability-details.tsx
+++ b/client/src/app/pages/vulnerability-details/vulnerability-details.tsx
@@ -1,13 +1,16 @@
-import React from "react";
-import { Link } from "react-router-dom";
+import React, { useState } from "react";
 
-import DetailsPage from "@patternfly/react-component-groups/dist/esm/DetailsPage";
 import {
-  Breadcrumb,
-  BreadcrumbItem,
+  Divider,
   PageSection,
+  PageSectionVariants,
   Popover,
+  Tab,
   TabAction,
+  Tabs,
+  TabTitleText,
+  Text,
+  TextContent,
 } from "@patternfly/react-core";
 import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 
@@ -23,159 +26,136 @@ import { SbomsByVulnerability } from "./sboms-by-vulnerability";
 
 export const CveDetails: React.FC = () => {
   const vulnerabilityId = useRouteParams(PathParam.VULNERABILITY_ID);
+  const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
 
   const { vulnerability, isFetching, fetchError } =
     useFetchVulnerabilityById(vulnerabilityId);
 
+  const handleTabClick = (
+    event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
+    tabIndex: string | number
+  ) => {
+    setActiveTabKey(tabIndex);
+  };
+
   return (
     <>
-      <PageSection variant="light">
-        <DetailsPage
-          breadcrumbs={
-            <Breadcrumb>
-              <BreadcrumbItem key="vulnerabilities">
-                <Link to="/vulnerabilities">Vulnerabilities</Link>
-              </BreadcrumbItem>
-              <BreadcrumbItem isActive>Vulnerability details</BreadcrumbItem>
-            </Breadcrumb>
-          }
-          actionButtons={[]}
-          pageHeading={{
-            title: vulnerability?.identifier ?? "",
-            label: vulnerability?.average_severity
-              ? {
-                  children: (
-                    <SeverityShieldAndText
-                      value={vulnerability.average_severity}
-                    />
-                  ),
-                  isCompact: true,
-                }
-              : undefined,
-          }}
-          tabs={[
-            {
-              eventKey: "overview",
-              title: "Overview",
-              children: (
-                <div className="pf-v5-u-m-md">
-                  <LoadingWrapper
-                    isFetching={isFetching}
-                    fetchError={fetchError}
-                  >
-                    {vulnerability && (
-                      <Overview vulnerability={vulnerability} />
-                    )}
-                  </LoadingWrapper>
-                </div>
-              ),
-            },
-            {
-              eventKey: "packages",
-              title: "Packages",
-              actions: (
-                <>
-                  <Popover
-                    bodyContent={
-                      <div>
-                        Packages that are <strong>mentioned</strong> in the
-                        current Vulnerability.
-                      </div>
-                    }
-                    position="top"
-                  >
-                    <TabAction>
-                      <HelpIcon />
-                    </TabAction>
-                  </Popover>
-                </>
-              ),
-              children: (
-                <div className="pf-v5-u-m-md">
-                  <LoadingWrapper
-                    isFetching={isFetching}
-                    fetchError={fetchError}
-                  >
-                    {vulnerability && (
-                      <PackagesByVulnerability
-                        advisories={vulnerability.advisories}
-                      />
-                    )}
-                  </LoadingWrapper>
-                </div>
-              ),
-            },
-            {
-              eventKey: "sboms",
-              title: "SBOMs",
-              actions: (
-                <>
-                  <Popover
-                    bodyContent={
-                      <div>
-                        SBOMs that are <strong>mentioned</strong> in the current
-                        Vulnerability.
-                      </div>
-                    }
-                    position="top"
-                  >
-                    <TabAction>
-                      <HelpIcon />
-                    </TabAction>
-                  </Popover>
-                </>
-              ),
-              children: (
-                <div className="pf-v5-u-m-md">
-                  <LoadingWrapper
-                    isFetching={isFetching}
-                    fetchError={fetchError}
-                  >
-                    {vulnerability && (
-                      <SbomsByVulnerability
-                        advisories={vulnerability.advisories}
-                      />
-                    )}
-                  </LoadingWrapper>
-                </div>
-              ),
-            },
-            {
-              eventKey: "advisories",
-              title: "Advisories",
-              actions: (
-                <>
-                  <Popover
-                    bodyContent={
-                      <div>
-                        Advisories that explain the current Vulnerability
-                      </div>
-                    }
-                    position="top"
-                  >
-                    <TabAction>
-                      <HelpIcon />
-                    </TabAction>
-                  </Popover>
-                </>
-              ),
-              children: (
-                <div className="pf-v5-u-m-md">
-                  <LoadingWrapper
-                    isFetching={isFetching}
-                    fetchError={fetchError}
-                  >
-                    {vulnerability && (
-                      <AdvisoriesByVulnerability
-                        advisories={vulnerability.advisories}
-                      />
-                    )}
-                  </LoadingWrapper>
-                </div>
-              ),
-            },
-          ]}
-        />
+      <PageSection variant={PageSectionVariants.light}>
+        <TextContent>
+          <Text component="h1">
+            {vulnerability?.identifier ?? ""}
+            {vulnerability?.average_severity ? (
+              <SeverityShieldAndText value={vulnerability.average_severity} />
+            ) : (
+              <></>
+            )}
+          </Text>
+        </TextContent>
+        <div className="pf-v5-u-m-md">
+          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+            {vulnerability && <Overview vulnerability={vulnerability} />}
+          </LoadingWrapper>
+        </div>
+      </PageSection>
+      <Divider component="div" />
+      <PageSection padding={{ default: "padding" }}>
+        <Tabs
+          activeKey={activeTabKey}
+          aria-label="CVE detail tabs"
+          onSelect={handleTabClick}
+          role="region"
+        >
+          <Tab
+            eventKey={0}
+            title={<TabTitleText>SBOMs</TabTitleText>}
+            aria-label="Related SBOMs for this CVE"
+            actions={
+              <>
+                <Popover
+                  bodyContent={
+                    <div>
+                      SBOMs that are <strong>mentioned</strong> in the current
+                      Vulnerability.
+                    </div>
+                  }
+                  position="top"
+                >
+                  <TabAction>
+                    <HelpIcon />
+                  </TabAction>
+                </Popover>
+              </>
+            }
+          >
+            <div className="pf-v5-u-m-md">
+              <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+                {vulnerability && (
+                  <SbomsByVulnerability advisories={vulnerability.advisories} />
+                )}
+              </LoadingWrapper>
+            </div>
+          </Tab>
+          <Tab
+            eventKey={1}
+            title={<TabTitleText>Advisories</TabTitleText>}
+            aria-label="Advisories that explain the current Vulnerability"
+            actions={
+              <>
+                <Popover
+                  bodyContent={
+                    <div>Advisories that explain the current Vulnerability</div>
+                  }
+                  position="top"
+                >
+                  <TabAction>
+                    <HelpIcon />
+                  </TabAction>
+                </Popover>
+              </>
+            }
+          >
+            <div className="pf-v5-u-m-md">
+              <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+                {vulnerability && (
+                  <AdvisoriesByVulnerability
+                    advisories={vulnerability.advisories}
+                  />
+                )}
+              </LoadingWrapper>
+            </div>
+          </Tab>
+          <Tab
+            eventKey={2}
+            title={<TabTitleText>Packages</TabTitleText>}
+            actions={
+              <>
+                <Popover
+                  bodyContent={
+                    <div>
+                      Packages that are <strong>mentioned</strong> in the
+                      current Vulnerability.
+                    </div>
+                  }
+                  position="top"
+                >
+                  <TabAction>
+                    <HelpIcon />
+                  </TabAction>
+                </Popover>
+              </>
+            }
+          >
+            <div className="pf-v5-u-m-md">
+              <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+                {vulnerability && (
+                  <PackagesByVulnerability
+                    advisories={vulnerability.advisories}
+                  />
+                )}
+              </LoadingWrapper>
+            </div>
+          </Tab>
+        </Tabs>
       </PageSection>
     </>
   );


### PR DESCRIPTION
implements #190 

## Changes

- Rearrange properties in `Overview` component to reflect v1
- Adapt labels in tables according to [this guide](https://docs.google.com/spreadsheets/d/1mhBd3-UYvSANIXwRPDrCdGplN7cq5rQPJhIywo5mcDY/edit?gid=1088076328#gid=1088076328)
- Move tabs + `Overview` into dedicated area outside of `DetailPage`
- Remove `DetailPage`, as we are no longer using those breadcrumbs, built-in tabs, or actions

## Comparison of v1 and v2

![v1v2](https://github.com/user-attachments/assets/a6cab7db-ff18-4d8c-9d6e-8e3f1c71c08b)

## New state

![Advisories](https://github.com/user-attachments/assets/2d238cf3-87e6-4a9a-926c-2f116c79704d)

![SBOMs](https://github.com/user-attachments/assets/23ec7be6-dc1d-4fc4-9103-14b613176b5f)

![Packages](https://github.com/user-attachments/assets/9ea33b66-e036-4606-8390-1ed0ad6f5c4e)

![Detail popover](https://github.com/user-attachments/assets/a0abdd66-00a7-4ce7-a023-6030c2e68acb)

## TBD

- Keep or ditch the "Related Products" tab from v1
- Keep or ditch "Packages" tab from v2
- Do we want to show properties not shown (available?) in v1 ("non-normative", "CWE", "withdrawn", "released")?
- What happened to the "Reserved" property in v1, was that renamed? maybe to one of the above?