### PR TITLE
ci: Storybook visualization

### DIFF
--- a/.github/workflows/ci-repo.yaml
+++ b/.github/workflows/ci-repo.yaml
@@ -30,6 +30,8 @@ jobs:
       #   run: npm run lint
       - name: Build
         run: npm run build
+      - name: Build storybook
+        run: npm run build-storybook
       - name: Test
         run: npm run test -- --coverage --watchAll=false
       - name: Format check

--- a/.github/workflows/storybook-pr-build.yaml
+++ b/.github/workflows/storybook-pr-build.yaml
@@ -1,0 +1,33 @@
+name: Storybook - PR Preview Build
+
+on:
+  pull_request:
+    paths:
+      - "**/*.stories.tsx"
+
+jobs:
+  build-storybook-pr-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm clean-install --ignore-scripts
+      - name: Build
+        run: npm run build
+      - name: Build storybook
+        run: npm run build-storybook
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+      - uses: actions/upload-artifact@v4
+        with:
+          name: storybook-static
+          path: storybook-static/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr
+          path: pr/

--- a/.github/workflows/storybook-pr-deploy.yaml
+++ b/.github/workflows/storybook-pr-deploy.yaml
@@ -1,0 +1,88 @@
+name: Storybook PR Preview Deploy
+on:
+  workflow_run:
+    workflows: ["Storybook - PR Preview Build"]
+    types:
+      - completed
+
+jobs:
+  deploy-storybook-pr-preview:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download storybook-static
+        uses: actions/github-script@v6
+        with:
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "storybook-static"
+            })[0];
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/storybook-static.zip', Buffer.from(download.data));
+      - name: Download PR number
+        uses: actions/github-script@v6
+        with:
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+
+      - run: unzip storybook-static.zip -d storybook-static/
+      - run: unzip pr.zip
+
+      - name: Generate issue_number
+        uses: actions/github-script@v6
+        id: issue_number
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            return Number(fs.readFileSync('./NR'));
+          result-encoding: string
+
+      - name: Generate Surge URL
+        uses: actions/github-script@v6
+        id: surge-url
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue_number = ${{steps.issue_number.outputs.result}};
+            return `trustify-ui-pr-${issue_number}-preview.surge.sh`;
+          result-encoding: string
+      - name: Install Surge
+        run: npm install -g surge
+      - name: Deploy to Surge
+        run: surge ./storybook-static/ "${{steps.surge-url.outputs.result}}" --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Post URL as PR comment
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: "🚀 Storybook Deployed Preview: https://${{steps.surge-url.outputs.result}} ✨"
+          repo-token: ${{ secrets.PREVIEW_BOT_TOKEN }}
+          issue: ${{steps.issue_number.outputs.result}}

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -1,0 +1,50 @@
+name: Storybook Deployment
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.stories.tsx"
+  workflow_dispatch:
+  workflow_call:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  gh-pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm clean-install --ignore-scripts
+      - name: Build
+        run: npm run build
+      - name: Build storybook
+        run: npm run build-storybook
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./storybook-static"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Add `storybook-pr-build.yaml` to build storybook each time any story is touched. If no story is touched then it won't be triggered.
- Add `storybook-pr-deploy.yaml` to deploy a preview of Storybook each time a story is touched in a PR. It will also add a comment to the PR indicating to the user where he can pre visualize his changes. Here is an example of how it will work https://github.com/carlosthe19916/trustify-ui/pull/10
- Add `storybook.yaml` to deploy Storybook in Github page. It will only deploy what is in the main branch. This is how it will look like once merge https://carlosthe19916.github.io/trustify-ui/ . I tested it in my own fork.

Requirements:

- We are using surge.sh to pre visualize PR stories. Therefore we need `SURGE_TOKEN` which is already set in the Organization.
- We are using a bot account to add a comment with the appropriate surge link in each PR. Therefore we need `PREVIEW_BOT_TOKEN` which is also already set in this GH Organization so there is no need to set any of the Secrets mentioned.