### PR TITLE
chore(cve): v1 parity detail enhancements

### DIFF
--- a/client/src/app/pages/vulnerability-details/advisories-by-vulnerability.stories.tsx
+++ b/client/src/app/pages/vulnerability-details/advisories-by-vulnerability.stories.tsx
@@ -28,3 +28,82 @@ export const EmptyState: Story = {
     advisories: [],
   },
 };
+
+export const PrimaryState: Story = {
+  args: {
+    variant: "compact",
+    advisories: [
+      {
+        uuid: "urn:uuid:753e8448-2086-4908-a027-1f1a7b95fa6a",
+        identifier: "CVE-2024-8391",
+        issuer: {
+          id: "9cf89bf3-ef8d-44ba-87a8-66a324795996",
+          name: "eclipse",
+          cpe_key: null,
+          website: null,
+        },
+        published: "2024-09-04T15:27:58.478Z",
+        modified: "2024-09-04T17:40:20.318Z",
+        withdrawn: null,
+        title:
+          "Eclipse Vert.x gRPC server does not limit the maximum message size",
+        labels: {
+          type: "cve",
+          file: "2024/8xxx/CVE-2024-8391.json",
+          importer: "cve",
+          source: "https://github.com/CVEProject/cvelistV5",
+        },
+        severity: null,
+        score: null,
+        cvss3_scores: [],
+        purls: {
+          affected: [
+            {
+              base_purl: {
+                uuid: "af66fc9c-65d5-5b36-a169-7a417641fb69",
+                purl: "pkg://maven/io.vertx/vertx-grpc-server",
+              },
+              version: "[4.3.0,4.5.10)",
+              context: null,
+            },
+          ],
+        },
+        number_of_vulnerabilities: 1,
+        sboms: [
+          {
+            id: "urn:uuid:0193013f-1b8a-7152-8857-8b8f4238b8ba",
+            document_id:
+              "https://access.redhat.com/security/data/sbom/spdx/quarkus-bom-3.2.12.Final-redhat-00002",
+            labels: {
+              type: "spdx",
+            },
+            data_licenses: ["CC0-1.0"],
+            published: "2024-07-05T09:40:48Z",
+            authors: [
+              "Organization: Red Hat Product Security (secalert@redhat.com)",
+            ],
+            name: "quarkus-bom",
+            version: "3.2.12.Final-redhat-00002",
+            status: ["affected"],
+          },
+          {
+            id: "urn:uuid:0193013f-0f00-77e1-afe4-b7d7f8585b7a",
+            document_id:
+              "https://access.redhat.com/security/data/sbom/spdx/quarkus-bom-3.2.11.Final-redhat-00001",
+            labels: {
+              type: "spdx",
+            },
+            data_licenses: ["CC0-1.0"],
+            published: "2024-05-28T09:26:01Z",
+            authors: [
+              "Organization: Red Hat Product Security (secalert@redhat.com)",
+            ],
+            name: "quarkus-bom",
+            version: "3.2.11.Final-redhat-00001",
+            status: ["affected"],
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/client/src/app/pages/vulnerability-details/advisories-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/advisories-by-vulnerability.tsx
@@ -1,15 +1,6 @@
 import React from "react";
 
-import {
-  Button,
-  ButtonVariant,
-  TextContent,
-  Title,
-  Toolbar,
-  ToolbarContent,
-  ToolbarItem,
-} from "@patternfly/react-core";
-import spacing from "@patternfly/react-styles/css/utilities/Spacing/spacing";
+import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import {
   Table,
   TableProps,
@@ -19,10 +10,9 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
+import { Link } from "react-router-dom";
 
-import { AdvisoryInDrawerInfo } from "@app/components/AdvisoryInDrawerInfo";
 import { FilterToolbar } from "@app/components/FilterToolbar";
-import { PageDrawerContent } from "@app/components/PageDrawerContext";
 import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
@@ -31,28 +21,16 @@ import {
 } from "@app/components/TableControls";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { formatDate } from "@app/utils/utils";
-import { VulnerabilityAdvisoryHead } from "@app/client";
+import { VulnerabilityAdvisorySummary } from "@app/client";
 
 interface AdvisoriesByVulnerabilityProps {
   variant?: TableProps["variant"];
-  advisories: VulnerabilityAdvisoryHead[];
+  advisories: VulnerabilityAdvisorySummary[];
 }
 
 export const AdvisoriesByVulnerability: React.FC<
   AdvisoriesByVulnerabilityProps
 > = ({ variant, advisories }) => {
-  type RowAction = "showAdvisory";
-  const [selectedRowAction, setSelectedRowAction] =
-    React.useState<RowAction | null>(null);
-  const [selectedRow, setSelectedRow] =
-    React.useState<VulnerabilityAdvisoryHead | null>(null);
-
-  const showDrawer = (action: RowAction, row: VulnerabilityAdvisoryHead) => {
-    setSelectedRowAction(action);
-    setSelectedRow(row);
-  };
-
-  //
   const tableControls = useLocalTableControls({
     variant: variant,
     tableName: "advisory-table",
@@ -60,11 +38,11 @@ export const AdvisoriesByVulnerability: React.FC<
     items: advisories,
     isLoading: false,
     columnNames: {
-      identifier: "Name",
-      title: "Description",
-      severity: "CVSS",
-      published: "Published",
-      modified: "Modified",
+      identifier: "ID",
+      title: "Title",
+      severity: "Aggregated Severity",
+      revision: "Revision",
+      vulnerabilities: "Vulnerabilities",
     },
     hasActionsColumn: false,
     isSortEnabled: false,
@@ -111,8 +89,8 @@ export const AdvisoriesByVulnerability: React.FC<
               <Th {...getThProps({ columnKey: "identifier" })} />
               <Th {...getThProps({ columnKey: "title" })} />
               <Th {...getThProps({ columnKey: "severity" })} />
-              <Th {...getThProps({ columnKey: "published" })} />
-              <Th {...getThProps({ columnKey: "modified" })} />
+              <Th {...getThProps({ columnKey: "revision" })} />
+              <Th {...getThProps({ columnKey: "vulnerabilities" })} />
             </TableHeaderContentWithControls>
           </Tr>
         </Thead>
@@ -127,13 +105,7 @@ export const AdvisoriesByVulnerability: React.FC<
               return (
                 <Tr key={item.identifier} {...getTrProps({ item })}>
                   <Td width={15} {...getTdProps({ columnKey: "identifier" })}>
-                    <Button
-                      size="sm"
-                      variant={ButtonVariant.secondary}
-                      onClick={() => showDrawer("showAdvisory", item)}
-                    >
-                      {item.identifier}
-                    </Button>
+                    <Link to={`/advisory/${item.uuid}`}>{item.identifier}</Link>
                   </Td>
                   <Td
                     width={50}
@@ -142,11 +114,7 @@ export const AdvisoriesByVulnerability: React.FC<
                   >
                     {item.title}
                   </Td>
-                  <Td
-                    width={10}
-                    modifier="truncate"
-                    {...getTdProps({ columnKey: "severity" })}
-                  >
+                  <Td width={10} {...getTdProps({ columnKey: "severity" })}>
                     {item.severity && (
                       <SeverityShieldAndText value={item.severity} />
                     )}
@@ -154,16 +122,16 @@ export const AdvisoriesByVulnerability: React.FC<
                   <Td
                     width={10}
                     modifier="truncate"
-                    {...getTdProps({ columnKey: "published" })}
+                    {...getTdProps({ columnKey: "revision" })}
                   >
-                    {formatDate(item.published)}
+                    {formatDate(item.modified)}
                   </Td>
                   <Td
                     width={10}
                     modifier="truncate"
-                    {...getTdProps({ columnKey: "modified" })}
+                    {...getTdProps({ columnKey: "vulnerabilities" })}
                   >
-                    {formatDate(item.modified)}
+                    {item.number_of_vulnerabilities}
                   </Td>
                 </Tr>
               );
@@ -177,32 +145,6 @@ export const AdvisoriesByVulnerability: React.FC<
         isCompact
         paginationProps={paginationProps}
       />
-
-      <PageDrawerContent
-        isExpanded={selectedRowAction !== null}
-        onCloseClick={() => setSelectedRowAction(null)}
-        pageKey="drawer"
-        drawerPanelContentProps={{ defaultSize: "600px" }}
-        header={
-          <>
-            {selectedRowAction === "showAdvisory" && (
-              <TextContent>
-                <Title headingLevel="h2" size="lg" className={spacing.mtXs}>
-                  Advisory
-                </Title>
-              </TextContent>
-            )}
-          </>
-        }
-      >
-        {selectedRowAction === "showAdvisory" && (
-          <>
-            {selectedRow && (
-              <AdvisoryInDrawerInfo advisoryId={selectedRow?.uuid} />
-            )}
-          </>
-        )}
-      </PageDrawerContent>
     </>
   );
 };

--- a/client/src/app/pages/vulnerability-details/overview.tsx
+++ b/client/src/app/pages/vulnerability-details/overview.tsx
@@ -5,8 +5,10 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  Text,
-  TextContent,
+  Grid,
+  GridItem,
+  Stack,
+  StackItem,
 } from "@patternfly/react-core";
 
 import { formatDate } from "@app/utils/utils";
@@ -19,52 +21,49 @@ interface OverviewProps {
 export const Overview: React.FC<OverviewProps> = ({ vulnerability }) => {
   return (
     <>
-      <TextContent>
-        <Text>{vulnerability.title || vulnerability.description}</Text>
-      </TextContent>
-      <br />
-      <DescriptionList
-        columnModifier={{
-          default: "2Col",
-        }}
-      >
-        <DescriptionListGroup>
-          <DescriptionListTerm>Published</DescriptionListTerm>
-          <DescriptionListDescription>
-            {formatDate(vulnerability.published)}
-          </DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Modified</DescriptionListTerm>
-          <DescriptionListDescription>
-            {formatDate(vulnerability.modified)}
-          </DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Released</DescriptionListTerm>
-          <DescriptionListDescription>
-            {formatDate(vulnerability.released)}
-          </DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Withdrawn</DescriptionListTerm>
-          <DescriptionListDescription>
-            {formatDate(vulnerability.withdrawn)}
-          </DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>CWEs</DescriptionListTerm>
-          <DescriptionListDescription>
-            {"vulnerability.cwes"}
-          </DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>Non normative</DescriptionListTerm>
-          <DescriptionListDescription>
-            {vulnerability.normative ? "Yes" : "No"}
-          </DescriptionListDescription>
-        </DescriptionListGroup>
-      </DescriptionList>
+      <Stack hasGutter>
+        <StackItem>
+          <Grid hasGutter>
+            <GridItem md={10}>
+              <Grid>
+                <GridItem md={8}>
+                  <DescriptionListGroup>
+                    <DescriptionListDescription>
+                      {vulnerability.title || vulnerability.description || ""}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                </GridItem>
+              </Grid>
+            </GridItem>
+            <GridItem md={10}>
+              <DescriptionList
+                columnModifier={{
+                  default: "3Col",
+                }}
+              >
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Reserved</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {formatDate(vulnerability.reserved)}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Published date</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {formatDate(vulnerability.published)}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Last modified</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {formatDate(vulnerability.modified)}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              </DescriptionList>
+            </GridItem>
+          </Grid>
+        </StackItem>
+      </Stack>
     </>
   );
 };

--- a/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
@@ -23,7 +23,7 @@ import {
   Tr,
 } from "@patternfly/react-table";
 
-import { DecomposedPurl, VulnerabilityStatus } from "@app/api/models";
+import { VulnerabilityStatus } from "@app/api/models";
 import { client } from "@app/axios-config/apiInit";
 import {
   getSbom,
@@ -31,8 +31,7 @@ import {
   VulnerabilityAdvisorySummary,
 } from "@app/client";
 import { AdvisoryInDrawerInfo } from "@app/components/AdvisoryInDrawerInfo";
-import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
-import { LabelsAsList } from "@app/components/LabelsAsList";
+import { FilterType } from "@app/components/FilterToolbar";
 import { PageDrawerContent } from "@app/components/PageDrawerContext";
 import { SbomInDrawerInfo } from "@app/components/SbomInDrawerInfo";
 import { SimplePagination } from "@app/components/SimplePagination";
@@ -44,12 +43,6 @@ import {
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useWithUiId } from "@app/utils/query-utils";
 import { formatDate } from "@app/utils/utils";
-
-interface SbomPackage {
-  uuid: string;
-  purl: string;
-  decomposedPurl?: DecomposedPurl;
-}
 
 interface TableData {
   sbomId: string;
@@ -67,7 +60,7 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
   variant,
   advisories,
 }) => {
-  type RowAction = "showSbom" | "showAdvisory" | "showPackages";
+  type RowAction = "showSbom" | "showAdvisory";
   const [selectedRowAction, setSelectedRowAction] =
     React.useState<RowAction | null>(null);
   const [selectedRow, setSelectedRow] = React.useState<TableData | null>(null);
@@ -172,6 +165,10 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
     isLoading: false,
     columnNames: {
       name: "Name",
+      version: "Version",
+      dependencies: "Dependencies",
+      supplier: "Supplier",
+      created: "Created on",
       published: "Published",
       labels: "Labels",
       status: "Status",
@@ -231,7 +228,6 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
       {tableControls.isFilterEnabled && (
         <Toolbar {...toolbarProps}>
           <ToolbarContent>
-            <FilterToolbar showFiltersSideBySide {...filterToolbarProps} />
             <ToolbarItem {...paginationToolbarItemProps}>
               <SimplePagination
                 idPrefix="sbom-table"
@@ -248,10 +244,11 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
           <Tr>
             <TableHeaderContentWithControls {...tableControls}>
               <Th {...getThProps({ columnKey: "name" })} />
-              <Th {...getThProps({ columnKey: "published" })} />
-              <Th {...getThProps({ columnKey: "labels" })} />
+              <Th {...getThProps({ columnKey: "version" })} />
               <Th {...getThProps({ columnKey: "status" })} />
-              <Th {...getThProps({ columnKey: "advisory" })} />
+              <Th {...getThProps({ columnKey: "dependencies" })} />
+              <Th {...getThProps({ columnKey: "supplier" })} />
+              <Th {...getThProps({ columnKey: "created" })} />
             </TableHeaderContentWithControls>
           </Tr>
         </Thead>
@@ -273,27 +270,14 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
                     <Td width={25} {...getTdProps({ columnKey: "name" })}>
                       <Button
                         size="sm"
-                        variant={ButtonVariant.secondary}
+                        variant={ButtonVariant.link}
                         onClick={() => showDrawer("showSbom", item)}
                       >
                         {item?.sbom?.name}
                       </Button>
                     </Td>
-                    <Td
-                      width={10}
-                      modifier="truncate"
-                      {...getTdProps({ columnKey: "published" })}
-                    >
-                      {formatDate(item.sbom?.published)}
-                    </Td>
-                    <Td
-                      width={40}
-                      modifier="truncate"
-                      {...getTdProps({ columnKey: "labels" })}
-                    >
-                      {item.sbom?.labels && (
-                        <LabelsAsList value={item.sbom.labels} />
-                      )}
+                    <Td width={10} {...getTdProps({ columnKey: "version" })}>
+                      {item.sbom?.described_by[0]?.version}
                     </Td>
                     <Td
                       width={10}
@@ -306,17 +290,20 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
                       </Label>
                     </Td>
                     <Td
-                      width={15}
-                      modifier="truncate"
-                      {...getTdProps({ columnKey: "advisory" })}
+                      width={10}
+                      {...getTdProps({ columnKey: "dependencies" })}
                     >
-                      <Button
-                        size="sm"
-                        variant={ButtonVariant.secondary}
-                        onClick={() => showDrawer("showAdvisory", item)}
-                      >
-                        {item.advisory.identifier}
-                      </Button>
+                      {item?.sbom?.number_of_packages}
+                    </Td>
+                    <Td width={10} {...getTdProps({ columnKey: "supplier" })}>
+                      {item?.sbom?.authors}
+                    </Td>
+                    <Td
+                      width={10}
+                      modifier="truncate"
+                      {...getTdProps({ columnKey: "created" })}
+                    >
+                      {formatDate(item.sbom?.published)}
                     </Td>
                   </TableRowContentWithControls>
                 </Tr>
@@ -331,7 +318,6 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
         isCompact
         paginationProps={paginationProps}
       />
-
       <PageDrawerContent
         isExpanded={selectedRowAction !== null}
         onCloseClick={() => setSelectedRowAction(null)}
@@ -350,13 +336,6 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
               <TextContent>
                 <Title headingLevel="h2" size="lg" className={spacing.mtXs}>
                   Advisory
-                </Title>
-              </TextContent>
-            )}
-            {selectedRowAction === "showPackages" && (
-              <TextContent>
-                <Title headingLevel="h2" size="lg" className={spacing.mtXs}>
-                  Packages
                 </Title>
               </TextContent>
             )}

--- a/client/src/app/pages/vulnerability-details/vulnerability-details.tsx
+++ b/client/src/app/pages/vulnerability-details/vulnerability-details.tsx
@@ -2,17 +2,16 @@ import React, { useState } from "react";
 
 import {
   Divider,
+  Flex,
+  FlexItem,
   PageSection,
   PageSectionVariants,
-  Popover,
   Tab,
-  TabAction,
   Tabs,
   TabTitleText,
   Text,
   TextContent,
 } from "@patternfly/react-core";
-import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 
 import { PathParam, useRouteParams } from "@app/Routes";
 import { LoadingWrapper } from "@app/components/LoadingWrapper";
@@ -21,7 +20,6 @@ import { useFetchVulnerabilityById } from "@app/queries/vulnerabilities";
 
 import { AdvisoriesByVulnerability } from "./advisories-by-vulnerability";
 import { Overview } from "./overview";
-import { PackagesByVulnerability } from "./packages-by-vulnerability";
 import { SbomsByVulnerability } from "./sboms-by-vulnerability";
 
 export const CveDetails: React.FC = () => {
@@ -41,16 +39,20 @@ export const CveDetails: React.FC = () => {
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
-        <TextContent>
-          <Text component="h1">
-            {vulnerability?.identifier ?? ""}
+        <Flex>
+          <FlexItem>
+            <TextContent>
+              <Text component="h1">{vulnerability?.identifier ?? ""} </Text>
+            </TextContent>
+          </FlexItem>
+          <FlexItem>
             {vulnerability?.average_severity ? (
               <SeverityShieldAndText value={vulnerability.average_severity} />
             ) : (
               <></>
             )}
-          </Text>
-        </TextContent>
+          </FlexItem>
+        </Flex>
         <div className="pf-v5-u-m-md">
           <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
             {vulnerability && <Overview vulnerability={vulnerability} />}
@@ -64,96 +66,31 @@ export const CveDetails: React.FC = () => {
           aria-label="CVE detail tabs"
           onSelect={handleTabClick}
           role="region"
+          isBox={true}
         >
           <Tab
             eventKey={0}
-            title={<TabTitleText>SBOMs</TabTitleText>}
+            title={<TabTitleText>Related SBOMs</TabTitleText>}
             aria-label="Related SBOMs for this CVE"
-            actions={
-              <>
-                <Popover
-                  bodyContent={
-                    <div>
-                      SBOMs that are <strong>mentioned</strong> in the current
-                      Vulnerability.
-                    </div>
-                  }
-                  position="top"
-                >
-                  <TabAction>
-                    <HelpIcon />
-                  </TabAction>
-                </Popover>
-              </>
-            }
           >
-            <div className="pf-v5-u-m-md">
-              <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
-                {vulnerability && (
-                  <SbomsByVulnerability advisories={vulnerability.advisories} />
-                )}
-              </LoadingWrapper>
-            </div>
+            <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+              {vulnerability && (
+                <SbomsByVulnerability advisories={vulnerability.advisories} />
+              )}
+            </LoadingWrapper>
           </Tab>
           <Tab
             eventKey={1}
-            title={<TabTitleText>Advisories</TabTitleText>}
+            title={<TabTitleText>Related Advisories</TabTitleText>}
             aria-label="Advisories that explain the current Vulnerability"
-            actions={
-              <>
-                <Popover
-                  bodyContent={
-                    <div>Advisories that explain the current Vulnerability</div>
-                  }
-                  position="top"
-                >
-                  <TabAction>
-                    <HelpIcon />
-                  </TabAction>
-                </Popover>
-              </>
-            }
           >
-            <div className="pf-v5-u-m-md">
-              <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
-                {vulnerability && (
-                  <AdvisoriesByVulnerability
-                    advisories={vulnerability.advisories}
-                  />
-                )}
-              </LoadingWrapper>
-            </div>
-          </Tab>
-          <Tab
-            eventKey={2}
-            title={<TabTitleText>Packages</TabTitleText>}
-            actions={
-              <>
-                <Popover
-                  bodyContent={
-                    <div>
-                      Packages that are <strong>mentioned</strong> in the
-                      current Vulnerability.
-                    </div>
-                  }
-                  position="top"
-                >
-                  <TabAction>
-                    <HelpIcon />
-                  </TabAction>
-                </Popover>
-              </>
-            }
-          >
-            <div className="pf-v5-u-m-md">
-              <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
-                {vulnerability && (
-                  <PackagesByVulnerability
-                    advisories={vulnerability.advisories}
-                  />
-                )}
-              </LoadingWrapper>
-            </div>
+            <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+              {vulnerability && (
+                <AdvisoriesByVulnerability
+                  advisories={vulnerability.advisories}
+                />
+              )}
+            </LoadingWrapper>
           </Tab>
         </Tabs>
       </PageSection>


### PR DESCRIPTION
This PR is for v1 parity of the CVE detail page, relates to #190 .

## Changes

- [x] Update overview details for CVE
- [x] Issue with tabs and background not matching
- [x] Remove search bar
- [x] Update tabs for Related Products -> Related CVEs
- [x] Remove Related Advisories tab

## v1 Reference

https://trust.rhcloud.com/cve/content/CVE-2023-1664

![Screenshot 2024-11-04 at 3 59 47 PM](https://github.com/user-attachments/assets/25aac9b5-6a96-4214-b752-db3eec9ad3bb)

