### PR TITLE
feat: Advisory List - Revision Column added

### DIFF
--- a/client/src/app/pages/advisory-list/advisory-context.tsx
+++ b/client/src/app/pages/advisory-list/advisory-context.tsx
@@ -17,9 +17,9 @@ import { useFetchAdvisories } from "@app/queries/advisories";
 interface IAdvisorySearchContext {
   tableControls: ITableControls<
     AdvisorySummary,
-    "identifier" | "title" | "severity" | "revision" | "vulnerabilities",
-    "identifier" | "severity",
-    "" | "average_severity" | "revision",
+    "identifier" | "title" | "severity" | "modified" | "vulnerabilities",
+    "identifier" | "severity" | "modified",
+    "" | "average_severity" | "modified",
     string
   >;
 
@@ -47,12 +47,12 @@ export const AdvisorySearchProvider: React.FunctionComponent<
       identifier: "ID",
       title: "Title",
       severity: "Aggregated Severity",
-      revision: "Revision",
+      modified: "Revision",
       vulnerabilities: "Vulnerabilities",
     },
     isPaginationEnabled: true,
     isSortEnabled: true,
-    sortableColumns: ["identifier", "severity"],
+    sortableColumns: ["identifier", "severity", "modified"],
     isFilterEnabled: true,
     filterCategories: [
       {
@@ -75,7 +75,7 @@ export const AdvisorySearchProvider: React.FunctionComponent<
         ],
       },
       {
-        categoryKey: "revision",
+        categoryKey: "modified",
         title: "Revision",
         type: FilterType.dateRange,
       },
@@ -93,6 +93,7 @@ export const AdvisorySearchProvider: React.FunctionComponent<
       hubSortFieldKeys: {
         identifier: "identifier",
         severity: "average_score",
+        modified: "modified",
       },
     })
   );

--- a/client/src/app/pages/advisory-list/advisory-table.tsx
+++ b/client/src/app/pages/advisory-list/advisory-table.tsx
@@ -23,6 +23,8 @@ import { useDownload } from "@app/hooks/domain-controls/useDownload";
 
 import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
 import { VulnerabilityGallery } from "@app/components/VulnerabilityGallery";
+import { formatDate } from "@app/utils/utils";
+
 import { AdvisorySearchContext } from "./advisory-context";
 
 export const AdvisoryTable: React.FC = ({}) => {
@@ -55,7 +57,7 @@ export const AdvisoryTable: React.FC = ({}) => {
               <Th {...getThProps({ columnKey: "identifier" })} />
               <Th {...getThProps({ columnKey: "title" })} />
               <Th {...getThProps({ columnKey: "severity" })} />
-              <Th {...getThProps({ columnKey: "revision" })} />
+              <Th {...getThProps({ columnKey: "modified" })} />
               <Th {...getThProps({ columnKey: "vulnerabilities" })} />
             </TableHeaderContentWithControls>
           </Tr>
@@ -120,10 +122,8 @@ export const AdvisoryTable: React.FC = ({}) => {
                         value={item.average_severity as Severity}
                       />
                     </Td>
-                    <Td width={10} {...getTdProps({ columnKey: "revision" })}>
-                      <a href="https://github.com/trustification/trustify/issues/967">
-                        issue-967
-                      </a>
+                    <Td width={10} {...getTdProps({ columnKey: "modified" })}>
+                      {formatDate(item.modified)}
                     </Td>
                     <Td
                       width={20}


### PR DESCRIPTION
The issue https://github.com/trustification/trustify/issues/967 is saying that the "revision" column from v1 should be the `modified` field of an advisory.

This PR is adding the "modified" field as a "Revision" Column in the table.
Also making the column sortable.

![image](https://github.com/user-attachments/assets/ac6765b3-76fc-400e-a2cc-122320fb77df)
