### PR TITLE
feat: add advisory-details page

### DIFF
--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -6,6 +6,8 @@ import { Bullseye, Spinner } from "@patternfly/react-core";
 import { ErrorFallback } from "./components/ErrorFallback";
 
 const Home = lazy(() => import("./pages/home"));
+const AdvisoryList = lazy(() => import("./pages/advisory-list"));
+const AdvisoryDetails = lazy(() => import("./pages/advisory-details"));
 const VulnerabilityList = lazy(() => import("./pages/vulnerability-list"));
 const VulnerabilityDetails = lazy(
   () => import("./pages/vulnerability-details")
@@ -14,7 +16,6 @@ const PackageList = lazy(() => import("./pages/package-list"));
 const PackageDetails = lazy(() => import("./pages/package-details"));
 const SBOMList = lazy(() => import("./pages/sbom-list"));
 const SBOMDetails = lazy(() => import("./pages/sbom-details"));
-const AdvisoryList = lazy(() => import("./pages/advisory-list"));
 const Search = lazy(() => import("./pages/search"));
 const ImporterList = lazy(() => import("./pages/importer-list"));
 const Upload = lazy(() => import("./pages/upload"));
@@ -31,6 +32,11 @@ export enum PathParam {
 export const AppRoutes = () => {
   const allRoutes = useRoutes([
     { path: "/", element: <Home /> },
+    { path: "/advisories", element: <AdvisoryList /> },
+    {
+      path: `/advisories/:${PathParam.ADVISORY_ID}`,
+      element: <AdvisoryDetails />,
+    },
     { path: "/vulnerabilities", element: <VulnerabilityList /> },
     {
       path: `/vulnerabilities/:${PathParam.VULNERABILITY_ID}`,
@@ -47,7 +53,6 @@ export const AppRoutes = () => {
       path: `/sboms/:${PathParam.SBOM_ID}`,
       element: <SBOMDetails />,
     },
-    { path: "/advisories", element: <AdvisoryList /> },
     {
       path: `/importers`,
       element: <ImporterList />,

--- a/client/src/app/pages/advisory-details/advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/advisory-details.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+
+import {
+  Button,
+  PageSection,
+  Split,
+  SplitItem,
+  Tab,
+  TabContent,
+  Tabs,
+  TabTitleText,
+  Text,
+  TextContent,
+} from "@patternfly/react-core";
+import DownloadIcon from "@patternfly/react-icons/dist/esm/icons/download-icon";
+
+import { PathParam, useRouteParams } from "@app/Routes";
+
+import { LoadingWrapper } from "@app/components/LoadingWrapper";
+import { useDownload } from "@app/hooks/domain-controls/useDownload";
+import { useFetchAdvisoryById } from "@app/queries/advisories";
+
+import { Overview } from "./overview";
+import { VulnerabilitiesByAdvisory } from "./vulnerabilities-by-advisory";
+
+export const AdvisoryDetails: React.FC = () => {
+  const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
+
+  const handleTabClick = (
+    event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
+    tabIndex: string | number
+  ) => {
+    setActiveTabKey(tabIndex);
+  };
+
+  const infoTabRef = React.createRef<HTMLElement>();
+  const vulnerabilitiesTabRef = React.createRef<HTMLElement>();
+
+  //
+
+  const advisoryId = useRouteParams(PathParam.ADVISORY_ID);
+  const { advisory, isFetching, fetchError } = useFetchAdvisoryById(advisoryId);
+
+  const { downloadAdvisory } = useDownload();
+
+  return (
+    <>
+      <PageSection variant="light">
+        <Split>
+          <SplitItem isFilled>
+            <TextContent>
+              <Text component="h1">
+                {advisory?.identifier ?? advisoryId ?? ""}
+              </Text>
+              <Text component="p">Advisory detail information</Text>
+            </TextContent>
+          </SplitItem>
+          <SplitItem>
+            {!isFetching && (
+              <Button
+                variant="secondary"
+                icon={<DownloadIcon />}
+                onClick={() => {
+                  if (advisoryId) {
+                    downloadAdvisory(
+                      advisoryId,
+                      advisory?.identifier
+                        ? `${advisory?.identifier}.json`
+                        : `${advisoryId}.json`
+                    );
+                  }
+                }}
+              >
+                Download
+              </Button>
+            )}
+          </SplitItem>
+        </Split>
+      </PageSection>
+      <PageSection type="nav">
+        <Tabs
+          mountOnEnter
+          activeKey={activeTabKey}
+          onSelect={handleTabClick}
+          aria-label="Tabs that contain the SBOM information"
+          role="region"
+        >
+          <Tab
+            eventKey={0}
+            title={<TabTitleText>Info</TabTitleText>}
+            tabContentId="refTabInfoSection"
+            tabContentRef={infoTabRef}
+          />
+          <Tab
+            eventKey={1}
+            title={<TabTitleText>Vulnerabilities</TabTitleText>}
+            tabContentId="refVulnerabilitiesSection"
+            tabContentRef={vulnerabilitiesTabRef}
+          />
+        </Tabs>
+      </PageSection>
+      <PageSection>
+        <TabContent
+          eventKey={0}
+          id="refTabInfoSection"
+          ref={infoTabRef}
+          aria-label="Information of the Advisory"
+        >
+          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+            {advisory && <Overview advisory={advisory} />}
+          </LoadingWrapper>
+        </TabContent>
+        <TabContent
+          eventKey={1}
+          id="refVulnerabilitiesSection"
+          ref={vulnerabilitiesTabRef}
+          aria-label="Vulnerabilities within the SBOM"
+          hidden
+        >
+          <VulnerabilitiesByAdvisory
+            isFetching={isFetching}
+            fetchError={fetchError}
+            vulnerabilities={advisory?.vulnerabilities || []}
+          />
+        </TabContent>
+      </PageSection>
+    </>
+  );
+};

--- a/client/src/app/pages/advisory-details/index.ts
+++ b/client/src/app/pages/advisory-details/index.ts
@@ -1,0 +1,1 @@
+export { AdvisoryDetails as default } from "./advisory-details";

--- a/client/src/app/pages/advisory-details/overview.tsx
+++ b/client/src/app/pages/advisory-details/overview.tsx
@@ -1,0 +1,191 @@
+import React from "react";
+
+import prettyBytes from "pretty-bytes";
+
+import { ChartDonut } from "@patternfly/react-charts";
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Grid,
+  GridItem,
+} from "@patternfly/react-core";
+
+import { compareBySeverityFn, severityList } from "@app/api/model-utils";
+import { AdvisorySummary, Severity } from "@app/client";
+import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
+import { formatDate } from "@app/utils/utils";
+
+interface InfoProps {
+  advisory: AdvisorySummary;
+}
+
+export const Overview: React.FC<InfoProps> = ({ advisory }) => {
+  return (
+    <Grid hasGutter>
+      <GridItem md={4}>
+        <Card isFullHeight>
+          <CardTitle>Overview</CardTitle>
+          <CardBody>
+            <DescriptionList>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Title</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {advisory.title}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Type</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {advisory.labels.type}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Aggregate Severity</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {advisory.average_severity && (
+                    <SeverityShieldAndText
+                      value={advisory.average_severity as Severity}
+                    />
+                  )}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Size</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {prettyBytes(advisory.size)}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          </CardBody>
+        </Card>
+      </GridItem>
+      <GridItem md={4}>
+        <Card isFullHeight>
+          <CardTitle>Publisher</CardTitle>
+          <CardBody>
+            <DescriptionList>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Name</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {advisory.issuer?.name}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Contact details</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {advisory.issuer?.website}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          </CardBody>
+        </Card>
+      </GridItem>
+      <GridItem md={4}>
+        <Card isFullHeight>
+          <CardTitle>Tracking</CardTitle>
+          <CardBody>
+            <DescriptionList>
+              <DescriptionListGroup>
+                <DescriptionListTerm>ID</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {advisory.identifier}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Initial release date</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {formatDate(advisory.published)}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Current release date</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {formatDate(advisory.modified)}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          </CardBody>
+        </Card>
+      </GridItem>
+    </Grid>
+  );
+};
+
+//
+
+interface ChartData {
+  severity: Severity;
+  legend: string;
+  count: number;
+  color: string;
+}
+
+interface CVEsChartProps {
+  data: { [key in Severity]: number };
+}
+
+export const CVEsChart: React.FC<CVEsChartProps> = ({ data }) => {
+  const enrichedData = Object.entries(data)
+    .map(([severity, count]) => {
+      const severityProps = severityList[severity as Severity];
+
+      const result: ChartData = {
+        severity: severity as Severity,
+        legend: severityProps.name,
+        color: severityProps.color.value,
+        count: count,
+      };
+
+      return result;
+    })
+    .sort(compareBySeverityFn((item) => item.severity));
+
+  const chartData = enrichedData.map((e) => {
+    return {
+      x: e.legend,
+      y: e.count,
+    };
+  });
+
+  const chartLegendData = enrichedData.map((e) => ({
+    name: `${e.count} ${e.legend}`,
+  }));
+
+  const chartColorData = enrichedData.map((e) => e.color);
+
+  return (
+    <>
+      <div style={{ height: "230px", width: "350px" }}>
+        <ChartDonut
+          ariaDesc="CVEs"
+          ariaTitle="CVEs"
+          constrainToVisibleArea
+          data={chartData}
+          labels={({ datum }) => `${datum.x}: ${datum.y}`}
+          legendData={chartLegendData}
+          colorScale={chartColorData}
+          legendOrientation="vertical"
+          legendPosition="right"
+          name="CVEs"
+          padding={{
+            bottom: 20,
+            left: 20,
+            right: 140, // Adjusted to accommodate legend
+            top: 20,
+          }}
+          subTitle="CVEs"
+          title={enrichedData
+            .map((e) => e.count)
+            .reduce((prev, current) => prev + current, 0)
+            .toString()}
+          width={350}
+        />
+      </div>
+    </>
+  );
+};

--- a/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
+++ b/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+import { AxiosError } from "axios";
+
+import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
+import { AdvisoryVulnerabilitySummary } from "@app/client";
+import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
+import { SimplePagination } from "@app/components/SimplePagination";
+import {
+  ConditionalTableBody,
+  TableHeaderContentWithControls,
+  TableRowContentWithControls,
+} from "@app/components/TableControls";
+import { useLocalTableControls } from "@app/hooks/table-controls";
+import { formatDate } from "@app/utils/utils";
+
+interface VulnerabilitiesByAdvisoryProps {
+  isFetching: boolean;
+  fetchError?: AxiosError;
+  vulnerabilities: AdvisoryVulnerabilitySummary[];
+}
+
+export const VulnerabilitiesByAdvisory: React.FC<
+  VulnerabilitiesByAdvisoryProps
+> = ({ isFetching, fetchError, vulnerabilities }) => {
+  const tableControls = useLocalTableControls({
+    tableName: "vulnerability-table",
+    idProperty: "identifier",
+    items: vulnerabilities,
+    isLoading: isFetching,
+    columnNames: {
+      identifier: "CVE ID",
+      title: "Title",
+      discovery: "Discovery",
+      release: "Release",
+      score: "Score",
+      cwe: "Score",
+    },
+    hasActionsColumn: false,
+    isSortEnabled: true,
+    sortableColumns: [],
+    getSortValues: (item) => ({}),
+    isPaginationEnabled: true,
+    isFilterEnabled: false,
+    filterCategories: [],
+    isExpansionEnabled: false,
+  });
+
+  const {
+    currentPageItems,
+    numRenderedColumns,
+    propHelpers: {
+      toolbarProps,
+      filterToolbarProps,
+      paginationToolbarItemProps,
+      paginationProps,
+      tableProps,
+      getThProps,
+      getTrProps,
+      getTdProps,
+    },
+    expansionDerivedState: { isCellExpanded },
+  } = tableControls;
+  return (
+    <>
+      <Toolbar {...toolbarProps}>
+        <ToolbarContent>
+          <ToolbarItem {...paginationToolbarItemProps}>
+            <SimplePagination
+              idPrefix="vulnerability-table"
+              isTop
+              paginationProps={paginationProps}
+            />
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+
+      <Table {...tableProps} aria-label="vulnerability table">
+        <Thead>
+          <Tr>
+            <TableHeaderContentWithControls {...tableControls}>
+              <Th {...getThProps({ columnKey: "identifier" })} />
+              <Th {...getThProps({ columnKey: "title" })} />
+              <Th {...getThProps({ columnKey: "discovery" })} />
+              <Th {...getThProps({ columnKey: "release" })} />
+              <Th {...getThProps({ columnKey: "score" })} />
+              <Th {...getThProps({ columnKey: "cwe" })} />
+            </TableHeaderContentWithControls>
+          </Tr>
+        </Thead>
+        <ConditionalTableBody
+          isLoading={isFetching}
+          isError={!!fetchError}
+          isNoData={vulnerabilities.length === 0}
+          numRenderedColumns={numRenderedColumns}
+        >
+          {currentPageItems?.map((item, rowIndex) => {
+            return (
+              <Tbody key={item.identifier} isExpanded={isCellExpanded(item)}>
+                <Tr {...getTrProps({ item })}>
+                  <TableRowContentWithControls
+                    {...tableControls}
+                    item={item}
+                    rowIndex={rowIndex}
+                  >
+                    <Td width={15} {...getTdProps({ columnKey: "identifier" })}>
+                      <Link to={`/vulnerabilities/${item.identifier}`}>
+                        {item.identifier}
+                      </Link>
+                    </Td>
+                    <Td
+                      width={40}
+                      modifier="truncate"
+                      {...getTdProps({ columnKey: "title" })}
+                    >
+                      {item.title || item.description}
+                    </Td>
+                    <Td width={15} {...getTdProps({ columnKey: "discovery" })}>
+                      {formatDate(item.discovered)}
+                    </Td>
+                    <Td
+                      width={10}
+                      modifier="truncate"
+                      {...getTdProps({ columnKey: "release" })}
+                    >
+                      {formatDate(item.released)}
+                    </Td>
+                    <Td
+                      width={10}
+                      modifier="truncate"
+                      {...getTdProps({ columnKey: "score" })}
+                    >
+                      {item.severity && (
+                        <SeverityShieldAndText value={item.severity} />
+                      )}
+                    </Td>
+                    <Td
+                      width={10}
+                      modifier="truncate"
+                      {...getTdProps({ columnKey: "cwe" })}
+                    >
+                      {item.cwes.join(", ")}
+                    </Td>
+                  </TableRowContentWithControls>
+                </Tr>
+              </Tbody>
+            );
+          })}
+        </ConditionalTableBody>
+      </Table>
+      <SimplePagination
+        idPrefix="vulnerability-table"
+        isTop={false}
+        isCompact
+        paginationProps={paginationProps}
+      />
+    </>
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15518,6 +15518,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
       "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "license": "MIT",
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
       },


### PR DESCRIPTION
fix: https://github.com/trustification/trustify-ui/issues/214

This PR adds the Advisory Details page.
There are some missing properties that V2 does not include but we can do it in a separate PR. I'd like this PR to be the skeleton of any additional properties we might add in the future.