### PR TITLE
fix(cve): change sorting columns in list view

### DIFF
--- a/client/src/app/pages/vulnerability-list/vulnerability-context.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-context.tsx
@@ -18,7 +18,7 @@ export interface IVulnerabilitySearchContext {
   tableControls: ITableControls<
     VulnerabilitySummary,
     "identifier" | "title" | "severity" | "published" | "sboms",
-    "published" | "sboms",
+    "published" | "severity",
     "" | "average_severity",
     string
   >;
@@ -52,7 +52,7 @@ export const VulnerabilitySearchProvider: React.FunctionComponent<
     },
     isPaginationEnabled: true,
     isSortEnabled: true,
-    sortableColumns: ["published", "sboms"],
+    sortableColumns: ["published", "severity"],
     isFilterEnabled: true,
     filterCategories: [
       {
@@ -87,8 +87,8 @@ export const VulnerabilitySearchProvider: React.FunctionComponent<
     getHubRequestParams({
       ...tableControlState,
       hubSortFieldKeys: {
+        severity: "severity",
         published: "published",
-        sboms: "sboms",
       },
     })
   );


### PR DESCRIPTION
Just a quick fix related to #235. This PR updates the sortable columns in CVE list view to be `published` and `severity`, and removes sorting by `Related documents`. Note that the default sort has been set to `published` because it seems to not be possible to sort by `severity`. Will check to see if this is supported by the backend.

![Screenshot 2024-11-13 at 11 54 47 AM](https://github.com/user-attachments/assets/a1df9772-bfdb-4214-aa42-9a6fa5c0e6f7)
