### PR TITLE
fix(storybook): add msw to mock network requests, fix existing stories

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -17,7 +17,6 @@ const config: StorybookConfig = {
   ],
   addons: [
     getAbsolutePath("@storybook/addon-webpack5-compiler-swc"),
-    getAbsolutePath("@storybook/addon-onboarding"),
     getAbsolutePath("@storybook/addon-links"),
     getAbsolutePath("@storybook/addon-essentials"),
     getAbsolutePath("@chromatic-com/storybook"),
@@ -31,6 +30,7 @@ const config: StorybookConfig = {
   docs: {
     autodocs: "tag",
   },
+  staticDirs: ["../public"],
   typescript: {
     reactDocgen: "react-docgen-typescript",
     reactDocgenTypescriptOptions: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import "@patternfly/patternfly/patternfly.css";
 import "@patternfly/patternfly/utilities/Accessibility/accessibility.css";
 import "@patternfly/patternfly/utilities/Display/display.css";
@@ -5,6 +6,9 @@ import "@patternfly/patternfly/utilities/Flex/flex.css";
 import "@patternfly/patternfly/utilities/Sizing/sizing.css";
 import "@patternfly/patternfly/utilities/Spacing/spacing.css";
 import type { Preview } from "@storybook/react";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 const preview: Preview = {
   parameters: {
@@ -15,6 +19,13 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
 };
 
 export default preview;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,11 +6,27 @@ import "@patternfly/patternfly/utilities/Flex/flex.css";
 import "@patternfly/patternfly/utilities/Sizing/sizing.css";
 import "@patternfly/patternfly/utilities/Spacing/spacing.css";
 import type { Preview } from "@storybook/react";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { initialize, mswLoader } from "msw-storybook-addon";
 
 const queryClient = new QueryClient();
 
+/*
+ * Initializes MSW
+ * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
+ * to learn how to customize it
+ */
+initialize();
+
 const preview: Preview = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    ),
+  ],
+  loaders: [mswLoader],
   parameters: {
     controls: {
       matchers: {
@@ -19,13 +35,6 @@ const preview: Preview = {
       },
     },
   },
-  decorators: [
-    (Story) => (
-      <QueryClientProvider client={queryClient}>
-        <Story />
-      </QueryClientProvider>
-    ),
-  ],
 };
 
 export default preview;

--- a/client/package.json
+++ b/client/package.json
@@ -77,7 +77,6 @@
     "html-webpack-plugin": "^5.5.0",
     "mini-css-extract-plugin": "^2.5.2",
     "monaco-editor-webpack-plugin": "^7.0.1",
-    "msw": "^1.2.3",
     "raw-loader": "^4.0.2",
     "react-refresh": "^0.14.0",
     "react-refresh-typescript": "^2.0.9",

--- a/client/src/app/pages/vulnerability-list/vulnerability-list.stories.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-list.stories.tsx
@@ -2,23 +2,477 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { BrowserRouter } from "react-router-dom";
 import { VulnerabilityList } from "./vulnerability-list";
+import { http, HttpResponse } from "msw";
 
 const meta = {
   title: "Components/vulnerability-list/vulnerability-list.tsx",
   component: VulnerabilityList,
   tags: ["autodocs"],
   decorators: [
-    (Story) => (
-      <BrowserRouter>
-        <Story />
-      </BrowserRouter>
-    ),
+    (Story) => {
+      return (
+        <BrowserRouter>
+          <Story />
+        </BrowserRouter>
+      );
+    },
   ],
 } satisfies Meta<typeof VulnerabilityList>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const PrimaryState: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(
+          "/api/v1/vulnerability?limit=10&offset=0&sort=published:asc",
+          () => {
+            return HttpResponse.json({
+              items: [
+                {
+                  normative: true,
+                  identifier: "CVE-2012-2055",
+                  title:
+                    'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+                  description:
+                    'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+                  reserved: "2012-04-04T00:00:00Z",
+                  published: "2012-04-04T10:00:00Z",
+                  modified: "2024-08-06T19:17:27.693Z",
+                  withdrawn: null,
+                  discovered: null,
+                  released: null,
+                  cwes: [],
+                  average_severity: null,
+                  average_score: null,
+                  advisories: [
+                    {
+                      uuid: "urn:uuid:688edfe3-b1e7-4591-b7c0-83b5be458f29",
+                      identifier: "CVE-2012-2055",
+                      issuer: {
+                        id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                        name: "mitre",
+                        cpe_key: null,
+                        website: null,
+                      },
+                      published: "2012-04-04T10:00:00Z",
+                      modified: "2024-08-06T19:17:27.693Z",
+                      withdrawn: null,
+                      title:
+                        'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+                      labels: {
+                        type: "cve",
+                        source: "https://github.com/CVEProject/cvelistV5",
+                        file: "2012/2xxx/CVE-2012-2055.json",
+                        importer: "cve",
+                      },
+                      severity: null,
+                      score: null,
+                    },
+                  ],
+                },
+                {
+                  normative: true,
+                  identifier: "CVE-2012-2054",
+                  title:
+                    'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+                  description:
+                    'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+                  reserved: "2012-04-04T00:00:00Z",
+                  published: "2012-04-04T10:00:00Z",
+                  modified: "2024-09-16T20:17:00.137Z",
+                  withdrawn: null,
+                  discovered: null,
+                  released: null,
+                  cwes: [],
+                  average_severity: null,
+                  average_score: null,
+                  advisories: [
+                    {
+                      uuid: "urn:uuid:13125ed4-a02b-4c81-a689-9b9cd13d13c9",
+                      identifier: "CVE-2012-2054",
+                      issuer: {
+                        id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                        name: "mitre",
+                        cpe_key: null,
+                        website: null,
+                      },
+                      published: "2012-04-04T10:00:00Z",
+                      modified: "2024-09-16T20:17:00.137Z",
+                      withdrawn: null,
+                      title:
+                        'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+                      labels: {
+                        file: "2012/2xxx/CVE-2012-2054.json",
+                        type: "cve",
+                        importer: "cve",
+                        source: "https://github.com/CVEProject/cvelistV5",
+                      },
+                      severity: null,
+                      score: null,
+                    },
+                  ],
+                },
+                {
+                  normative: true,
+                  identifier: "CVE-2012-2053",
+                  title:
+                    "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+                  description:
+                    "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+                  reserved: "2012-04-03T00:00:00Z",
+                  published: "2012-04-04T10:00:00Z",
+                  modified: "2024-08-06T19:17:27.65Z",
+                  withdrawn: null,
+                  discovered: null,
+                  released: null,
+                  cwes: [],
+                  average_severity: null,
+                  average_score: null,
+                  advisories: [
+                    {
+                      uuid: "urn:uuid:254f8858-e103-4502-8c24-5294cb091789",
+                      identifier: "CVE-2012-2053",
+                      issuer: {
+                        id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                        name: "mitre",
+                        cpe_key: null,
+                        website: null,
+                      },
+                      published: "2012-04-04T10:00:00Z",
+                      modified: "2024-08-06T19:17:27.65Z",
+                      withdrawn: null,
+                      title:
+                        "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+                      labels: {
+                        importer: "cve",
+                        file: "2012/2xxx/CVE-2012-2053.json",
+                        type: "cve",
+                        source: "https://github.com/CVEProject/cvelistV5",
+                      },
+                      severity: null,
+                      score: null,
+                    },
+                  ],
+                },
+                {
+                  normative: true,
+                  identifier: "CVE-2012-2215",
+                  title:
+                    "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+                  description:
+                    "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+                  reserved: "2012-04-09T00:00:00Z",
+                  published: "2012-04-09T21:00:00Z",
+                  modified: "2024-08-06T19:26:09.074Z",
+                  withdrawn: null,
+                  discovered: null,
+                  released: null,
+                  cwes: [],
+                  average_severity: null,
+                  average_score: null,
+                  advisories: [
+                    {
+                      uuid: "urn:uuid:4dada0af-ab37-4da4-83e6-dfdaabc46257",
+                      identifier: "CVE-2012-2215",
+                      issuer: {
+                        id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                        name: "mitre",
+                        cpe_key: null,
+                        website: null,
+                      },
+                      published: "2012-04-09T21:00:00Z",
+                      modified: "2024-08-06T19:26:09.074Z",
+                      withdrawn: null,
+                      title:
+                        "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+                      labels: {
+                        file: "2012/2xxx/CVE-2012-2215.json",
+                        importer: "cve",
+                        source: "https://github.com/CVEProject/cvelistV5",
+                        type: "cve",
+                      },
+                      severity: null,
+                      score: null,
+                    },
+                  ],
+                },
+                {
+                  normative: true,
+                  identifier: "CVE-2012-2156",
+                  title:
+                    "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+                  description:
+                    "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+                  reserved: "2012-04-04T00:00:00Z",
+                  published: "2012-04-11T10:00:00Z",
+                  modified: "2024-08-06T19:26:07.776Z",
+                  withdrawn: null,
+                  discovered: null,
+                  released: null,
+                  cwes: [],
+                  average_severity: null,
+                  average_score: null,
+                  advisories: [
+                    {
+                      uuid: "urn:uuid:29ee07f7-4f84-40bc-ae80-5b791b08c05f",
+                      identifier: "CVE-2012-2156",
+                      issuer: {
+                        id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                        name: "mitre",
+                        cpe_key: null,
+                        website: null,
+                      },
+                      published: "2012-04-11T10:00:00Z",
+                      modified: "2024-08-06T19:26:07.776Z",
+                      withdrawn: null,
+                      title:
+                        "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+                      labels: {
+                        importer: "cve",
+                        source: "https://github.com/CVEProject/cvelistV5",
+                        file: "2012/2xxx/CVE-2012-2156.json",
+                        type: "cve",
+                      },
+                      severity: null,
+                      score: null,
+                    },
+                  ],
+                },
+                {
+                  normative: true,
+                  identifier: "CVE-2012-2223",
+                  title:
+                    "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+                  description:
+                    "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+                  reserved: "2012-04-11T00:00:00Z",
+                  published: "2012-04-11T10:00:00Z",
+                  modified: "2024-08-06T19:26:08.954Z",
+                  withdrawn: null,
+                  discovered: null,
+                  released: null,
+                  cwes: [],
+                  average_severity: null,
+                  average_score: null,
+                  advisories: [
+                    {
+                      uuid: "urn:uuid:297d67e0-b508-40f4-8aaf-277ec423f9bb",
+                      identifier: "CVE-2012-2223",
+                      issuer: {
+                        id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                        name: "mitre",
+                        cpe_key: null,
+                        website: null,
+                      },
+                      published: "2012-04-11T10:00:00Z",
+                      modified: "2024-08-06T19:26:08.954Z",
+                      withdrawn: null,
+                      title:
+                        "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+                      labels: {
+                        type: "cve",
+                        file: "2012/2xxx/CVE-2012-2223.json",
+                        source: "https://github.com/CVEProject/cvelistV5",
+                        importer: "cve",
+                      },
+                      severity: null,
+                      score: null,
+                    },
+                  ],
+                },
+                {
+                  normative: true,
+                  identifier: "CVE-2012-2224",
+                  title:
+                    'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+                  description:
+                    'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+                  reserved: "2012-04-11T00:00:00Z",
+                  published: "2012-04-11T10:00:00Z",
+                  modified: "2024-08-06T19:26:09.029Z",
+                  withdrawn: null,
+                  discovered: null,
+                  released: null,
+                  cwes: [],
+                  average_severity: null,
+                  average_score: null,
+                  advisories: [
+                    {
+                      uuid: "urn:uuid:45078715-1f2f-4f19-87db-c4e5e5666198",
+                      identifier: "CVE-2012-2224",
+                      issuer: {
+                        id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                        name: "mitre",
+                        cpe_key: null,
+                        website: null,
+                      },
+                      published: "2012-04-11T10:00:00Z",
+                      modified: "2024-08-06T19:26:09.029Z",
+                      withdrawn: null,
+                      title:
+                        'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+                      labels: {
+                        file: "2012/2xxx/CVE-2012-2224.json",
+                        type: "cve",
+                        importer: "cve",
+                        source: "https://github.com/CVEProject/cvelistV5",
+                      },
+                      severity: null,
+                      score: null,
+                    },
+                  ],
+                },
+                {
+                  normative: true,
+                  identifier: "CVE-2012-2210",
+                  title:
+                    "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+                  description:
+                    "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+                  reserved: "2012-04-04T00:00:00Z",
+                  published: "2012-04-11T10:00:00Z",
+                  modified: "2024-08-06T19:26:09.004Z",
+                  withdrawn: null,
+                  discovered: null,
+                  released: null,
+                  cwes: [],
+                  average_severity: null,
+                  average_score: null,
+                  advisories: [
+                    {
+                      uuid: "urn:uuid:962cb8ac-ae47-4e79-b00f-c1cf128f39b0",
+                      identifier: "CVE-2012-2210",
+                      issuer: {
+                        id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                        name: "mitre",
+                        cpe_key: null,
+                        website: null,
+                      },
+                      published: "2012-04-11T10:00:00Z",
+                      modified: "2024-08-06T19:26:09.004Z",
+                      withdrawn: null,
+                      title:
+                        "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+                      labels: {
+                        source: "https://github.com/CVEProject/cvelistV5",
+                        type: "cve",
+                        importer: "cve",
+                        file: "2012/2xxx/CVE-2012-2210.json",
+                      },
+                      severity: null,
+                      score: null,
+                    },
+                  ],
+                },
+                {
+                  normative: true,
+                  identifier: "CVE-2012-2225",
+                  title:
+                    "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+                  description:
+                    "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+                  reserved: "2012-04-11T00:00:00Z",
+                  published: "2012-04-11T10:00:00Z",
+                  modified: "2024-08-06T19:26:08.912Z",
+                  withdrawn: null,
+                  discovered: null,
+                  released: null,
+                  cwes: [],
+                  average_severity: null,
+                  average_score: null,
+                  advisories: [
+                    {
+                      uuid: "urn:uuid:129b04e4-83c6-4092-a592-0e470ee2adaf",
+                      identifier: "CVE-2012-2225",
+                      issuer: {
+                        id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                        name: "mitre",
+                        cpe_key: null,
+                        website: null,
+                      },
+                      published: "2012-04-11T10:00:00Z",
+                      modified: "2024-08-06T19:26:08.912Z",
+                      withdrawn: null,
+                      title:
+                        "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+                      labels: {
+                        source: "https://github.com/CVEProject/cvelistV5",
+                        file: "2012/2xxx/CVE-2012-2225.json",
+                        type: "cve",
+                        importer: "cve",
+                      },
+                      severity: null,
+                      score: null,
+                    },
+                  ],
+                },
+                {
+                  normative: true,
+                  identifier: "CVE-2012-2230",
+                  title:
+                    "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+                  description:
+                    "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+                  reserved: "2012-04-12T00:00:00Z",
+                  published: "2012-04-12T10:00:00Z",
+                  modified: "2024-08-06T19:26:08.997Z",
+                  withdrawn: null,
+                  discovered: null,
+                  released: null,
+                  cwes: [],
+                  average_severity: null,
+                  average_score: null,
+                  advisories: [
+                    {
+                      uuid: "urn:uuid:dc310f12-70ac-4ada-a936-2d4cda202a0d",
+                      identifier: "CVE-2012-2230",
+                      issuer: {
+                        id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                        name: "mitre",
+                        cpe_key: null,
+                        website: null,
+                      },
+                      published: "2012-04-12T10:00:00Z",
+                      modified: "2024-08-06T19:26:08.997Z",
+                      withdrawn: null,
+                      title:
+                        "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+                      labels: {
+                        file: "2012/2xxx/CVE-2012-2230.json",
+                        source: "https://github.com/CVEProject/cvelistV5",
+                        type: "cve",
+                        importer: "cve",
+                      },
+                      severity: null,
+                      score: null,
+                    },
+                  ],
+                },
+              ],
+              total: 106717,
+            });
+          }
+        ),
+      ],
+    },
+  },
+};
+
 export const EmptyState: Story = {
   args: {},
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(
+          "/api/v1/vulnerability?limit=10&offset=0&sort=published:asc",
+          () => {
+            return HttpResponse.json(null);
+          }
+        ),
+      ],
+    },
+  },
 };

--- a/client/src/app/pages/vulnerability-list/vulnerability-table.stories.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-table.stories.tsx
@@ -1,454 +1,1524 @@
+import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import React, { createContext, useContext } from "react";
 import { BrowserRouter } from "react-router-dom";
 import { VulnerabilityTable } from "./vulnerability-table";
-import {
-  IVulnerabilitySearchContext,
-  VulnerabilitySearchContext,
-} from "./vulnerability-context";
-
-const contextDefaultValue = {} as IVulnerabilitySearchContext;
+import { VulnerabilitySearchContext } from "./vulnerability-context";
+import { http, HttpResponse } from "msw";
 
 const customTableControls = {
-  currentPageItems: 10,
+  currentPageItems: [],
   numRenderedColumns: 3,
-  tableName: "My little table",
-  columnNames: {
-    identifier: "",
+  propHelpers: {
+    paginationProps: null,
+    getThProps: () => {},
   },
 };
 
-const myTableControls = [
-  {
-    normative: true,
-    identifier: "CVE-2012-2000",
-    title:
-      "Multiple unspecified vulnerabilities in HP System Health Application and Command Line Utilities before 9.0.0 allow remote attackers to execute arbitrary code via unknown vectors.",
-    description:
-      "Multiple unspecified vulnerabilities in HP System Health Application and Command Line Utilities before 9.0.0 allow remote attackers to execute arbitrary code via unknown vectors.",
-    reserved: "2012-04-02T00:00:00Z",
-    published: "2012-05-02T21:00:00Z",
-    modified: "2024-08-06T19:17:27.757Z",
-    withdrawn: null,
-    discovered: null,
-    released: null,
-    cwes: [],
-    average_severity: null,
-    average_score: null,
-    advisories: [
-      {
-        uuid: "urn:uuid:0022ae6d-dc8a-4a99-9d68-6997eea8add4",
-        identifier: "CVE-2012-2000",
-        issuer: {
-          id: "59233971-e451-43da-ba38-13cd0951aa1d",
-          name: "hp",
-          cpe_key: null,
-          website: null,
-        },
-        published: "2012-05-02T21:00:00Z",
-        modified: "2024-08-06T19:17:27.757Z",
-        withdrawn: null,
-        title:
-          "Multiple unspecified vulnerabilities in HP System Health Application and Command Line Utilities before 9.0.0 allow remote attackers to execute arbitrary code via unknown vectors.",
-        labels: {
-          file: "2012/2xxx/CVE-2012-2000.json",
-          type: "cve",
-          importer: "cve",
-          source: "https://github.com/CVEProject/cvelistV5",
-        },
-        severity: null,
-        score: null,
-      },
-    ],
-  },
-  {
-    normative: true,
-    identifier: "CVE-2012-2001",
-    title:
-      "Cross-site scripting (XSS) vulnerability in HP SNMP Agents for Linux before 9.0.0 allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.",
-    description:
-      "Cross-site scripting (XSS) vulnerability in HP SNMP Agents for Linux before 9.0.0 allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.",
-    reserved: "2012-04-02T00:00:00Z",
-    published: "2012-05-02T22:00:00Z",
-    modified: "2024-08-06T19:17:27.691Z",
-    withdrawn: null,
-    discovered: null,
-    released: null,
-    cwes: [],
-    average_severity: null,
-    average_score: null,
-    advisories: [
-      {
-        uuid: "urn:uuid:977b41a3-1057-466f-aa8c-679bb62e8e3c",
-        identifier: "CVE-2012-2001",
-        issuer: {
-          id: "59233971-e451-43da-ba38-13cd0951aa1d",
-          name: "hp",
-          cpe_key: null,
-          website: null,
-        },
-        published: "2012-05-02T22:00:00Z",
-        modified: "2024-08-06T19:17:27.691Z",
-        withdrawn: null,
-        title:
-          "Cross-site scripting (XSS) vulnerability in HP SNMP Agents for Linux before 9.0.0 allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.",
-        labels: {
-          file: "2012/2xxx/CVE-2012-2001.json",
-          source: "https://github.com/CVEProject/cvelistV5",
-          type: "cve",
-          importer: "cve",
-        },
-        severity: null,
-        score: null,
-      },
-    ],
-  },
-  {
-    normative: true,
-    identifier: "CVE-2012-2002",
-    title:
-      "Open redirect vulnerability in HP SNMP Agents for Linux before 9.0.0 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via unspecified vectors.",
-    description:
-      "Open redirect vulnerability in HP SNMP Agents for Linux before 9.0.0 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via unspecified vectors.",
-    reserved: "2012-04-02T00:00:00Z",
-    published: "2012-05-02T22:00:00Z",
-    modified: "2024-08-06T19:17:27.684Z",
-    withdrawn: null,
-    discovered: null,
-    released: null,
-    cwes: [],
-    average_severity: null,
-    average_score: null,
-    advisories: [
-      {
-        uuid: "urn:uuid:cd3c0923-0392-4792-a35d-9618a85a2cb8",
-        identifier: "CVE-2012-2002",
-        issuer: {
-          id: "59233971-e451-43da-ba38-13cd0951aa1d",
-          name: "hp",
-          cpe_key: null,
-          website: null,
-        },
-        published: "2012-05-02T22:00:00Z",
-        modified: "2024-08-06T19:17:27.684Z",
-        withdrawn: null,
-        title:
-          "Open redirect vulnerability in HP SNMP Agents for Linux before 9.0.0 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via unspecified vectors.",
-        labels: {
-          source: "https://github.com/CVEProject/cvelistV5",
-          file: "2012/2xxx/CVE-2012-2002.json",
-          type: "cve",
-          importer: "cve",
-        },
-        severity: null,
-        score: null,
-      },
-    ],
-  },
-  {
-    normative: true,
-    identifier: "CVE-2012-2003",
-    title:
-      "Cross-site request forgery (CSRF) vulnerability in HP Insight Management Agents before 9.0.0.0 on Windows Server 2003 and 2008 allows remote attackers to hijack the authentication of unspecified victims via unknown vectors.",
-    description:
-      "Cross-site request forgery (CSRF) vulnerability in HP Insight Management Agents before 9.0.0.0 on Windows Server 2003 and 2008 allows remote attackers to hijack the authentication of unspecified victims via unknown vectors.",
-    reserved: "2012-04-02T00:00:00Z",
-    published: "2012-05-02T22:00:00Z",
-    modified: "2024-08-06T19:17:27.747Z",
-    withdrawn: null,
-    discovered: null,
-    released: null,
-    cwes: [],
-    average_severity: null,
-    average_score: null,
-    advisories: [
-      {
-        uuid: "urn:uuid:f3f25a24-5b0c-44ef-b63b-e00b7eabe1c3",
-        identifier: "CVE-2012-2003",
-        issuer: {
-          id: "59233971-e451-43da-ba38-13cd0951aa1d",
-          name: "hp",
-          cpe_key: null,
-          website: null,
-        },
-        published: "2012-05-02T22:00:00Z",
-        modified: "2024-08-06T19:17:27.747Z",
-        withdrawn: null,
-        title:
-          "Cross-site request forgery (CSRF) vulnerability in HP Insight Management Agents before 9.0.0.0 on Windows Server 2003 and 2008 allows remote attackers to hijack the authentication of unspecified victims via unknown vectors.",
-        labels: {
-          source: "https://github.com/CVEProject/cvelistV5",
-          type: "cve",
-          importer: "cve",
-          file: "2012/2xxx/CVE-2012-2003.json",
-        },
-        severity: null,
-        score: null,
-      },
-    ],
-  },
-  {
-    normative: true,
-    identifier: "CVE-2012-2004",
-    title:
-      "Open redirect vulnerability in HP Insight Management Agents before 9.0.0.0 on Windows Server 2003 and 2008 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via unspecified vectors.",
-    description:
-      "Open redirect vulnerability in HP Insight Management Agents before 9.0.0.0 on Windows Server 2003 and 2008 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via unspecified vectors.",
-    reserved: "2012-04-02T00:00:00Z",
-    published: "2012-05-02T22:00:00Z",
-    modified: "2024-08-06T19:17:27.626Z",
-    withdrawn: null,
-    discovered: null,
-    released: null,
-    cwes: [],
-    average_severity: null,
-    average_score: null,
-    advisories: [
-      {
-        uuid: "urn:uuid:296f83e7-7c80-4a1d-bd7e-78a64c8c34b5",
-        identifier: "CVE-2012-2004",
-        issuer: {
-          id: "59233971-e451-43da-ba38-13cd0951aa1d",
-          name: "hp",
-          cpe_key: null,
-          website: null,
-        },
-        published: "2012-05-02T22:00:00Z",
-        modified: "2024-08-06T19:17:27.626Z",
-        withdrawn: null,
-        title:
-          "Open redirect vulnerability in HP Insight Management Agents before 9.0.0.0 on Windows Server 2003 and 2008 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks via unspecified vectors.",
-        labels: {
-          type: "cve",
-          source: "https://github.com/CVEProject/cvelistV5",
-          file: "2012/2xxx/CVE-2012-2004.json",
-          importer: "cve",
-        },
-        severity: null,
-        score: null,
-      },
-    ],
-  },
-  {
-    normative: true,
-    identifier: "CVE-2012-2005",
-    title:
-      "Cross-site scripting (XSS) vulnerability in HP Insight Management Agents before 9.0.0.0 on Windows Server 2003 and 2008 allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.",
-    description:
-      "Cross-site scripting (XSS) vulnerability in HP Insight Management Agents before 9.0.0.0 on Windows Server 2003 and 2008 allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.",
-    reserved: "2012-04-02T00:00:00Z",
-    published: "2012-05-02T22:00:00Z",
-    modified: "2024-08-06T19:17:27.745Z",
-    withdrawn: null,
-    discovered: null,
-    released: null,
-    cwes: [],
-    average_severity: null,
-    average_score: null,
-    advisories: [
-      {
-        uuid: "urn:uuid:e84a45c3-0e4b-4cd9-a69a-160cf50f807a",
-        identifier: "CVE-2012-2005",
-        issuer: {
-          id: "59233971-e451-43da-ba38-13cd0951aa1d",
-          name: "hp",
-          cpe_key: null,
-          website: null,
-        },
-        published: "2012-05-02T22:00:00Z",
-        modified: "2024-08-06T19:17:27.745Z",
-        withdrawn: null,
-        title:
-          "Cross-site scripting (XSS) vulnerability in HP Insight Management Agents before 9.0.0.0 on Windows Server 2003 and 2008 allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.",
-        labels: {
-          type: "cve",
-          file: "2012/2xxx/CVE-2012-2005.json",
-          source: "https://github.com/CVEProject/cvelistV5",
-          importer: "cve",
-        },
-        severity: null,
-        score: null,
-      },
-    ],
-  },
-  {
-    normative: true,
-    identifier: "CVE-2012-2006",
-    title:
-      "Unspecified vulnerability in HP Insight Management Agents before 9.0.0.0 on Windows Server 2003 and 2008 allows remote attackers to modify data or cause a denial of service via unknown vectors.",
-    description:
-      "Unspecified vulnerability in HP Insight Management Agents before 9.0.0.0 on Windows Server 2003 and 2008 allows remote attackers to modify data or cause a denial of service via unknown vectors.",
-    reserved: "2012-04-02T00:00:00Z",
-    published: "2012-05-02T22:00:00Z",
-    modified: "2024-08-06T19:17:27.763Z",
-    withdrawn: null,
-    discovered: null,
-    released: null,
-    cwes: [],
-    average_severity: null,
-    average_score: null,
-    advisories: [
-      {
-        uuid: "urn:uuid:ec4d61f8-1d40-4900-a277-2bee18e8acf4",
-        identifier: "CVE-2012-2006",
-        issuer: {
-          id: "59233971-e451-43da-ba38-13cd0951aa1d",
-          name: "hp",
-          cpe_key: null,
-          website: null,
-        },
-        published: "2012-05-02T22:00:00Z",
-        modified: "2024-08-06T19:17:27.763Z",
-        withdrawn: null,
-        title:
-          "Unspecified vulnerability in HP Insight Management Agents before 9.0.0.0 on Windows Server 2003 and 2008 allows remote attackers to modify data or cause a denial of service via unknown vectors.",
-        labels: {
-          source: "https://github.com/CVEProject/cvelistV5",
-          importer: "cve",
-          file: "2012/2xxx/CVE-2012-2006.json",
-          type: "cve",
-        },
-        severity: null,
-        score: null,
-      },
-    ],
-  },
-  {
-    normative: true,
-    identifier: "CVE-2012-2007",
-    title:
-      "SQL injection vulnerability in HP Performance Insight for Networks 5.3.x, 5.41, 5.41.001, and 5.41.002 allows remote attackers to execute arbitrary SQL commands via unspecified vectors.",
-    description:
-      "SQL injection vulnerability in HP Performance Insight for Networks 5.3.x, 5.41, 5.41.001, and 5.41.002 allows remote attackers to execute arbitrary SQL commands via unspecified vectors.",
-    reserved: "2012-04-02T00:00:00Z",
-    published: "2012-05-09T10:00:00Z",
-    modified: "2024-08-06T19:17:27.709Z",
-    withdrawn: null,
-    discovered: null,
-    released: null,
-    cwes: [],
-    average_severity: null,
-    average_score: null,
-    advisories: [
-      {
-        uuid: "urn:uuid:b14fa42d-4257-4fd7-83d7-07a58f581a72",
-        identifier: "CVE-2012-2007",
-        issuer: {
-          id: "59233971-e451-43da-ba38-13cd0951aa1d",
-          name: "hp",
-          cpe_key: null,
-          website: null,
-        },
-        published: "2012-05-09T10:00:00Z",
-        modified: "2024-08-06T19:17:27.709Z",
-        withdrawn: null,
-        title:
-          "SQL injection vulnerability in HP Performance Insight for Networks 5.3.x, 5.41, 5.41.001, and 5.41.002 allows remote attackers to execute arbitrary SQL commands via unspecified vectors.",
-        labels: {
-          file: "2012/2xxx/CVE-2012-2007.json",
-          source: "https://github.com/CVEProject/cvelistV5",
-          type: "cve",
-          importer: "cve",
-        },
-        severity: null,
-        score: null,
-      },
-    ],
-  },
-  {
-    normative: true,
-    identifier: "CVE-2012-2008",
-    title:
-      "Cross-site scripting (XSS) vulnerability in HP Performance Insight for Networks 5.3.x, 5.41, 5.41.001, and 5.41.002 allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.",
-    description:
-      "Cross-site scripting (XSS) vulnerability in HP Performance Insight for Networks 5.3.x, 5.41, 5.41.001, and 5.41.002 allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.",
-    reserved: "2012-04-02T00:00:00Z",
-    published: "2012-05-09T10:00:00Z",
-    modified: "2024-08-06T19:17:27.822Z",
-    withdrawn: null,
-    discovered: null,
-    released: null,
-    cwes: [],
-    average_severity: null,
-    average_score: null,
-    advisories: [
-      {
-        uuid: "urn:uuid:ee11791d-7395-491d-befb-b2314a700aa7",
-        identifier: "CVE-2012-2008",
-        issuer: {
-          id: "59233971-e451-43da-ba38-13cd0951aa1d",
-          name: "hp",
-          cpe_key: null,
-          website: null,
-        },
-        published: "2012-05-09T10:00:00Z",
-        modified: "2024-08-06T19:17:27.822Z",
-        withdrawn: null,
-        title:
-          "Cross-site scripting (XSS) vulnerability in HP Performance Insight for Networks 5.3.x, 5.41, 5.41.001, and 5.41.002 allows remote attackers to inject arbitrary web script or HTML via unspecified vectors.",
-        labels: {
-          type: "cve",
-          importer: "cve",
-          source: "https://github.com/CVEProject/cvelistV5",
-          file: "2012/2xxx/CVE-2012-2008.json",
-        },
-        severity: null,
-        score: null,
-      },
-    ],
-  },
-  {
-    normative: true,
-    identifier: "CVE-2012-2009",
-    title:
-      "Unspecified vulnerability in HP Performance Insight for Networks 5.3.x, 5.41, 5.41.001, and 5.41.002 allows remote authenticated users to gain privileges via unknown vectors.",
-    description:
-      "Unspecified vulnerability in HP Performance Insight for Networks 5.3.x, 5.41, 5.41.001, and 5.41.002 allows remote authenticated users to gain privileges via unknown vectors.",
-    reserved: "2012-04-02T00:00:00Z",
-    published: "2012-05-09T10:00:00Z",
-    modified: "2024-08-06T19:17:27.75Z",
-    withdrawn: null,
-    discovered: null,
-    released: null,
-    cwes: [],
-    average_severity: null,
-    average_score: null,
-    advisories: [
-      {
-        uuid: "urn:uuid:7799ce4d-d2d7-486b-a3fb-62e627dbef06",
-        identifier: "CVE-2012-2009",
-        issuer: {
-          id: "59233971-e451-43da-ba38-13cd0951aa1d",
-          name: "hp",
-          cpe_key: null,
-          website: null,
-        },
-        published: "2012-05-09T10:00:00Z",
-        modified: "2024-08-06T19:17:27.75Z",
-        withdrawn: null,
-        title:
-          "Unspecified vulnerability in HP Performance Insight for Networks 5.3.x, 5.41, 5.41.001, and 5.41.002 allows remote authenticated users to gain privileges via unknown vectors.",
-        labels: {
-          source: "https://github.com/CVEProject/cvelistV5",
-          type: "cve",
-          file: "2012/2xxx/CVE-2012-2009.json",
-          importer: "cve",
-        },
-        severity: null,
-        score: null,
-      },
-    ],
-  },
-];
-
-export const EmptyContext = createContext(contextDefaultValue);
-
-export const NonEmptyContext = createContext({
+const dummyContextData = {
   isFetching: false,
   fetchError: "",
-  tableControls: myTableControls,
+  tableControls: customTableControls,
   totalItemCount: 3,
-});
+  currentPageItems: 10,
+  numRenderedColumns: 3,
+};
+
+const requestResponse = {
+  items: [
+    {
+      normative: true,
+      identifier: "CVE-2012-2055",
+      title:
+        'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+      description:
+        'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+      reserved: "2012-04-04T00:00:00Z",
+      published: "2012-04-04T10:00:00Z",
+      modified: "2024-08-06T19:17:27.693Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:688edfe3-b1e7-4591-b7c0-83b5be458f29",
+          identifier: "CVE-2012-2055",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-04T10:00:00Z",
+          modified: "2024-08-06T19:17:27.693Z",
+          withdrawn: null,
+          title:
+            'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+          labels: {
+            type: "cve",
+            importer: "cve",
+            source: "https://github.com/CVEProject/cvelistV5",
+            file: "2012/2xxx/CVE-2012-2055.json",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2054",
+      title:
+        'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+      description:
+        'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+      reserved: "2012-04-04T00:00:00Z",
+      published: "2012-04-04T10:00:00Z",
+      modified: "2024-09-16T20:17:00.137Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:13125ed4-a02b-4c81-a689-9b9cd13d13c9",
+          identifier: "CVE-2012-2054",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-04T10:00:00Z",
+          modified: "2024-09-16T20:17:00.137Z",
+          withdrawn: null,
+          title:
+            'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+          labels: {
+            source: "https://github.com/CVEProject/cvelistV5",
+            file: "2012/2xxx/CVE-2012-2054.json",
+            type: "cve",
+            importer: "cve",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2053",
+      title:
+        "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+      description:
+        "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+      reserved: "2012-04-03T00:00:00Z",
+      published: "2012-04-04T10:00:00Z",
+      modified: "2024-08-06T19:17:27.65Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:254f8858-e103-4502-8c24-5294cb091789",
+          identifier: "CVE-2012-2053",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-04T10:00:00Z",
+          modified: "2024-08-06T19:17:27.65Z",
+          withdrawn: null,
+          title:
+            "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+          labels: {
+            source: "https://github.com/CVEProject/cvelistV5",
+            importer: "cve",
+            type: "cve",
+            file: "2012/2xxx/CVE-2012-2053.json",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2215",
+      title:
+        "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+      description:
+        "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+      reserved: "2012-04-09T00:00:00Z",
+      published: "2012-04-09T21:00:00Z",
+      modified: "2024-08-06T19:26:09.074Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:4dada0af-ab37-4da4-83e6-dfdaabc46257",
+          identifier: "CVE-2012-2215",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-09T21:00:00Z",
+          modified: "2024-08-06T19:26:09.074Z",
+          withdrawn: null,
+          title:
+            "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+          labels: {
+            importer: "cve",
+            source: "https://github.com/CVEProject/cvelistV5",
+            file: "2012/2xxx/CVE-2012-2215.json",
+            type: "cve",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2156",
+      title:
+        "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+      description:
+        "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+      reserved: "2012-04-04T00:00:00Z",
+      published: "2012-04-11T10:00:00Z",
+      modified: "2024-08-06T19:26:07.776Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:29ee07f7-4f84-40bc-ae80-5b791b08c05f",
+          identifier: "CVE-2012-2156",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:07.776Z",
+          withdrawn: null,
+          title:
+            "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+          labels: {
+            file: "2012/2xxx/CVE-2012-2156.json",
+            importer: "cve",
+            type: "cve",
+            source: "https://github.com/CVEProject/cvelistV5",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2223",
+      title:
+        "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+      description:
+        "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+      reserved: "2012-04-11T00:00:00Z",
+      published: "2012-04-11T10:00:00Z",
+      modified: "2024-08-06T19:26:08.954Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:297d67e0-b508-40f4-8aaf-277ec423f9bb",
+          identifier: "CVE-2012-2223",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:08.954Z",
+          withdrawn: null,
+          title:
+            "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+          labels: {
+            importer: "cve",
+            type: "cve",
+            source: "https://github.com/CVEProject/cvelistV5",
+            file: "2012/2xxx/CVE-2012-2223.json",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2224",
+      title:
+        'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+      description:
+        'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+      reserved: "2012-04-11T00:00:00Z",
+      published: "2012-04-11T10:00:00Z",
+      modified: "2024-08-06T19:26:09.029Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:45078715-1f2f-4f19-87db-c4e5e5666198",
+          identifier: "CVE-2012-2224",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:09.029Z",
+          withdrawn: null,
+          title:
+            'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+          labels: {
+            importer: "cve",
+            type: "cve",
+            file: "2012/2xxx/CVE-2012-2224.json",
+            source: "https://github.com/CVEProject/cvelistV5",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2210",
+      title:
+        "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+      description:
+        "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+      reserved: "2012-04-04T00:00:00Z",
+      published: "2012-04-11T10:00:00Z",
+      modified: "2024-08-06T19:26:09.004Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:962cb8ac-ae47-4e79-b00f-c1cf128f39b0",
+          identifier: "CVE-2012-2210",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:09.004Z",
+          withdrawn: null,
+          title:
+            "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+          labels: {
+            type: "cve",
+            source: "https://github.com/CVEProject/cvelistV5",
+            file: "2012/2xxx/CVE-2012-2210.json",
+            importer: "cve",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2225",
+      title:
+        "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+      description:
+        "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+      reserved: "2012-04-11T00:00:00Z",
+      published: "2012-04-11T10:00:00Z",
+      modified: "2024-08-06T19:26:08.912Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:129b04e4-83c6-4092-a592-0e470ee2adaf",
+          identifier: "CVE-2012-2225",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:08.912Z",
+          withdrawn: null,
+          title:
+            "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+          labels: {
+            type: "cve",
+            source: "https://github.com/CVEProject/cvelistV5",
+            importer: "cve",
+            file: "2012/2xxx/CVE-2012-2225.json",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2230",
+      title:
+        "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+      description:
+        "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+      reserved: "2012-04-12T00:00:00Z",
+      published: "2012-04-12T10:00:00Z",
+      modified: "2024-08-06T19:26:08.997Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:dc310f12-70ac-4ada-a936-2d4cda202a0d",
+          identifier: "CVE-2012-2230",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-12T10:00:00Z",
+          modified: "2024-08-06T19:26:08.997Z",
+          withdrawn: null,
+          title:
+            "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+          labels: {
+            source: "https://github.com/CVEProject/cvelistV5",
+            importer: "cve",
+            file: "2012/2xxx/CVE-2012-2230.json",
+            type: "cve",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+  ],
+  total: 106717,
+};
+
+const tableControlsCustom = {
+  tableName: "vulnerability",
+  persistenceKeyPrefix: "vn",
+  columnNames: {
+    identifier: "ID",
+    title: "Description",
+    severity: "CVSS",
+    published: "Date published",
+    sboms: "Related documents",
+  },
+  isPaginationEnabled: true,
+  isSortEnabled: true,
+  sortableColumns: ["published", "sboms"],
+  isFilterEnabled: true,
+  filterCategories: [
+    {
+      categoryKey: "",
+      title: "Filter text",
+      placeholderText: "Search",
+      type: "search",
+    },
+    {
+      categoryKey: "average_severity",
+      title: "CVSS",
+      placeholderText: "CVSS",
+      type: "multiselect",
+      selectOptions: [
+        {
+          value: "none",
+          label: "None",
+        },
+        {
+          value: "low",
+          label: "Low",
+        },
+        {
+          value: "medium",
+          label: "Medium",
+        },
+        {
+          value: "high",
+          label: "High",
+        },
+        {
+          value: "critical",
+          label: "Critical",
+        },
+      ],
+    },
+  ],
+  isExpansionEnabled: true,
+  expandableVariant: "compound",
+  filterState: {
+    filterValues: {},
+  },
+  sortState: {
+    activeSort: {
+      columnKey: "published",
+      direction: "asc",
+    },
+  },
+  paginationState: {
+    pageNumber: 1,
+    itemsPerPage: 10,
+  },
+  expansionState: {
+    expandedCells: {},
+  },
+  activeItemState: {
+    activeItemId: null,
+  },
+  columnState: {
+    columns: [
+      {
+        id: "identifier",
+        label: "ID",
+        isVisible: true,
+      },
+      {
+        id: "title",
+        label: "Description",
+        isVisible: true,
+      },
+      {
+        id: "severity",
+        label: "CVSS",
+        isVisible: true,
+      },
+      {
+        id: "published",
+        label: "Date published",
+        isVisible: true,
+      },
+      {
+        id: "sboms",
+        label: "Related documents",
+        isVisible: true,
+      },
+    ],
+  },
+  idProperty: "identifier",
+  currentPageItems: [
+    {
+      normative: true,
+      identifier: "CVE-2012-2055",
+      title:
+        'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+      description:
+        'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+      reserved: "2012-04-04T00:00:00Z",
+      published: "2012-04-04T10:00:00Z",
+      modified: "2024-08-06T19:17:27.693Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:688edfe3-b1e7-4591-b7c0-83b5be458f29",
+          identifier: "CVE-2012-2055",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-04T10:00:00Z",
+          modified: "2024-08-06T19:17:27.693Z",
+          withdrawn: null,
+          title:
+            'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+          labels: {
+            type: "cve",
+            importer: "cve",
+            file: "2012/2xxx/CVE-2012-2055.json",
+            source: "https://github.com/CVEProject/cvelistV5",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2054",
+      title:
+        'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+      description:
+        'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+      reserved: "2012-04-04T00:00:00Z",
+      published: "2012-04-04T10:00:00Z",
+      modified: "2024-09-16T20:17:00.137Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:13125ed4-a02b-4c81-a689-9b9cd13d13c9",
+          identifier: "CVE-2012-2054",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-04T10:00:00Z",
+          modified: "2024-09-16T20:17:00.137Z",
+          withdrawn: null,
+          title:
+            'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+          labels: {
+            source: "https://github.com/CVEProject/cvelistV5",
+            file: "2012/2xxx/CVE-2012-2054.json",
+            type: "cve",
+            importer: "cve",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2053",
+      title:
+        "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+      description:
+        "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+      reserved: "2012-04-03T00:00:00Z",
+      published: "2012-04-04T10:00:00Z",
+      modified: "2024-08-06T19:17:27.65Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:254f8858-e103-4502-8c24-5294cb091789",
+          identifier: "CVE-2012-2053",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-04T10:00:00Z",
+          modified: "2024-08-06T19:17:27.65Z",
+          withdrawn: null,
+          title:
+            "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+          labels: {
+            type: "cve",
+            file: "2012/2xxx/CVE-2012-2053.json",
+            source: "https://github.com/CVEProject/cvelistV5",
+            importer: "cve",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2215",
+      title:
+        "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+      description:
+        "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+      reserved: "2012-04-09T00:00:00Z",
+      published: "2012-04-09T21:00:00Z",
+      modified: "2024-08-06T19:26:09.074Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:4dada0af-ab37-4da4-83e6-dfdaabc46257",
+          identifier: "CVE-2012-2215",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-09T21:00:00Z",
+          modified: "2024-08-06T19:26:09.074Z",
+          withdrawn: null,
+          title:
+            "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+          labels: {
+            source: "https://github.com/CVEProject/cvelistV5",
+            file: "2012/2xxx/CVE-2012-2215.json",
+            importer: "cve",
+            type: "cve",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2156",
+      title:
+        "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+      description:
+        "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+      reserved: "2012-04-04T00:00:00Z",
+      published: "2012-04-11T10:00:00Z",
+      modified: "2024-08-06T19:26:07.776Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:29ee07f7-4f84-40bc-ae80-5b791b08c05f",
+          identifier: "CVE-2012-2156",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:07.776Z",
+          withdrawn: null,
+          title:
+            "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+          labels: {
+            file: "2012/2xxx/CVE-2012-2156.json",
+            type: "cve",
+            importer: "cve",
+            source: "https://github.com/CVEProject/cvelistV5",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2223",
+      title:
+        "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+      description:
+        "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+      reserved: "2012-04-11T00:00:00Z",
+      published: "2012-04-11T10:00:00Z",
+      modified: "2024-08-06T19:26:08.954Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:297d67e0-b508-40f4-8aaf-277ec423f9bb",
+          identifier: "CVE-2012-2223",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:08.954Z",
+          withdrawn: null,
+          title:
+            "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+          labels: {
+            importer: "cve",
+            type: "cve",
+            file: "2012/2xxx/CVE-2012-2223.json",
+            source: "https://github.com/CVEProject/cvelistV5",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2224",
+      title:
+        'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+      description:
+        'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+      reserved: "2012-04-11T00:00:00Z",
+      published: "2012-04-11T10:00:00Z",
+      modified: "2024-08-06T19:26:09.029Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:45078715-1f2f-4f19-87db-c4e5e5666198",
+          identifier: "CVE-2012-2224",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:09.029Z",
+          withdrawn: null,
+          title:
+            'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+          labels: {
+            file: "2012/2xxx/CVE-2012-2224.json",
+            type: "cve",
+            importer: "cve",
+            source: "https://github.com/CVEProject/cvelistV5",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2210",
+      title:
+        "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+      description:
+        "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+      reserved: "2012-04-04T00:00:00Z",
+      published: "2012-04-11T10:00:00Z",
+      modified: "2024-08-06T19:26:09.004Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:962cb8ac-ae47-4e79-b00f-c1cf128f39b0",
+          identifier: "CVE-2012-2210",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:09.004Z",
+          withdrawn: null,
+          title:
+            "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+          labels: {
+            source: "https://github.com/CVEProject/cvelistV5",
+            file: "2012/2xxx/CVE-2012-2210.json",
+            importer: "cve",
+            type: "cve",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2225",
+      title:
+        "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+      description:
+        "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+      reserved: "2012-04-11T00:00:00Z",
+      published: "2012-04-11T10:00:00Z",
+      modified: "2024-08-06T19:26:08.912Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:129b04e4-83c6-4092-a592-0e470ee2adaf",
+          identifier: "CVE-2012-2225",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:08.912Z",
+          withdrawn: null,
+          title:
+            "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+          labels: {
+            file: "2012/2xxx/CVE-2012-2225.json",
+            importer: "cve",
+            source: "https://github.com/CVEProject/cvelistV5",
+            type: "cve",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+    {
+      normative: true,
+      identifier: "CVE-2012-2230",
+      title:
+        "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+      description:
+        "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+      reserved: "2012-04-12T00:00:00Z",
+      published: "2012-04-12T10:00:00Z",
+      modified: "2024-08-06T19:26:08.997Z",
+      withdrawn: null,
+      discovered: null,
+      released: null,
+      cwes: [],
+      average_severity: null,
+      average_score: null,
+      advisories: [
+        {
+          uuid: "urn:uuid:dc310f12-70ac-4ada-a936-2d4cda202a0d",
+          identifier: "CVE-2012-2230",
+          issuer: {
+            id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+            name: "mitre",
+            cpe_key: null,
+            website: null,
+          },
+          published: "2012-04-12T10:00:00Z",
+          modified: "2024-08-06T19:26:08.997Z",
+          withdrawn: null,
+          title:
+            "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+          labels: {
+            importer: "cve",
+            type: "cve",
+            source: "https://github.com/CVEProject/cvelistV5",
+            file: "2012/2xxx/CVE-2012-2230.json",
+          },
+          severity: null,
+          score: null,
+        },
+      ],
+    },
+  ],
+  totalItemCount: 106717,
+  isLoading: false,
+  selectionState: {
+    selectedItems: [],
+    areAllSelected: false,
+  },
+  numColumnsBeforeData: 0,
+  numColumnsAfterData: 0,
+  numRenderedColumns: 5,
+  expansionDerivedState: {},
+  activeItemDerivedState: {
+    activeItem: null,
+  },
+  propHelpers: {
+    toolbarProps: {
+      className: "",
+      collapseListedFiltersBreakpoint: "xl",
+      clearFiltersButtonText: "Clear all filters",
+    },
+    tableProps: {
+      isExpandable: true,
+    },
+    filterToolbarProps: {
+      filterCategories: [
+        {
+          categoryKey: "",
+          title: "Filter text",
+          placeholderText: "Search",
+          type: "search",
+        },
+        {
+          categoryKey: "average_severity",
+          title: "CVSS",
+          placeholderText: "CVSS",
+          type: "multiselect",
+          selectOptions: [
+            {
+              value: "none",
+              label: "None",
+            },
+            {
+              value: "low",
+              label: "Low",
+            },
+            {
+              value: "medium",
+              label: "Medium",
+            },
+            {
+              value: "high",
+              label: "High",
+            },
+            {
+              value: "critical",
+              label: "Critical",
+            },
+          ],
+        },
+      ],
+      filterValues: {},
+    },
+    filterPanelProps: {
+      filterCategories: [
+        {
+          categoryKey: "",
+          title: "Filter text",
+          placeholderText: "Search",
+          type: "search",
+        },
+        {
+          categoryKey: "average_severity",
+          title: "CVSS",
+          placeholderText: "CVSS",
+          type: "multiselect",
+          selectOptions: [
+            {
+              value: "none",
+              label: "None",
+            },
+            {
+              value: "low",
+              label: "Low",
+            },
+            {
+              value: "medium",
+              label: "Medium",
+            },
+            {
+              value: "high",
+              label: "High",
+            },
+            {
+              value: "critical",
+              label: "Critical",
+            },
+          ],
+        },
+      ],
+      filterValues: {},
+    },
+    getThProps: () => {},
+    getTrProps: () => {},
+    getTdProps: () => {},
+    paginationProps: {
+      itemCount: 106717,
+      perPage: 10,
+      page: 1,
+    },
+    paginationToolbarItemProps: {
+      variant: "pagination",
+      align: {
+        default: "alignRight",
+      },
+    },
+    toolbarBulkSelectorProps: {
+      areAllSelected: false,
+      selectedRows: [],
+      paginationProps: {
+        itemCount: 106717,
+        perPage: 10,
+        page: 1,
+      },
+      currentPageItems: [
+        {
+          normative: true,
+          identifier: "CVE-2012-2055",
+          title:
+            'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+          description:
+            'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+          reserved: "2012-04-04T00:00:00Z",
+          published: "2012-04-04T10:00:00Z",
+          modified: "2024-08-06T19:17:27.693Z",
+          withdrawn: null,
+          discovered: null,
+          released: null,
+          cwes: [],
+          average_severity: null,
+          average_score: null,
+          advisories: [
+            {
+              uuid: "urn:uuid:688edfe3-b1e7-4591-b7c0-83b5be458f29",
+              identifier: "CVE-2012-2055",
+              issuer: {
+                id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                name: "mitre",
+                cpe_key: null,
+                website: null,
+              },
+              published: "2012-04-04T10:00:00Z",
+              modified: "2024-08-06T19:17:27.693Z",
+              withdrawn: null,
+              title:
+                'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+              labels: {
+                type: "cve",
+                importer: "cve",
+                file: "2012/2xxx/CVE-2012-2055.json",
+                source: "https://github.com/CVEProject/cvelistV5",
+              },
+              severity: null,
+              score: null,
+            },
+          ],
+        },
+        {
+          normative: true,
+          identifier: "CVE-2012-2054",
+          title:
+            'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+          description:
+            'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+          reserved: "2012-04-04T00:00:00Z",
+          published: "2012-04-04T10:00:00Z",
+          modified: "2024-09-16T20:17:00.137Z",
+          withdrawn: null,
+          discovered: null,
+          released: null,
+          cwes: [],
+          average_severity: null,
+          average_score: null,
+          advisories: [
+            {
+              uuid: "urn:uuid:13125ed4-a02b-4c81-a689-9b9cd13d13c9",
+              identifier: "CVE-2012-2054",
+              issuer: {
+                id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                name: "mitre",
+                cpe_key: null,
+                website: null,
+              },
+              published: "2012-04-04T10:00:00Z",
+              modified: "2024-09-16T20:17:00.137Z",
+              withdrawn: null,
+              title:
+                'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+              labels: {
+                source: "https://github.com/CVEProject/cvelistV5",
+                file: "2012/2xxx/CVE-2012-2054.json",
+                type: "cve",
+                importer: "cve",
+              },
+              severity: null,
+              score: null,
+            },
+          ],
+        },
+        {
+          normative: true,
+          identifier: "CVE-2012-2053",
+          title:
+            "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+          description:
+            "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+          reserved: "2012-04-03T00:00:00Z",
+          published: "2012-04-04T10:00:00Z",
+          modified: "2024-08-06T19:17:27.65Z",
+          withdrawn: null,
+          discovered: null,
+          released: null,
+          cwes: [],
+          average_severity: null,
+          average_score: null,
+          advisories: [
+            {
+              uuid: "urn:uuid:254f8858-e103-4502-8c24-5294cb091789",
+              identifier: "CVE-2012-2053",
+              issuer: {
+                id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                name: "mitre",
+                cpe_key: null,
+                website: null,
+              },
+              published: "2012-04-04T10:00:00Z",
+              modified: "2024-08-06T19:17:27.65Z",
+              withdrawn: null,
+              title:
+                "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+              labels: {
+                type: "cve",
+                file: "2012/2xxx/CVE-2012-2053.json",
+                source: "https://github.com/CVEProject/cvelistV5",
+                importer: "cve",
+              },
+              severity: null,
+              score: null,
+            },
+          ],
+        },
+        {
+          normative: true,
+          identifier: "CVE-2012-2215",
+          title:
+            "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+          description:
+            "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+          reserved: "2012-04-09T00:00:00Z",
+          published: "2012-04-09T21:00:00Z",
+          modified: "2024-08-06T19:26:09.074Z",
+          withdrawn: null,
+          discovered: null,
+          released: null,
+          cwes: [],
+          average_severity: null,
+          average_score: null,
+          advisories: [
+            {
+              uuid: "urn:uuid:4dada0af-ab37-4da4-83e6-dfdaabc46257",
+              identifier: "CVE-2012-2215",
+              issuer: {
+                id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                name: "mitre",
+                cpe_key: null,
+                website: null,
+              },
+              published: "2012-04-09T21:00:00Z",
+              modified: "2024-08-06T19:26:09.074Z",
+              withdrawn: null,
+              title:
+                "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+              labels: {
+                source: "https://github.com/CVEProject/cvelistV5",
+                file: "2012/2xxx/CVE-2012-2215.json",
+                importer: "cve",
+                type: "cve",
+              },
+              severity: null,
+              score: null,
+            },
+          ],
+        },
+        {
+          normative: true,
+          identifier: "CVE-2012-2156",
+          title:
+            "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+          description:
+            "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+          reserved: "2012-04-04T00:00:00Z",
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:07.776Z",
+          withdrawn: null,
+          discovered: null,
+          released: null,
+          cwes: [],
+          average_severity: null,
+          average_score: null,
+          advisories: [
+            {
+              uuid: "urn:uuid:29ee07f7-4f84-40bc-ae80-5b791b08c05f",
+              identifier: "CVE-2012-2156",
+              issuer: {
+                id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                name: "mitre",
+                cpe_key: null,
+                website: null,
+              },
+              published: "2012-04-11T10:00:00Z",
+              modified: "2024-08-06T19:26:07.776Z",
+              withdrawn: null,
+              title:
+                "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+              labels: {
+                file: "2012/2xxx/CVE-2012-2156.json",
+                type: "cve",
+                importer: "cve",
+                source: "https://github.com/CVEProject/cvelistV5",
+              },
+              severity: null,
+              score: null,
+            },
+          ],
+        },
+        {
+          normative: true,
+          identifier: "CVE-2012-2223",
+          title:
+            "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+          description:
+            "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+          reserved: "2012-04-11T00:00:00Z",
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:08.954Z",
+          withdrawn: null,
+          discovered: null,
+          released: null,
+          cwes: [],
+          average_severity: null,
+          average_score: null,
+          advisories: [
+            {
+              uuid: "urn:uuid:297d67e0-b508-40f4-8aaf-277ec423f9bb",
+              identifier: "CVE-2012-2223",
+              issuer: {
+                id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                name: "mitre",
+                cpe_key: null,
+                website: null,
+              },
+              published: "2012-04-11T10:00:00Z",
+              modified: "2024-08-06T19:26:08.954Z",
+              withdrawn: null,
+              title:
+                "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+              labels: {
+                importer: "cve",
+                type: "cve",
+                file: "2012/2xxx/CVE-2012-2223.json",
+                source: "https://github.com/CVEProject/cvelistV5",
+              },
+              severity: null,
+              score: null,
+            },
+          ],
+        },
+        {
+          normative: true,
+          identifier: "CVE-2012-2224",
+          title:
+            'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+          description:
+            'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+          reserved: "2012-04-11T00:00:00Z",
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:09.029Z",
+          withdrawn: null,
+          discovered: null,
+          released: null,
+          cwes: [],
+          average_severity: null,
+          average_score: null,
+          advisories: [
+            {
+              uuid: "urn:uuid:45078715-1f2f-4f19-87db-c4e5e5666198",
+              identifier: "CVE-2012-2224",
+              issuer: {
+                id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                name: "mitre",
+                cpe_key: null,
+                website: null,
+              },
+              published: "2012-04-11T10:00:00Z",
+              modified: "2024-08-06T19:26:09.029Z",
+              withdrawn: null,
+              title:
+                'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+              labels: {
+                file: "2012/2xxx/CVE-2012-2224.json",
+                type: "cve",
+                importer: "cve",
+                source: "https://github.com/CVEProject/cvelistV5",
+              },
+              severity: null,
+              score: null,
+            },
+          ],
+        },
+        {
+          normative: true,
+          identifier: "CVE-2012-2210",
+          title:
+            "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+          description:
+            "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+          reserved: "2012-04-04T00:00:00Z",
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:09.004Z",
+          withdrawn: null,
+          discovered: null,
+          released: null,
+          cwes: [],
+          average_severity: null,
+          average_score: null,
+          advisories: [
+            {
+              uuid: "urn:uuid:962cb8ac-ae47-4e79-b00f-c1cf128f39b0",
+              identifier: "CVE-2012-2210",
+              issuer: {
+                id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                name: "mitre",
+                cpe_key: null,
+                website: null,
+              },
+              published: "2012-04-11T10:00:00Z",
+              modified: "2024-08-06T19:26:09.004Z",
+              withdrawn: null,
+              title:
+                "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+              labels: {
+                source: "https://github.com/CVEProject/cvelistV5",
+                file: "2012/2xxx/CVE-2012-2210.json",
+                importer: "cve",
+                type: "cve",
+              },
+              severity: null,
+              score: null,
+            },
+          ],
+        },
+        {
+          normative: true,
+          identifier: "CVE-2012-2225",
+          title:
+            "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+          description:
+            "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+          reserved: "2012-04-11T00:00:00Z",
+          published: "2012-04-11T10:00:00Z",
+          modified: "2024-08-06T19:26:08.912Z",
+          withdrawn: null,
+          discovered: null,
+          released: null,
+          cwes: [],
+          average_severity: null,
+          average_score: null,
+          advisories: [
+            {
+              uuid: "urn:uuid:129b04e4-83c6-4092-a592-0e470ee2adaf",
+              identifier: "CVE-2012-2225",
+              issuer: {
+                id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                name: "mitre",
+                cpe_key: null,
+                website: null,
+              },
+              published: "2012-04-11T10:00:00Z",
+              modified: "2024-08-06T19:26:08.912Z",
+              withdrawn: null,
+              title:
+                "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+              labels: {
+                file: "2012/2xxx/CVE-2012-2225.json",
+                importer: "cve",
+                source: "https://github.com/CVEProject/cvelistV5",
+                type: "cve",
+              },
+              severity: null,
+              score: null,
+            },
+          ],
+        },
+        {
+          normative: true,
+          identifier: "CVE-2012-2230",
+          title:
+            "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+          description:
+            "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+          reserved: "2012-04-12T00:00:00Z",
+          published: "2012-04-12T10:00:00Z",
+          modified: "2024-08-06T19:26:08.997Z",
+          withdrawn: null,
+          discovered: null,
+          released: null,
+          cwes: [],
+          average_severity: null,
+          average_score: null,
+          advisories: [
+            {
+              uuid: "urn:uuid:dc310f12-70ac-4ada-a936-2d4cda202a0d",
+              identifier: "CVE-2012-2230",
+              issuer: {
+                id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                name: "mitre",
+                cpe_key: null,
+                website: null,
+              },
+              published: "2012-04-12T10:00:00Z",
+              modified: "2024-08-06T19:26:08.997Z",
+              withdrawn: null,
+              title:
+                "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+              labels: {
+                importer: "cve",
+                type: "cve",
+                source: "https://github.com/CVEProject/cvelistV5",
+                file: "2012/2xxx/CVE-2012-2230.json",
+              },
+              severity: null,
+              score: null,
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
 
 const meta = {
   title: "Components/vulnerability-list/vulnerability-table.tsx",
@@ -466,29 +1536,41 @@ const meta = {
       );
     },
   ],
-  excludeStories: /.*(Empty|NonEmpty)Context$/,
 } satisfies Meta<typeof VulnerabilityTable>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const NoMock: Story = {};
-
-export const EmptyState: Story = {
-  //   args: {
-  //     tableControls: {
-  //       numRenderedColumns: 5,
-  //       currentPageItems: [],
-  //     },
-  //   },
+export const PrimaryState: Story = {
   parameters: {
-    contextDefaultValue: EmptyContext,
+    contextDefaultValue: {
+      isFetching: false,
+      fetchError: "",
+      tableControls: { ...tableControlsCustom, getThProps: () => {} },
+      totalItemCount: 3,
+      currentPageItems: 10,
+      numRenderedColumns: 3,
+    },
+    msw: {
+      handlers: [
+        http.get("/api/v1/vulnerability", () => {
+          return HttpResponse.json(requestResponse);
+        }),
+      ],
+    },
   },
 };
 
-export const PrimaryState: Story = {
-  // override params
+export const EmptyState: Story = {
+  args: {
+    isFetching: false,
+    fetchError: "",
+    tableControls: customTableControls,
+    totalItemCount: 3,
+    currentPageItems: 10,
+    numRenderedColumns: 3,
+  },
   parameters: {
-    contextDefaultValue: NonEmptyContext,
+    contextDefaultValue: dummyContextData,
   },
 };

--- a/client/src/app/pages/vulnerability-list/vulnerability-toolbar.stories.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-toolbar.stories.tsx
@@ -2,23 +2,567 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { BrowserRouter } from "react-router-dom";
 import { VulnerabilityToolbar } from "./vulnerability-toolbar";
+import { VulnerabilitySearchContext } from "./vulnerability-context";
+
+const customContextData = {
+  tableControls: {
+    propHelpers: {
+      toolbarProps: {
+        className: "",
+        collapseListedFiltersBreakpoint: "xl",
+        clearFiltersButtonText: "Clear all filters",
+      },
+      tableProps: {
+        isExpandable: true,
+      },
+      filterToolbarProps: {
+        filterCategories: [
+          {
+            categoryKey: "",
+            title: "Filter text",
+            placeholderText: "Search",
+            type: "search",
+          },
+          {
+            categoryKey: "average_severity",
+            title: "CVSS",
+            placeholderText: "CVSS",
+            type: "multiselect",
+            selectOptions: [
+              {
+                value: "none",
+                label: "None",
+              },
+              {
+                value: "low",
+                label: "Low",
+              },
+              {
+                value: "medium",
+                label: "Medium",
+              },
+              {
+                value: "high",
+                label: "High",
+              },
+              {
+                value: "critical",
+                label: "Critical",
+              },
+            ],
+          },
+        ],
+        filterValues: {},
+      },
+      filterPanelProps: {
+        filterCategories: [
+          {
+            categoryKey: "",
+            title: "Filter text",
+            placeholderText: "Search",
+            type: "search",
+          },
+          {
+            categoryKey: "average_severity",
+            title: "CVSS",
+            placeholderText: "CVSS",
+            type: "multiselect",
+            selectOptions: [
+              {
+                value: "none",
+                label: "None",
+              },
+              {
+                value: "low",
+                label: "Low",
+              },
+              {
+                value: "medium",
+                label: "Medium",
+              },
+              {
+                value: "high",
+                label: "High",
+              },
+              {
+                value: "critical",
+                label: "Critical",
+              },
+            ],
+          },
+        ],
+        filterValues: {},
+      },
+      paginationProps: {
+        itemCount: 106717,
+        perPage: 10,
+        page: 1,
+      },
+      paginationToolbarItemProps: {
+        variant: "pagination",
+        align: {
+          default: "alignRight",
+        },
+      },
+      toolbarBulkSelectorProps: {
+        areAllSelected: false,
+        selectedRows: [],
+        paginationProps: {
+          itemCount: 106717,
+          perPage: 10,
+          page: 1,
+        },
+        currentPageItems: [
+          {
+            normative: true,
+            identifier: "CVE-2012-2055",
+            title:
+              'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+            description:
+              'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+            reserved: "2012-04-04T00:00:00Z",
+            published: "2012-04-04T10:00:00Z",
+            modified: "2024-08-06T19:17:27.693Z",
+            withdrawn: null,
+            discovered: null,
+            released: null,
+            cwes: [],
+            average_severity: null,
+            average_score: null,
+            advisories: [
+              {
+                uuid: "urn:uuid:688edfe3-b1e7-4591-b7c0-83b5be458f29",
+                identifier: "CVE-2012-2055",
+                issuer: {
+                  id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                  name: "mitre",
+                  cpe_key: null,
+                  website: null,
+                },
+                published: "2012-04-04T10:00:00Z",
+                modified: "2024-08-06T19:17:27.693Z",
+                withdrawn: null,
+                title:
+                  'GitHub Enterprise before 20120304 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set the public_key[user_id] value via a modified URL for the public-key update form, related to a "mass assignment" vulnerability.',
+                labels: {
+                  importer: "cve",
+                  file: "2012/2xxx/CVE-2012-2055.json",
+                  type: "cve",
+                  source: "https://github.com/CVEProject/cvelistV5",
+                },
+                severity: null,
+                score: null,
+              },
+            ],
+          },
+          {
+            normative: true,
+            identifier: "CVE-2012-2054",
+            title:
+              'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+            description:
+              'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+            reserved: "2012-04-04T00:00:00Z",
+            published: "2012-04-04T10:00:00Z",
+            modified: "2024-09-16T20:17:00.137Z",
+            withdrawn: null,
+            discovered: null,
+            released: null,
+            cwes: [],
+            average_severity: null,
+            average_score: null,
+            advisories: [
+              {
+                uuid: "urn:uuid:13125ed4-a02b-4c81-a689-9b9cd13d13c9",
+                identifier: "CVE-2012-2054",
+                issuer: {
+                  id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                  name: "mitre",
+                  cpe_key: null,
+                  website: null,
+                },
+                published: "2012-04-04T10:00:00Z",
+                modified: "2024-09-16T20:17:00.137Z",
+                withdrawn: null,
+                title:
+                  'Redmine before 1.3.2 does not properly restrict the use of a hash to provide values for a model\'s attributes, which allows remote attackers to set attributes in the (1) Comment, (2) Document, (3) IssueCategory, (4) MembersController, (5) Message, (6) News, (7) TimeEntry, (8) Version, (9) Wiki, (10) UserPreference, or (11) Board model via a modified URL, related to a "mass assignment" vulnerability, a different vulnerability than CVE-2012-0327.',
+                labels: {
+                  source: "https://github.com/CVEProject/cvelistV5",
+                  importer: "cve",
+                  file: "2012/2xxx/CVE-2012-2054.json",
+                  type: "cve",
+                },
+                severity: null,
+                score: null,
+              },
+            ],
+          },
+          {
+            normative: true,
+            identifier: "CVE-2012-2053",
+            title:
+              "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+            description:
+              "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+            reserved: "2012-04-03T00:00:00Z",
+            published: "2012-04-04T10:00:00Z",
+            modified: "2024-08-06T19:17:27.65Z",
+            withdrawn: null,
+            discovered: null,
+            released: null,
+            cwes: [],
+            average_severity: null,
+            average_score: null,
+            advisories: [
+              {
+                uuid: "urn:uuid:254f8858-e103-4502-8c24-5294cb091789",
+                identifier: "CVE-2012-2053",
+                issuer: {
+                  id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                  name: "mitre",
+                  cpe_key: null,
+                  website: null,
+                },
+                published: "2012-04-04T10:00:00Z",
+                modified: "2024-08-06T19:17:27.65Z",
+                withdrawn: null,
+                title:
+                  "The sudoers file in the Linux system configuration in F5 FirePass 6.0.0 through 6.1.0 and 7.0.0 does not require a password for executing commands as root, which allows local users to gain privileges via the sudo program, as demonstrated by the user account that executes PHP scripts, a different vulnerability than CVE-2012-1777.",
+                labels: {
+                  file: "2012/2xxx/CVE-2012-2053.json",
+                  type: "cve",
+                  source: "https://github.com/CVEProject/cvelistV5",
+                  importer: "cve",
+                },
+                severity: null,
+                score: null,
+              },
+            ],
+          },
+          {
+            normative: true,
+            identifier: "CVE-2012-2215",
+            title:
+              "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+            description:
+              "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+            reserved: "2012-04-09T00:00:00Z",
+            published: "2012-04-09T21:00:00Z",
+            modified: "2024-08-06T19:26:09.074Z",
+            withdrawn: null,
+            discovered: null,
+            released: null,
+            cwes: [],
+            average_severity: null,
+            average_score: null,
+            advisories: [
+              {
+                uuid: "urn:uuid:4dada0af-ab37-4da4-83e6-dfdaabc46257",
+                identifier: "CVE-2012-2215",
+                issuer: {
+                  id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                  name: "mitre",
+                  cpe_key: null,
+                  website: null,
+                },
+                published: "2012-04-09T21:00:00Z",
+                modified: "2024-08-06T19:26:09.074Z",
+                withdrawn: null,
+                title:
+                  "Directory traversal vulnerability in the Preboot Service in Novell ZENworks Configuration Management (ZCM) 11.1 and 11.1a allows remote attackers to read arbitrary files via an opcode 0x21 request.",
+                labels: {
+                  file: "2012/2xxx/CVE-2012-2215.json",
+                  type: "cve",
+                  source: "https://github.com/CVEProject/cvelistV5",
+                  importer: "cve",
+                },
+                severity: null,
+                score: null,
+              },
+            ],
+          },
+          {
+            normative: true,
+            identifier: "CVE-2012-2156",
+            title:
+              "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+            description:
+              "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+            reserved: "2012-04-04T00:00:00Z",
+            published: "2012-04-11T10:00:00Z",
+            modified: "2024-08-06T19:26:07.776Z",
+            withdrawn: null,
+            discovered: null,
+            released: null,
+            cwes: [],
+            average_severity: null,
+            average_score: null,
+            advisories: [
+              {
+                uuid: "urn:uuid:29ee07f7-4f84-40bc-ae80-5b791b08c05f",
+                identifier: "CVE-2012-2156",
+                issuer: {
+                  id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                  name: "mitre",
+                  cpe_key: null,
+                  website: null,
+                },
+                published: "2012-04-11T10:00:00Z",
+                modified: "2024-08-06T19:26:07.776Z",
+                withdrawn: null,
+                title:
+                  "Multiple cross-site scripting (XSS) vulnerabilities in Plume CMS 1.2.4 and earlier allow remote attackers to inject arbitrary web script or HTML via (1) the u_email parameter (aka Authors Email field) to manager/users.php, (2) the u_realname parameter (aka Authors Name field) to manager/users.php, or (3) the c_author parameter (aka Author field) in an ADD A COMMENT section.",
+                labels: {
+                  type: "cve",
+                  importer: "cve",
+                  source: "https://github.com/CVEProject/cvelistV5",
+                  file: "2012/2xxx/CVE-2012-2156.json",
+                },
+                severity: null,
+                score: null,
+              },
+            ],
+          },
+          {
+            normative: true,
+            identifier: "CVE-2012-2223",
+            title:
+              "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+            description:
+              "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+            reserved: "2012-04-11T00:00:00Z",
+            published: "2012-04-11T10:00:00Z",
+            modified: "2024-08-06T19:26:08.954Z",
+            withdrawn: null,
+            discovered: null,
+            released: null,
+            cwes: [],
+            average_severity: null,
+            average_score: null,
+            advisories: [
+              {
+                uuid: "urn:uuid:297d67e0-b508-40f4-8aaf-277ec423f9bb",
+                identifier: "CVE-2012-2223",
+                issuer: {
+                  id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                  name: "mitre",
+                  cpe_key: null,
+                  website: null,
+                },
+                published: "2012-04-11T10:00:00Z",
+                modified: "2024-08-06T19:26:08.954Z",
+                withdrawn: null,
+                title:
+                  "The xplat agent in Novell ZENworks Configuration Management (ZCM) 10.3.x before 10.3.4 and 11.x before 11.2 enables the HTTP TRACE method, which might make it easier for remote attackers to conduct cross-site tracing (XST) attacks via unspecified vectors.",
+                labels: {
+                  source: "https://github.com/CVEProject/cvelistV5",
+                  type: "cve",
+                  importer: "cve",
+                  file: "2012/2xxx/CVE-2012-2223.json",
+                },
+                severity: null,
+                score: null,
+              },
+            ],
+          },
+          {
+            normative: true,
+            identifier: "CVE-2012-2224",
+            title:
+              'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+            description:
+              'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+            reserved: "2012-04-11T00:00:00Z",
+            published: "2012-04-11T10:00:00Z",
+            modified: "2024-08-06T19:26:09.029Z",
+            withdrawn: null,
+            discovered: null,
+            released: null,
+            cwes: [],
+            average_severity: null,
+            average_score: null,
+            advisories: [
+              {
+                uuid: "urn:uuid:45078715-1f2f-4f19-87db-c4e5e5666198",
+                identifier: "CVE-2012-2224",
+                issuer: {
+                  id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                  name: "mitre",
+                  cpe_key: null,
+                  website: null,
+                },
+                published: "2012-04-11T10:00:00Z",
+                modified: "2024-08-06T19:26:09.029Z",
+                withdrawn: null,
+                title:
+                  'Xunlei Thunder before 7.2.6 allows remote attackers to execute arbitrary code via a crafted file, related to a "DLL injection vulnerability."',
+                labels: {
+                  importer: "cve",
+                  file: "2012/2xxx/CVE-2012-2224.json",
+                  source: "https://github.com/CVEProject/cvelistV5",
+                  type: "cve",
+                },
+                severity: null,
+                score: null,
+              },
+            ],
+          },
+          {
+            normative: true,
+            identifier: "CVE-2012-2210",
+            title:
+              "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+            description:
+              "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+            reserved: "2012-04-04T00:00:00Z",
+            published: "2012-04-11T10:00:00Z",
+            modified: "2024-08-06T19:26:09.004Z",
+            withdrawn: null,
+            discovered: null,
+            released: null,
+            cwes: [],
+            average_severity: null,
+            average_score: null,
+            advisories: [
+              {
+                uuid: "urn:uuid:962cb8ac-ae47-4e79-b00f-c1cf128f39b0",
+                identifier: "CVE-2012-2210",
+                issuer: {
+                  id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                  name: "mitre",
+                  cpe_key: null,
+                  website: null,
+                },
+                published: "2012-04-11T10:00:00Z",
+                modified: "2024-08-06T19:26:09.004Z",
+                withdrawn: null,
+                title:
+                  "The Sony Bravia TV KDL-32CX525 allows remote attackers to cause a denial of service (configuration outage or device crash) via a flood of TCP SYN packets, as demonstrated by hping, a related issue to CVE-1999-0116.",
+                labels: {
+                  type: "cve",
+                  file: "2012/2xxx/CVE-2012-2210.json",
+                  importer: "cve",
+                  source: "https://github.com/CVEProject/cvelistV5",
+                },
+                severity: null,
+                score: null,
+              },
+            ],
+          },
+          {
+            normative: true,
+            identifier: "CVE-2012-2225",
+            title:
+              "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+            description:
+              "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+            reserved: "2012-04-11T00:00:00Z",
+            published: "2012-04-11T10:00:00Z",
+            modified: "2024-08-06T19:26:08.912Z",
+            withdrawn: null,
+            discovered: null,
+            released: null,
+            cwes: [],
+            average_severity: null,
+            average_score: null,
+            advisories: [
+              {
+                uuid: "urn:uuid:129b04e4-83c6-4092-a592-0e470ee2adaf",
+                identifier: "CVE-2012-2225",
+                issuer: {
+                  id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                  name: "mitre",
+                  cpe_key: null,
+                  website: null,
+                },
+                published: "2012-04-11T10:00:00Z",
+                modified: "2024-08-06T19:26:08.912Z",
+                withdrawn: null,
+                title:
+                  "360zip 1.93beta allows remote attackers to execute arbitrary code via vectors related to file browsing and file extraction.",
+                labels: {
+                  importer: "cve",
+                  type: "cve",
+                  file: "2012/2xxx/CVE-2012-2225.json",
+                  source: "https://github.com/CVEProject/cvelistV5",
+                },
+                severity: null,
+                score: null,
+              },
+            ],
+          },
+          {
+            normative: true,
+            identifier: "CVE-2012-2230",
+            title:
+              "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+            description:
+              "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+            reserved: "2012-04-12T00:00:00Z",
+            published: "2012-04-12T10:00:00Z",
+            modified: "2024-08-06T19:26:08.997Z",
+            withdrawn: null,
+            discovered: null,
+            released: null,
+            cwes: [],
+            average_severity: null,
+            average_score: null,
+            advisories: [
+              {
+                uuid: "urn:uuid:dc310f12-70ac-4ada-a936-2d4cda202a0d",
+                identifier: "CVE-2012-2230",
+                issuer: {
+                  id: "3bc1fd81-9c49-4df6-9edb-2fc18d49f283",
+                  name: "mitre",
+                  cpe_key: null,
+                  website: null,
+                },
+                published: "2012-04-12T10:00:00Z",
+                modified: "2024-08-06T19:26:08.997Z",
+                withdrawn: null,
+                title:
+                  "Cloudera Manager 3.7.x before 3.7.5 and Service and Configuration Manager 3.5, when Kerberos is not enabled, does not properly install taskcontroller.cfg, which allows remote authenticated users to impersonate arbitrary user accounts via unspecified vectors, a different vulnerability than CVE-2012-1574.",
+                labels: {
+                  type: "cve",
+                  importer: "cve",
+                  file: "2012/2xxx/CVE-2012-2230.json",
+                  source: "https://github.com/CVEProject/cvelistV5",
+                },
+                severity: null,
+                score: null,
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+};
 
 const meta = {
   title: "Components/vulnerability-list/vulnerability-toolbar.tsx",
   component: VulnerabilityToolbar,
   tags: ["autodocs"],
   decorators: [
-    (Story) => (
-      <BrowserRouter>
-        <Story />
-      </BrowserRouter>
-    ),
+    (Story, { parameters }) => {
+      const { contextDefaultValue } = parameters;
+      return (
+        <BrowserRouter>
+          <VulnerabilitySearchContext.Provider value={contextDefaultValue}>
+            <Story />
+          </VulnerabilitySearchContext.Provider>
+        </BrowserRouter>
+      );
+    },
   ],
 } satisfies Meta<typeof VulnerabilityToolbar>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const EmptyState: Story = {
+export const PrimaryState: Story = {
   args: {},
+  parameters: {
+    contextDefaultValue: customContextData,
+  },
 };

--- a/client/src/mocks/browser.ts
+++ b/client/src/mocks/browser.ts
@@ -1,4 +1,5 @@
-import { type RestHandler, setupWorker, rest } from "msw";
+import { setupWorker } from "msw/browser";
+import { http, passthrough, RequestHandler } from "msw";
 
 import config from "./config";
 import stubNewWork from "./stub-new-work";
@@ -8,14 +9,14 @@ import stubNewWork from "./stub-new-work";
  * server to handle.  This is useful to see traffic, in the console logs, that is not
  * being mocked elsewhere.
  */
-const passthroughHandler: RestHandler = rest.all("/api/*", (req) => {
+const passthroughHandler: RequestHandler = http.all("/api/*", (req) => {
   console.log(
     "%cmsw passthrough%c \u{1fa83} %s",
     "font-weight: bold",
     "font-weight: normal",
-    req.url
+    req.request.url
   );
-  return req.passthrough();
+  return passthrough();
 });
 
 const handlers = [

--- a/client/src/mocks/stub-new-work/index.ts
+++ b/client/src/mocks/stub-new-work/index.ts
@@ -1,4 +1,4 @@
-import { type RestHandler } from "msw";
+import { type RequestHandler } from "msw";
 import { config } from "../config";
 
 const enableMe = (me: string) =>
@@ -8,6 +8,6 @@ const enableMe = (me: string) =>
 /**
  * Return the stub-new-work handlers that are enabled by config.
  */
-const enabledStubs: RestHandler[] = [].filter(Boolean);
+const enabledStubs: RequestHandler[] = [].filter(Boolean);
 
 export default enabledStubs;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@storybook/addon-essentials": "^8.3.6",
         "@storybook/addon-interactions": "^8.3.6",
         "@storybook/addon-links": "^8.3.6",
-        "@storybook/addon-onboarding": "^8.3.6",
         "@storybook/addon-queryparams": "^7.0.1",
         "@storybook/addon-webpack5-compiler-swc": "^1.0.5",
         "@storybook/blocks": "^8.3.6",
@@ -50,6 +49,8 @@
         "jest-resolve": "^29.7.0",
         "jest-watch-typeahead": "^2.2.2",
         "lint-staged": "^14.0.1",
+        "msw": "^2.6.4",
+        "msw-storybook-addon": "^2.0.4",
         "prettier": "^3.0.2",
         "rimraf": "^5.0.7",
         "rollup": "^3.29.4",
@@ -128,7 +129,6 @@
         "html-webpack-plugin": "^5.5.0",
         "mini-css-extract-plugin": "^2.5.2",
         "monaco-editor-webpack-plugin": "^7.0.1",
-        "msw": "^1.2.3",
         "raw-loader": "^4.0.2",
         "react-refresh": "^0.14.0",
         "react-refresh-typescript": "^2.0.9",
@@ -750,6 +750,43 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+      "dev": true,
+      "dependencies": {
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/@bundled-es-modules/cookie/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
+    "node_modules/@bundled-es-modules/tough-cookie": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
+      "integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
+      "dev": true,
+      "dependencies": {
+        "@types/tough-cookie": "^4.0.5",
+        "tough-cookie": "^4.1.4"
+      }
     },
     "node_modules/@chromatic-com/storybook": {
       "version": "1.9.0",
@@ -1405,6 +1442,136 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.2.tgz",
+      "integrity": "sha512-KJLUHOaKnNCYzwVbryj3TNBxyZIrr56fR5N45v6K9IPrbT6B7DcudBMfylkV1A8PUdJE15mybkEQyp2/ZUpxUA==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^10.1.0",
+        "@inquirer/type": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.0.tgz",
+      "integrity": "sha512-I+ETk2AL+yAVbvuKx5AJpQmoaWhpiTFOg/UJb7ZkMAK4blmtG8ATh5ct+T/8xNld0CZG/2UhtkdMwpgvld92XQ==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/@inquirer/core/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
+      "integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
+      "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -2115,50 +2282,6 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@mswjs/cookies": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
-      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@mswjs/interceptors": {
-      "version": "0.17.10",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
-      "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.8.3",
-        "debug": "^4.3.3",
-        "headers-polyfill": "3.2.5",
-        "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.4",
-        "web-encoding": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@mswjs/interceptors/node_modules/strict-event-emitter": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
-      "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "events": "^3.3.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2197,12 +2320,21 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@open-draft/until": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
-      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
     },
     "node_modules/@patternfly/patternfly": {
       "version": "5.4.2",
@@ -2931,23 +3063,6 @@
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "tiny-invariant": "^1.3.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.4.2"
-      }
-    },
-    "node_modules/@storybook/addon-onboarding": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-onboarding/-/addon-onboarding-8.4.2.tgz",
-      "integrity": "sha512-zWzOyRASnIPt2AcaEl1KhI+aOaKDuoIcNB7u1GoABj0YM+V9d6o3lvcsmOAQG5pgwgFyqyOnLwpTfvRSEyzGFA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-confetti": "^6.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4090,13 +4205,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -4406,13 +4514,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/js-levenshtein": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/js-levenshtein/-/js-levenshtein-1.1.3.tgz",
-      "integrity": "sha512-jd+Q+sD20Qfu9e2aEXogiO3vpOC1PYJOUdyN9gvs4Qrvkg4wF43L5OhqrPeokdv8TL0/mXoYfpkcoGZMNN2pkQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
@@ -4594,16 +4695,6 @@
         "@types/send": "*"
       }
     },
-    "node_modules/@types/set-cookie-parser": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
-      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/sockjs": {
       "version": "0.3.36",
       "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
@@ -4620,6 +4711,12 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.5.tgz",
+      "integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
+      "dev": true
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -5177,16 +5274,6 @@
         }
       }
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -5200,14 +5287,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@zxing/text-encoding": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-      "dev": true,
-      "license": "(Unlicense OR Apache-2.0)",
-      "optional": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -5865,27 +5944,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5945,43 +6003,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/bl/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/body-parser": {
@@ -6142,31 +6163,6 @@
       },
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -6361,13 +6357,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/check-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -6510,19 +6499,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-truncate": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
@@ -6538,16 +6514,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-width": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/cliui": {
@@ -6626,16 +6592,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/clone-deep": {
@@ -6915,16 +6871,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/cookie-parser": {
       "version": "1.4.7",
@@ -7974,19 +7920,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-data-property": {
@@ -9520,21 +9453,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9660,32 +9578,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -10684,13 +10576,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/headers-polyfill": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
-      "integrity": "sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -11062,27 +10947,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -11173,127 +11037,6 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==",
       "license": "MIT"
-    },
-    "node_modules/inquirer": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
-      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.1",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "0.0.8",
-        "ora": "^5.4.1",
-        "run-async": "^2.4.0",
-        "rxjs": "^7.5.5",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6",
-        "wrap-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/inquirer/node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/inquirer/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer/node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/inquirer/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/inquirer/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -11612,16 +11355,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -11841,19 +11574,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-weakmap": {
@@ -13322,16 +13042,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/js-levenshtein": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13937,23 +13647,6 @@
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/log-update": {
       "version": "5.0.1",
@@ -15002,45 +14695,42 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.5.tgz",
-      "integrity": "sha512-nG3fpmBXxFbKSIdk6miPuL3KjU6WMxgoW4tG1YgnP1M+TRG3Qn7b7R0euKAHq4vpwARHb18ZyfZljSxsTnMX2w==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.6.4.tgz",
+      "integrity": "sha512-Pm4LmWQeytDsNCR+A7gt39XAdtH6zQb6jnIKRig0FlvYOn8eksn3s1nXxUfz5KYUjbckof7Z4p2ewzgffPoCbg==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.10",
-        "@open-draft/until": "^1.0.3",
-        "@types/cookie": "^0.4.1",
-        "@types/js-levenshtein": "^1.1.1",
-        "chalk": "^4.1.1",
-        "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
+        "@bundled-es-modules/cookie": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@bundled-es-modules/tough-cookie": "^0.1.6",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.36.5",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "chalk": "^4.1.2",
         "graphql": "^16.8.1",
-        "headers-polyfill": "3.2.5",
-        "inquirer": "^8.2.0",
+        "headers-polyfill": "^4.0.2",
         "is-node-process": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
-        "outvariant": "^1.4.0",
+        "outvariant": "^1.4.3",
         "path-to-regexp": "^6.3.0",
-        "strict-event-emitter": "^0.4.3",
-        "type-fest": "^2.19.0",
-        "yargs": "^17.3.1"
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.26.1",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "msw": "cli/index.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mswjs"
+        "url": "https://github.com/sponsors/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.4.x"
+        "typescript": ">= 4.8.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -15048,78 +14738,66 @@
         }
       }
     },
-    "node_modules/msw/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+    "node_modules/msw-storybook-addon": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-2.0.4.tgz",
+      "integrity": "sha512-rstO8+r01sRMg6PPP7OxM8LG5/6r4+wmp2uapHeHvm9TQQRHvpPXOU/Y9/Somysz8Oi4Ea1aummXH3JlnP2LIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "is-node-process": "^1.0.1"
       },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
+      "peerDependencies": {
+        "msw": "^2.0.0"
       }
     },
-    "node_modules/msw/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+    "node_modules/msw/node_modules/@mswjs/interceptors": {
+      "version": "0.36.10",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.36.10.tgz",
+      "integrity": "sha512-GXrJgakgJW3DWKueebkvtYgGKkxA7s0u5B0P5syJM5rvQUnrpLPigvci8Hukl7yEM+sU06l+er2Fgvx/gmiRgg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
-        "is-glob": "^4.0.1"
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=18"
       }
     },
-    "node_modules/msw/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
+    "node_modules/msw/node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
-    "node_modules/msw/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
+    "node_modules/msw/node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "node_modules/msw/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=12.20"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15138,13 +14816,6 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
-    },
-    "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/nanoclone": {
       "version": "0.2.1",
@@ -15739,93 +15410,11 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/ora/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
@@ -17902,16 +17491,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -18315,13 +17894,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -18893,13 +18465,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/strict-event-emitter": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
-      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
@@ -19634,13 +19199,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -19724,19 +19282,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/tmpl": {
@@ -21000,29 +20545,6 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/web-encoding": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "util": "^0.12.3"
-      },
-      "optionalDependencies": {
-        "@zxing/text-encoding": "0.9.0"
-      }
-    },
     "node_modules/web-vitals": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
@@ -22096,6 +21618,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@storybook/addon-essentials": "^8.3.6",
     "@storybook/addon-interactions": "^8.3.6",
     "@storybook/addon-links": "^8.3.6",
-    "@storybook/addon-onboarding": "^8.3.6",
     "@storybook/addon-queryparams": "^7.0.1",
     "@storybook/addon-webpack5-compiler-swc": "^1.0.5",
     "@storybook/blocks": "^8.3.6",
@@ -76,6 +75,8 @@
     "jest-resolve": "^29.7.0",
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^14.0.1",
+    "msw": "^2.6.4",
+    "msw-storybook-addon": "^2.0.4",
     "prettier": "^3.0.2",
     "rimraf": "^5.0.7",
     "rollup": "^3.29.4",
@@ -86,5 +87,10 @@
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "type-fest": "^3.13.0",
     "typescript": "^5.5.3"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,295 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const PACKAGE_VERSION = "2.6.4";
+const INTEGRITY_CHECKSUM = "ca7800994cc8bfb5eb961e037c877074";
+const IS_MOCKED_RESPONSE = Symbol("isMockedResponse");
+const activeClientIds = new Set();
+
+self.addEventListener("install", function () {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("message", async function (event) {
+  const clientId = event.source.id;
+
+  if (!clientId || !self.clients) {
+    return;
+  }
+
+  const client = await self.clients.get(clientId);
+
+  if (!client) {
+    return;
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: "window",
+  });
+
+  switch (event.data) {
+    case "KEEPALIVE_REQUEST": {
+      sendToClient(client, {
+        type: "KEEPALIVE_RESPONSE",
+      });
+      break;
+    }
+
+    case "INTEGRITY_CHECK_REQUEST": {
+      sendToClient(client, {
+        type: "INTEGRITY_CHECK_RESPONSE",
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      });
+      break;
+    }
+
+    case "MOCK_ACTIVATE": {
+      activeClientIds.add(clientId);
+
+      sendToClient(client, {
+        type: "MOCKING_ENABLED",
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      });
+      break;
+    }
+
+    case "MOCK_DEACTIVATE": {
+      activeClientIds.delete(clientId);
+      break;
+    }
+
+    case "CLIENT_CLOSED": {
+      activeClientIds.delete(clientId);
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId;
+      });
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister();
+      }
+
+      break;
+    }
+  }
+});
+
+self.addEventListener("fetch", function (event) {
+  const { request } = event;
+
+  // Bypass navigation requests.
+  if (request.mode === "navigate") {
+    return;
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === "only-if-cached" && request.mode !== "same-origin") {
+    return;
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return;
+  }
+
+  // Generate unique request ID.
+  const requestId = crypto.randomUUID();
+  event.respondWith(handleRequest(event, requestId));
+});
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event);
+  const response = await getResponse(event, client, requestId);
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    (async function () {
+      const responseClone = response.clone();
+
+      sendToClient(
+        client,
+        {
+          type: "RESPONSE",
+          payload: {
+            requestId,
+            isMockedResponse: IS_MOCKED_RESPONSE in response,
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            body: responseClone.body,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+          },
+        },
+        [responseClone.body]
+      );
+    })();
+  }
+
+  return response;
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId);
+
+  if (activeClientIds.has(event.clientId)) {
+    return client;
+  }
+
+  if (client?.frameType === "top-level") {
+    return client;
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: "window",
+  });
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === "visible";
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id);
+    });
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event;
+
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = request.clone();
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers);
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    headers.delete("accept", "msw/passthrough");
+
+    return fetch(requestClone, { headers });
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough();
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough();
+  }
+
+  // Notify the client that a request has been intercepted.
+  const requestBuffer = await request.arrayBuffer();
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: "REQUEST",
+      payload: {
+        id: requestId,
+        url: request.url,
+        mode: request.mode,
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        cache: request.cache,
+        credentials: request.credentials,
+        destination: request.destination,
+        integrity: request.integrity,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        body: requestBuffer,
+        keepalive: request.keepalive,
+      },
+    },
+    [requestBuffer]
+  );
+
+  switch (clientMessage.type) {
+    case "MOCK_RESPONSE": {
+      return respondWithMock(clientMessage.data);
+    }
+
+    case "PASSTHROUGH": {
+      return passthrough();
+    }
+  }
+
+  return passthrough();
+}
+
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel();
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error);
+      }
+
+      resolve(event.data);
+    };
+
+    client.postMessage(
+      message,
+      [channel.port2].concat(transferrables.filter(Boolean))
+    );
+  });
+}
+
+async function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error();
+  }
+
+  const mockedResponse = new Response(response.body, response);
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  });
+
+  return mockedResponse;
+}


### PR DESCRIPTION
This PR paves the way for other connected components or pages that require network requests from within Storybook. The long-term goal here is to have a platform we can iterate on and ideate with, without modifying the main UI.

- Add support for msw in Storybook, migrate existing msw 1.x to 2.x
- Mock requests for vulnerability list page in Storybook
- Fix broken stories by wrapping in the appropriate provider and/or providing data as expected
- Remove `storybook/onboarding` add-on, as it's no longer necessary

Relates to #193 