### PR TITLE
feat(cve): add filter by published date

### DIFF
--- a/client/src/app/pages/search/search.tsx
+++ b/client/src/app/pages/search/search.tsx
@@ -248,7 +248,7 @@ export const Search: React.FC = () => {
                 eventKey={2}
                 title={
                   <TabTitleText>
-                    Vulnerabilities{"  "}
+                    CVEs{"  "}
                     <Badge screenReaderText="Search Result Count">
                       {vulnerabilityTotalCount}
                     </Badge>

--- a/client/src/app/pages/vulnerability-list/vulnerability-context.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-context.tsx
@@ -19,7 +19,7 @@ export interface IVulnerabilitySearchContext {
     VulnerabilitySummary,
     "identifier" | "title" | "severity" | "published" | "sboms",
     "published" | "severity",
-    "" | "average_severity",
+    "" | "average_severity" | "published",
     string
   >;
 
@@ -73,6 +73,11 @@ export const VulnerabilitySearchProvider: React.FunctionComponent<
           { value: "high", label: "High" },
           { value: "critical", label: "Critical" },
         ],
+      },
+      {
+        categoryKey: "published",
+        title: "Created on",
+        type: FilterType.dateRange,
       },
     ],
     isExpansionEnabled: true,


### PR DESCRIPTION
Implements #234 

- Add filter by CVE `published` property
- Update tab in Search page to use `CVEs` instead of `Vulnerabilities`

![Screenshot 2024-11-14 at 10 10 09 AM](https://github.com/user-attachments/assets/c2b8056f-a9aa-410d-891d-e7435782a3d3)

![Screenshot 2024-11-14 at 10 13 03 AM](https://github.com/user-attachments/assets/efeb7746-376a-433e-8d50-bfad0a924afb)
