### PR TITLE
fix: header nav bar - use `sub` if `preferred_username` does not exists

### DIFF
--- a/client/src/app/layout/header.tsx
+++ b/client/src/app/layout/header.tsx
@@ -204,7 +204,8 @@ export const HeaderApp: React.FC = () => {
                           isExpanded={isUserDropdownOpen}
                           icon={<Avatar src={imgAvatar} alt="" />}
                         >
-                          {auth.user?.profile.preferred_username}
+                          {auth.user?.profile.preferred_username ||
+                            auth.user?.profile.sub}
                         </MenuToggle>
                       )}
                     >


### PR DESCRIPTION
Fixes: https://github.com/trustification/trustify-ui/issues/145