### PR TITLE
fix: add package section to SBOM Details-Info Tab

### DIFF
--- a/client/src/app/pages/sbom-details/overview.tsx
+++ b/client/src/app/pages/sbom-details/overview.tsx
@@ -43,6 +43,12 @@ export const Overview: React.FC<InfoProps> = ({ sbom }) => {
                   {sbom.document_id}
                 </DescriptionListDescription>
               </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Data License</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {sbom.data_licenses.join(", ")}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
             </DescriptionList>
           </CardBody>
         </Card>
@@ -56,12 +62,6 @@ export const Overview: React.FC<InfoProps> = ({ sbom }) => {
                 <DescriptionListTerm>Created</DescriptionListTerm>
                 <DescriptionListDescription>
                   {formatDate(sbom.published)}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>License List Version</DescriptionListTerm>
-                <DescriptionListDescription>
-                  {sbom.data_licenses.join(", ")}
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>
@@ -89,6 +89,44 @@ export const Overview: React.FC<InfoProps> = ({ sbom }) => {
                 <DescriptionListTerm>Packages</DescriptionListTerm>
                 <DescriptionListDescription>
                   {sbom.number_of_packages}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          </CardBody>
+        </Card>
+      </GridItem>
+      <GridItem md={12}>
+        <Card isFullHeight>
+          <CardTitle>Package</CardTitle>
+          <CardBody>
+            <DescriptionList>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Name</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {sbom.name}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Version</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {sbom.described_by.map((e) => e.version).join(", ")}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>External References</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <List>
+                    {sbom.described_by
+                      .flatMap((e) => e.cpe)
+                      .map((e) => (
+                        <ListItem>{e}</ListItem>
+                      ))}
+                    <ListItem>
+                      {sbom.described_by
+                        .flatMap((e) => e.purl)
+                        .map((e) => e.purl)}
+                    </ListItem>
+                  </List>
                 </DescriptionListDescription>
               </DescriptionListGroup>
             </DescriptionList>


### PR DESCRIPTION
Fixes: https://github.com/trustification/trustify-ui/issues/89

This PR adds the "Package" section to the SBOM Details Page / Info Tab. See image below.

![Screenshot From 2024-11-19 13-02-51](https://github.com/user-attachments/assets/2454b85f-8a6b-439d-ae36-380d964a97f0)
 