### PR TITLE
fix: search page - set fixed width to the filters bar

### DIFF
--- a/client/src/app/pages/search/search.tsx
+++ b/client/src/app/pages/search/search.tsx
@@ -19,7 +19,7 @@ import {
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
-  ToolbarItem
+  ToolbarItem,
 } from "@patternfly/react-core";
 import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
 


### PR DESCRIPTION
When the size of the screen becomes half of the screen then the Date filters start to overflow the other parts of the page:

Before:
![Screenshot From 2024-11-19 15-40-14](https://github.com/user-attachments/assets/ec5f7024-5d4f-49aa-b88e-999a7bf95f70)

After:
![Screenshot From 2024-11-19 15-39-53](https://github.com/user-attachments/assets/594c00f2-8748-47e5-b087-11738d6e095e)

