### PR TITLE
fix: upload progress does not have blue color. Force it

### DIFF
--- a/client/src/app/App.css
+++ b/client/src/app/App.css
@@ -12,3 +12,16 @@
 table.vertical-middle-aligned-table tr td {
   vertical-align: middle;
 }
+
+.multiple-file-upload-status-item-force-blue .pf-v5-c-progress.pf-m-success {
+  --pf-v5-c-progress__bar--before--BackgroundColor: var(
+    --pf-v5-global--primary-color--100
+  ) !important;
+  --pf-v5-c-progress__status-icon--Color: var(--pf-v5-global--Color--100);
+}
+
+.multiple-file-upload-status-item-force-blue .pf-v5-c-progress__indicator {
+  background-color: var(
+    --pf-v5-c-progress__indicator--BackgroundColor
+  ) !important;
+}

--- a/client/src/app/pages/upload/components/upload-file.tsx
+++ b/client/src/app/pages/upload/components/upload-file.tsx
@@ -14,6 +14,8 @@ import {
   MultipleFileUploadMain,
   MultipleFileUploadStatus,
   MultipleFileUploadStatusItem,
+  Spinner,
+  Text,
 } from "@patternfly/react-core";
 
 import FileIcon from "@patternfly/react-icons/dist/esm/icons/file-code-icon";
@@ -111,6 +113,11 @@ export const UploadFiles: React.FC<IUploadFilesProps> = ({
           >
             {Array.from(uploads.entries()).map(([file, upload], index) => (
               <MultipleFileUploadStatusItem
+                className={
+                  upload.progress < 100 || !upload.response
+                    ? "multiple-file-upload-status-item-force-blue"
+                    : undefined
+                }
                 fileIcon={<FileIcon />}
                 file={file}
                 key={`${file.name}-${index}`}
@@ -128,6 +135,13 @@ export const UploadFiles: React.FC<IUploadFilesProps> = ({
                     <HelperText isLiveRegion>
                       <HelperTextItem variant="error">
                         {extractErrorMessage(upload.error)}
+                      </HelperTextItem>
+                    </HelperText>
+                  ) : upload.progress === 100 && !upload.response ? (
+                    <HelperText isLiveRegion>
+                      <HelperTextItem variant="warning">
+                        <Spinner isInline />
+                        File uploaded. Waiting for the server to process it.
                       </HelperTextItem>
                     </HelperText>
                   ) : upload.response ? (


### PR DESCRIPTION
fixes: https://github.com/trustification/trustify-ui/issues/265

Currently Patternfly React does not allow to use the BLUE color for the "In progress" bars. I reported this bug in their repository https://github.com/patternfly/patternfly-react/issues/11276 but that will take time to be fixed.

@jcrossley3 the main reason of the issue was that although a file cam be 100% sent to the server, the server can still take time to process the file although the file has been fully sent already. This PR should make the Progress Bar always BLUE unless the server gives a response. It also adds a helper text to explain that.


https://github.com/user-attachments/assets/d5a02a23-ee0c-41d1-98a3-c0205473bb9b

