### PR TITLE
fix: reduce calls to backend on vulnerabilities page

### DIFF
--- a/client/src/app/components/VulnerabilityStatusLabel.tsx
+++ b/client/src/app/components/VulnerabilityStatusLabel.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import { Label } from "@patternfly/react-core";
+
+import { VulnerabilityStatus } from "@app/api/models";
+
+interface VulnerabilityStatusLabelProps {
+  value: VulnerabilityStatus;
+}
+
+export const VulnerabilityStatusLabel: React.FC<
+  VulnerabilityStatusLabelProps
+> = ({ value }) => {
+  return (
+    <Label>
+      {value.charAt(0).toUpperCase() + value.slice(1).replace("_", " ")}
+    </Label>
+  );
+};

--- a/client/src/app/hooks/domain-controls/useSbomsOfVulnerability.ts
+++ b/client/src/app/hooks/domain-controls/useSbomsOfVulnerability.ts
@@ -1,29 +1,111 @@
 import React from "react";
 
 import { VulnerabilityStatus } from "@app/api/models";
-import { client } from "@app/axios-config/apiInit";
-import {
-  getSbom,
-  SbomSummary,
-  VulnerabilityAdvisorySummary,
-} from "@app/client";
+import { SbomHead, VulnerabilityAdvisorySummary } from "@app/client";
 import { useFetchVulnerabilityById } from "@app/queries/vulnerabilities";
 
-interface SbomOfVulnerability {
-  sbomId: string;
+const areSbomOfVulnerabilityEqual = (
+  a: SbomOfVulnerability,
+  b: SbomOfVulnerability | FlatSbomOfVulnerability
+) => {
+  return a.sbom.id === b.sbom.id && a.sbomStatus === b.sbomStatus;
+};
+
+interface FlatSbomOfVulnerability {
+  sbom: SbomHead & { version: string | null };
+  sbomStatus: VulnerabilityStatus;
   advisory: VulnerabilityAdvisorySummary;
-  status: VulnerabilityStatus;
-  sbom?: SbomSummary;
+}
+
+interface SbomOfVulnerability {
+  sbom: SbomHead & { version: string | null };
+  sbomStatus: VulnerabilityStatus;
+  relatedPackages: {
+    advisory: VulnerabilityAdvisorySummary;
+  }[];
 }
 
 export interface SbomOfVulnerabilitySummary {
   total: number;
-  status: { [key in VulnerabilityStatus]: number };
+  sbomStatus: { [key in VulnerabilityStatus]: number };
 }
 
 const DEFAULT_SUMMARY: SbomOfVulnerabilitySummary = {
   total: 0,
-  status: { affected: 0, fixed: 0, known_not_affected: 0, not_affected: 0 },
+  sbomStatus: { affected: 0, fixed: 0, known_not_affected: 0, not_affected: 0 },
+};
+
+const advisoryToModels = (advisories: VulnerabilityAdvisorySummary[]) => {
+  const sboms = advisories.flatMap((advisory) => {
+    return (
+      (advisory.sboms ?? [])
+        .flatMap((sbomStatuses) => {
+          return sbomStatuses.status.map((sbomStatus) => {
+            const result: FlatSbomOfVulnerability = {
+              sbom: {
+                ...sbomStatuses,
+                version: sbomStatuses.version || null,
+              },
+              sbomStatus: sbomStatus as VulnerabilityStatus,
+              advisory: advisory,
+            };
+            return result;
+          });
+        })
+        // group
+        .reduce((prev, current) => {
+          const existingElement = prev.find((item) => {
+            return areSbomOfVulnerabilityEqual(item, current);
+          });
+
+          if (existingElement) {
+            const arrayWithoutExistingItem = prev.filter(
+              (item) => !areSbomOfVulnerabilityEqual(item, existingElement)
+            );
+
+            const updatedItemInArray: SbomOfVulnerability = {
+              ...existingElement,
+              relatedPackages: [
+                ...existingElement.relatedPackages,
+                {
+                  advisory: current.advisory,
+                },
+              ],
+            };
+
+            return [...arrayWithoutExistingItem, updatedItemInArray];
+          } else {
+            const newItemInArray: SbomOfVulnerability = {
+              sbom: current.sbom,
+              sbomStatus: current.sbomStatus,
+              relatedPackages: [
+                {
+                  advisory: current.advisory,
+                },
+              ],
+            };
+            return [...prev, newItemInArray];
+          }
+        }, [] as SbomOfVulnerability[])
+    );
+  });
+
+  const summary = sboms.reduce((prev, current) => {
+    const sbomStatus = current.sbomStatus;
+    return {
+      ...prev,
+      total: prev.total + 1,
+      sbomStatus: {
+        ...prev.sbomStatus,
+        [sbomStatus]: prev.sbomStatus[sbomStatus] + 1,
+      },
+    };
+  }, DEFAULT_SUMMARY);
+
+  return {
+    sboms,
+    summary,
+  };
 };
 
 export const useSbomsOfVulnerability = (sbomId: string) => {
@@ -33,109 +115,13 @@ export const useSbomsOfVulnerability = (sbomId: string) => {
     fetchError: fetchErrorAdvisories,
   } = useFetchVulnerabilityById(sbomId);
 
-  const [allSboms, setAllSboms] = React.useState<SbomOfVulnerability[]>([]);
-  const [sbomsById, setSbomsById] = React.useState<Map<string, SbomSummary>>(
-    new Map()
-  );
-  const [isFetchingSboms, setIsFetchingSboms] = React.useState(false);
-
-  React.useEffect(() => {
-    if (vulnerability?.advisories?.length === 0) {
-      return;
-    }
-
-    const sboms = (vulnerability?.advisories ?? [])
-      .flatMap((advisory) => {
-        return (advisory.sboms ?? []).flatMap((sbom) => {
-          return sbom.status.map((status) => {
-            const result: SbomOfVulnerability = {
-              sbomId: sbom.id,
-              status: status as VulnerabilityStatus,
-              advisory: { ...advisory },
-            };
-            return result;
-          });
-        });
-      })
-      // Remove duplicates if exists
-      .reduce((prev, current) => {
-        const exists = prev.find(
-          (item) =>
-            item.sbomId === current.sbomId &&
-            item.advisory.uuid === current.advisory.uuid
-        );
-        if (!exists) {
-          return [...prev, current];
-        } else {
-          return prev;
-        }
-      }, [] as SbomOfVulnerability[]);
-
-    setAllSboms(sboms);
-    setIsFetchingSboms(true);
-
-    Promise.all(
-      sboms
-        .map(async (item) => {
-          const response = await getSbom({
-            client,
-            path: { id: item.sbomId },
-          });
-          return response.data;
-        })
-        .map((sbom) => sbom.catch(() => null))
-    ).then((sboms) => {
-      const validSboms = sboms.reduce((prev, current) => {
-        if (current) {
-          return [...prev, current];
-        } else {
-          // Filter out error responses
-          return prev;
-        }
-      }, [] as SbomSummary[]);
-
-      const sbomsById = new Map<string, SbomSummary>();
-      validSboms.forEach((sbom) => sbomsById.set(sbom.id, sbom));
-
-      setSbomsById(sbomsById);
-      setIsFetchingSboms(false);
-    });
+  const result = React.useMemo(() => {
+    return advisoryToModels(vulnerability?.advisories || []);
   }, [vulnerability]);
 
-  const allSbomsWithMappedData = React.useMemo(() => {
-    return allSboms.map((item) => {
-      const result: SbomOfVulnerability = {
-        ...item,
-        sbom: sbomsById.get(item.sbomId),
-      };
-      return result;
-    });
-  }, [allSboms, sbomsById]);
-
-  // Summary
-
-  const sbomsSummary = React.useMemo(() => {
-    return allSbomsWithMappedData.reduce((prev, current) => {
-      if (current.status) {
-        const status = current.status;
-        return {
-          ...prev,
-          total: prev.total + 1,
-          status: {
-            ...prev.status,
-            [status]: prev.status[status] + 1,
-          },
-        };
-      } else {
-        return prev;
-      }
-    }, DEFAULT_SUMMARY);
-  }, [allSbomsWithMappedData]);
-
   return {
-    isFetching: isFetchingAdvisories || isFetchingSboms,
+    data: result,
+    isFetching: isFetchingAdvisories,
     fetchError: fetchErrorAdvisories,
-    sboms: allSbomsWithMappedData,
-    summary: sbomsSummary,
   };
 };

--- a/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
+++ b/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
@@ -7,7 +7,7 @@ import {
   useFetchSbomsAdvisoryBatch,
 } from "@app/queries/sboms";
 
-const areEqualVulnerabilityOfSbomEqual = (
+const areVulnerabilityOfSbomEqual = (
   a: VulnerabilityOfSbom,
   b: VulnerabilityOfSbom | FlatVulnerabilityOfSbom
 ) => {
@@ -58,7 +58,7 @@ const DEFAULT_SUMMARY: VulnerabilityOfSbomSummary = {
   },
 };
 
-const advisoryStatusToModels = (advisories: SbomAdvisory[]) => {
+const advisoryToModels = (advisories: SbomAdvisory[]) => {
   const vulnerabilities = advisories.flatMap((advisory) => {
     return (
       (advisory.status ?? [])
@@ -74,12 +74,12 @@ const advisoryStatusToModels = (advisories: SbomAdvisory[]) => {
         // group
         .reduce((prev, current) => {
           const existingElement = prev.find((item) => {
-            return areEqualVulnerabilityOfSbomEqual(item, current);
+            return areVulnerabilityOfSbomEqual(item, current);
           });
 
           if (existingElement) {
             const arrayWithoutExistingItem = prev.filter(
-              (item) => !areEqualVulnerabilityOfSbomEqual(item, existingElement)
+              (item) => !areVulnerabilityOfSbomEqual(item, existingElement)
             );
 
             const updatedItemInArray: VulnerabilityOfSbom = {
@@ -147,7 +147,7 @@ export const useVulnerabilitiesOfSbom = (sbomId: string) => {
   } = useFetchSbomsAdvisory(sbomId);
 
   const result = React.useMemo(() => {
-    return advisoryStatusToModels(advisories || []);
+    return advisoryToModels(advisories || []);
   }, [advisories]);
 
   return {
@@ -163,7 +163,7 @@ export const useVulnerabilitiesOfSboms = (sbomIds: string[]) => {
 
   const result = React.useMemo(() => {
     return (advisories ?? []).map((item) => {
-      return advisoryStatusToModels(item || []);
+      return advisoryToModels(item || []);
     });
   }, [advisories]);
 

--- a/client/src/app/pages/vulnerability-details/packages-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/packages-by-vulnerability.tsx
@@ -22,6 +22,7 @@ import {
 } from "@patternfly/react-table";
 
 import { DecomposedPurl, VulnerabilityStatus } from "@app/api/models";
+import { Purl, StatusContext, VulnerabilityAdvisorySummary } from "@app/client";
 import { AdvisoryInDrawerInfo } from "@app/components/AdvisoryInDrawerInfo";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 import { PackageInDrawerInfo } from "@app/components/PackageInDrawerInfo";
@@ -32,10 +33,10 @@ import {
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
+import { VulnerabilityStatusLabel } from "@app/components/VulnerabilityStatusLabel";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useWithUiId } from "@app/utils/query-utils";
 import { decomposePurl } from "@app/utils/utils";
-import { Purl, StatusContext, VulnerabilityAdvisorySummary } from "@app/client";
 
 interface TableData {
   basePurl: {
@@ -276,10 +277,7 @@ export const PackagesByVulnerability: React.FC<
                       modifier="truncate"
                       {...getTdProps({ columnKey: "status" })}
                     >
-                      <Label>
-                        {item.status.charAt(0).toUpperCase() +
-                          item.status.slice(1).replace("_", " ")}
-                      </Label>
+                      <VulnerabilityStatusLabel value={item.status} />
                     </Td>
                   </TableRowContentWithControls>
                 </Tr>

--- a/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
@@ -4,28 +4,14 @@ import { Link } from "react-router-dom";
 import dayjs from "dayjs";
 
 import {
-  Label,
   Toolbar,
   ToolbarContent,
-  ToolbarItem,
+  ToolbarItem
 } from "@patternfly/react-core";
-import {
-  Table,
-  TableProps,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tr,
-} from "@patternfly/react-table";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import { VulnerabilityStatus } from "@app/api/models";
-import { client } from "@app/axios-config/apiInit";
-import {
-  getSbom,
-  SbomSummary,
-  VulnerabilityAdvisorySummary,
-} from "@app/client";
+import { SbomSummary, VulnerabilityAdvisorySummary } from "@app/client";
 import { FilterType } from "@app/components/FilterToolbar";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
@@ -33,10 +19,11 @@ import {
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
+import { VulnerabilityStatusLabel } from "@app/components/VulnerabilityStatusLabel";
+import { useSbomsOfVulnerability } from "@app/hooks/domain-controls/useSbomsOfVulnerability";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useWithUiId } from "@app/utils/query-utils";
 import { formatDate } from "@app/utils/utils";
-import { useSbomsOfVulnerability } from "@app/hooks/domain-controls/useSbomsOfVulnerability";
 
 interface TableData {
   sbomId: string;
@@ -52,12 +39,15 @@ interface SbomsByVulnerabilityProps {
 export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
   vulnerabilityId,
 }) => {
-  const { sboms, isFetching, fetchError } =
-    useSbomsOfVulnerability(vulnerabilityId);
+  const {
+    data: { sboms },
+    isFetching,
+    fetchError,
+  } = useSbomsOfVulnerability(vulnerabilityId);
 
   const tableDataWithUiId = useWithUiId(
     sboms,
-    (d) => `${d.sbomId}-${d.advisory.identifier}-${d.advisory.uuid}`
+    (d) => `${d.sbom.id}-${d.sbomStatus}`
   );
 
   const tableControls = useLocalTableControls({
@@ -68,21 +58,18 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
     columnNames: {
       name: "Name",
       version: "Version",
+      status: "Status",
       dependencies: "Dependencies",
       supplier: "Supplier",
       created: "Created on",
-      published: "Published",
-      labels: "Labels",
-      status: "Status",
-      advisory: "Advisory",
     },
     hasActionsColumn: false,
     isSortEnabled: true,
-    sortableColumns: ["published"],
+    sortableColumns: ["name", "dependencies", "created"],
     getSortValues: (item) => ({
-      published: item.sbom?.published
-        ? dayjs(item.sbom.published).valueOf()
-        : 0,
+      name: item.sbom.name,
+      dependencies: item.sbom.number_of_packages,
+      created: item.sbom?.published ? dayjs(item.sbom.published).valueOf() : 0,
     }),
     isPaginationEnabled: true,
     isFilterEnabled: true,
@@ -151,7 +138,7 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
         >
           {currentPageItems?.map((item, rowIndex) => {
             return (
-              <Tbody key={item.sbomId} isExpanded={isCellExpanded(item)}>
+              <Tbody key={item._ui_unique_id} isExpanded={isCellExpanded(item)}>
                 <Tr {...getTrProps({ item })}>
                   <TableRowContentWithControls
                     {...tableControls}
@@ -159,22 +146,19 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
                     rowIndex={rowIndex}
                   >
                     <Td width={25} {...getTdProps({ columnKey: "name" })}>
-                      <Link to={`/sboms/${item.sbomId}`}>
+                      <Link to={`/sboms/${item.sbom.id}`}>
                         {item?.sbom?.name}
                       </Link>
                     </Td>
                     <Td width={10} {...getTdProps({ columnKey: "version" })}>
-                      {item.sbom?.described_by[0]?.version}
+                      {item.sbom?.version}
                     </Td>
                     <Td
                       width={10}
                       modifier="truncate"
                       {...getTdProps({ columnKey: "status" })}
                     >
-                      <Label>
-                        {item.status.charAt(0).toUpperCase() +
-                          item.status.slice(1).replace("_", " ")}
-                      </Label>
+                      <VulnerabilityStatusLabel value={item.sbomStatus} />
                     </Td>
                     <Td
                       width={10}
@@ -183,7 +167,7 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
                       {item?.sbom?.number_of_packages}
                     </Td>
                     <Td width={10} {...getTdProps({ columnKey: "supplier" })}>
-                      {item?.sbom?.authors}
+                      {item?.sbom?.authors.join(", ")}
                     </Td>
                     <Td
                       width={10}

--- a/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
@@ -3,11 +3,7 @@ import { Link } from "react-router-dom";
 
 import dayjs from "dayjs";
 
-import {
-  Toolbar,
-  ToolbarContent,
-  ToolbarItem
-} from "@patternfly/react-core";
+import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
 import { VulnerabilityStatus } from "@app/api/models";

--- a/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
@@ -6,8 +6,6 @@ import dayjs from "dayjs";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
-import { VulnerabilityStatus } from "@app/api/models";
-import { SbomSummary, VulnerabilityAdvisorySummary } from "@app/client";
 import { FilterType } from "@app/components/FilterToolbar";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
@@ -20,13 +18,6 @@ import { useSbomsOfVulnerability } from "@app/hooks/domain-controls/useSbomsOfVu
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useWithUiId } from "@app/utils/query-utils";
 import { formatDate } from "@app/utils/utils";
-
-interface TableData {
-  sbomId: string;
-  sbom?: SbomSummary;
-  status: VulnerabilityStatus;
-  advisory: VulnerabilityAdvisorySummary;
-}
 
 interface SbomsByVulnerabilityProps {
   vulnerabilityId: string;

--- a/client/src/app/pages/vulnerability-list/components/SbomsCount.stories.tsx
+++ b/client/src/app/pages/vulnerability-list/components/SbomsCount.stories.tsx
@@ -154,16 +154,18 @@ export const ErrorState: Story = {
         toJSON: () => new Object(),
         name: "A name here",
       },
-      summary: {
-        total: 5,
-        status: {
-          affected: 3,
-          fixed: 2,
-          not_affected: 0,
-          known_not_affected: 0,
+      data: {
+        summary: {
+          total: 5,
+          sbomStatus: {
+            affected: 3,
+            fixed: 2,
+            not_affected: 0,
+            known_not_affected: 0,
+          },
         },
+        sboms: [],
       },
-      sboms: [],
     });
   },
   parameters: {
@@ -202,16 +204,18 @@ export const PopulatedState: Story = {
         toJSON: () => new Object(),
         name: "A name here",
       },
-      summary: {
-        total: 0,
-        status: {
-          affected: 0,
-          fixed: 0,
-          not_affected: 0,
-          known_not_affected: 0,
+      data: {
+        summary: {
+          total: 0,
+          sbomStatus: {
+            affected: 0,
+            fixed: 0,
+            not_affected: 0,
+            known_not_affected: 0,
+          },
         },
+        sboms: [],
       },
-      sboms: [],
     });
   },
   parameters: {

--- a/client/src/app/pages/vulnerability-list/components/SbomsCount.tsx
+++ b/client/src/app/pages/vulnerability-list/components/SbomsCount.tsx
@@ -10,7 +10,7 @@ interface SbomsCountProps {
 }
 
 export const SbomsCount: React.FC<SbomsCountProps> = ({ vulnerabilityId }) => {
-  const { summary, isFetching, fetchError } =
+  const { data, isFetching, fetchError } =
     useSbomsOfVulnerability(vulnerabilityId);
 
   return (
@@ -20,7 +20,7 @@ export const SbomsCount: React.FC<SbomsCountProps> = ({ vulnerabilityId }) => {
       isFetchingState={<Skeleton screenreaderText="Loading contents" />}
       fetchErrorState={<Label color="red">Error</Label>}
     >
-      {summary.status.affected}
+      {data.summary.sbomStatus.affected}
     </LoadingWrapper>
   );
 };


### PR DESCRIPTION
Thanks to this https://github.com/trustification/trustify/issues/1006 we can reduce the number of calls done to the backend when we are at the CVEs details page:

BEFORE:
- For each SBOM found in the Vulnerability/CVE we fetch the SBOM.

AFTER
- We do not need to fetch each SBOM as the original request has everything we need.

![Screenshot From 2024-11-25 15-11-01](https://github.com/user-attachments/assets/45f51f10-ff45-4af9-ba8b-1344c62a1fd9)
