### PR TITLE
fix: Search Page wrong advisories count

### DIFF
--- a/client/src/app/pages/search/components/SearchTabs.tsx
+++ b/client/src/app/pages/search/components/SearchTabs.tsx
@@ -13,15 +13,14 @@ import {
   TabTitleText,
 } from "@patternfly/react-core";
 
-import { PackageTable } from "@app/pages/package-list/package-table";
+import { FilterPanel } from "@app/components/FilterPanel";
 import { AdvisoryTable } from "@app/pages/advisory-list/advisory-table";
+import { PackageTable } from "@app/pages/package-list/package-table";
 import { SbomTable } from "@app/pages/sbom-list/sbom-table";
 import { VulnerabilityTable } from "@app/pages/vulnerability-list/vulnerability-table";
 import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
-import { FilterPanel } from "@app/components/FilterPanel";
 
 export interface SearchTabsProps {
-  advisoryTable?: ReactNode;
   filterPanelProps: {
     advisoryFilterPanelProps?: any;
     packageFilterPanelProps?: any;
@@ -34,24 +33,27 @@ export interface SearchTabsProps {
   sbomTotalCount: number;
   vulnerabilityTable?: ReactElement;
   vulnerabilityTotalCount: number;
+  advisoryTable?: ReactNode;
+  advisoryTotalCount: number;
 }
 
 export const SearchTabs: React.FC<SearchTabsProps> = ({
-  advisoryTable,
   filterPanelProps,
-  packageTable,
-  packageTotalCount,
   sbomTable,
   sbomTotalCount,
+  packageTable,
+  packageTotalCount,
   vulnerabilityTable,
   vulnerabilityTotalCount,
+  advisoryTable,
+  advisoryTotalCount,
 }) => {
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
   const {
-    advisoryFilterPanelProps,
-    packageFilterPanelProps,
     sbomFilterPanelProps,
+    packageFilterPanelProps,
     vulnerabilityFilterPanelProps,
+    advisoryFilterPanelProps,
   } = filterPanelProps;
 
   const handleTabClick = (
@@ -166,7 +168,7 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
               <TabTitleText>
                 Advisories{"  "}
                 <Badge screenReaderText="Advisory Result Count">
-                  {vulnerabilityTotalCount}
+                  {advisoryTotalCount}
                 </Badge>
               </TabTitleText>
             }

--- a/client/src/app/pages/search/search.tsx
+++ b/client/src/app/pages/search/search.tsx
@@ -112,6 +112,7 @@ export const Search: React.FC<SearchPageProps> = ({ searchBodyOverride }) => {
       packageTotalCount={packageTotalCount}
       sbomTotalCount={sbomTotalCount}
       vulnerabilityTotalCount={vulnerabilityTotalCount}
+      advisoryTotalCount={advisoryTotalCount}
     />
   );
 


### PR DESCRIPTION
Fixes https://github.com/trustification/trustify-ui/issues/280

- `vulnerabilityTotalCount` was set instead of `advisoryTotalCount` => fixed that
- Just order the variable declarations in the same order in which the tabs are rendered. This has zero effect on the final result but just wanted it to help me to better read the code in the future