### PR TITLE
fix: dashboard to use ingested time to fetch last sbom/advisory

### DIFF
--- a/client/src/app/pages/home/components/MonitoringSection.tsx
+++ b/client/src/app/pages/home/components/MonitoringSection.tsx
@@ -36,7 +36,7 @@ import { LoadingWrapper } from "@app/components/LoadingWrapper";
 import { useVulnerabilitiesOfSboms } from "@app/hooks/domain-controls/useVulnerabilitiesOfSbom";
 import { useFetchAdvisories } from "@app/queries/advisories";
 import { useFetchSBOMs } from "@app/queries/sboms";
-import { formatDate } from "@app/utils/utils";
+import { formatDateTime } from "@app/utils/utils";
 
 interface Legend {
   severity: Severity;
@@ -62,7 +62,7 @@ export const MonitoringSection: React.FC = () => {
   } = useFetchSBOMs(
     {
       page: { pageNumber: 1, itemsPerPage: 10 },
-      sort: { field: "published", direction: "desc" },
+      sort: { field: "ingested", direction: "desc" },
     },
     true
   );
@@ -90,7 +90,7 @@ export const MonitoringSection: React.FC = () => {
   } = useFetchAdvisories(
     {
       page: { pageNumber: 1, itemsPerPage: 10 },
-      sort: { field: "published", direction: "desc" },
+      sort: { field: "ingested", direction: "desc" },
     },
     true
   );
@@ -264,7 +264,7 @@ export const MonitoringSection: React.FC = () => {
                       <DescriptionListDescription>
                         <Stack>
                           <StackItem>
-                            {formatDate(barchartSboms?.[0]?.published)}
+                            {formatDateTime(barchartSboms?.[0]?.ingested)}
                           </StackItem>
                           <StackItem>
                             <Link to={`/sboms/${barchartSboms?.[0]?.id}`}>
@@ -295,7 +295,7 @@ export const MonitoringSection: React.FC = () => {
                       <DescriptionListDescription>
                         <Stack>
                           <StackItem>
-                            {formatDate(advisories?.[0]?.published)}
+                            {formatDateTime(advisories?.[0]?.ingested)}
                           </StackItem>
                           <StackItem>{advisories?.[0]?.identifier}</StackItem>
                         </Stack>

--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -38,7 +38,7 @@ export const formatDate = (value?: string | null) => {
   return value ? dayjs(value).format(RENDER_DATE_FORMAT) : null;
 };
 
-export const formatDateTime = (value?: string) => {
+export const formatDateTime = (value?: string | null) => {
   return value ? dayjs(value).format(RENDER_DATETIME_FORMAT) : null;
 };
 


### PR DESCRIPTION
The code in the main branch fetches the SBOMs and Advisories based on their "published" data which is wrong and it was just a placeholder while we wait for https://github.com/trustification/trustify/issues/1077 to be implemented in the backend.

Now that we can sort SBOM/Advisory by `ingested` we can use it to get the last SBOMs and advisories ingested into the system to properly populate the dashboard.