### PR TITLE
fix: sbom's packages view

### DIFF
--- a/client/src/app/pages/package-details/package-details.tsx
+++ b/client/src/app/pages/package-details/package-details.tsx
@@ -15,6 +15,7 @@ import {
 } from "@patternfly/react-core";
 
 import { PathParam, useRouteParams } from "@app/Routes";
+import { LoadingWrapper } from "@app/components/LoadingWrapper";
 import { PackageQualifiers } from "@app/components/PackageQualifiers";
 import { useFetchPackageById } from "@app/queries/packages";
 import { decomposePurl } from "@app/utils/utils";
@@ -24,7 +25,7 @@ import { VulnerabilitiesByPackage } from "./vulnerabilities-by-package";
 
 export const PackageDetails: React.FC = () => {
   const packageId = useRouteParams(PathParam.PACKAGE_ID);
-  const { pkg } = useFetchPackageById(packageId);
+  const { pkg, isFetching, fetchError } = useFetchPackageById(packageId);
 
   const decomposedPurl = React.useMemo(() => {
     return pkg ? decomposePurl(pkg.purl) : undefined;
@@ -106,7 +107,9 @@ export const PackageDetails: React.FC = () => {
           aria-label="SBOMs using the Package"
           hidden
         >
-          {packageId && <SbomsByPackage packageId={packageId} />}
+          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+            {pkg?.purl && <SbomsByPackage purl={pkg.purl} />}
+          </LoadingWrapper>
         </TabContent>
       </PageSection>
     </>

--- a/client/src/app/pages/package-details/sboms-by-package.tsx
+++ b/client/src/app/pages/package-details/sboms-by-package.tsx
@@ -20,11 +20,11 @@ import { useSelectionState } from "@app/hooks/useSelectionState";
 import { useFetchSbomsByPackageId } from "@app/queries/sboms";
 
 interface SbomsByPackageProps {
-  packageId: string;
+  purl: string;
 }
 
 export const SbomsByPackage: React.FC<SbomsByPackageProps> = ({
-  packageId,
+  purl,
 }) => {
   const tableControlState = useTableControlState({
     tableName: "sboms",
@@ -53,7 +53,7 @@ export const SbomsByPackage: React.FC<SbomsByPackageProps> = ({
     isFetching,
     fetchError,
   } = useFetchSbomsByPackageId(
-    packageId,
+    purl,
     getHubRequestParams({
       ...tableControlState,
       hubSortFieldKeys: {},

--- a/client/src/app/pages/package-details/sboms-by-package.tsx
+++ b/client/src/app/pages/package-details/sboms-by-package.tsx
@@ -23,9 +23,7 @@ interface SbomsByPackageProps {
   purl: string;
 }
 
-export const SbomsByPackage: React.FC<SbomsByPackageProps> = ({
-  purl,
-}) => {
+export const SbomsByPackage: React.FC<SbomsByPackageProps> = ({ purl }) => {
   const tableControlState = useTableControlState({
     tableName: "sboms",
     persistenceKeyPrefix: TablePersistenceKeyPrefixes.sboms_by_package,

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -138,15 +138,15 @@ export const useUpdateSbomLabelsMutation = (
 };
 
 export const useFetchSbomsByPackageId = (
-  packageId: string,
+  purl: string,
   params: HubRequestParams = {}
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ["SBOMsQueryKeysss", "by-package", packageId, params],
+    queryKey: ["SBOMsQueryKeysss", "by-package", purl, params],
     queryFn: () => {
       return listRelatedSboms({
         client,
-        query: { id: packageId, ...requestParamsQuery(params) },
+        query: { purl, ...requestParamsQuery(params) },
       });
     },
   });


### PR DESCRIPTION
In response to https://github.com/trustification/trustify/issues/1163

The UI now should use the QueryParam `purl` to get the sboms related to a package

![image](https://github.com/user-attachments/assets/dd29e11c-0359-49d7-96bf-dd1f616b3b2e)
