### PR TITLE
ci: add backport action

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,29 @@
+name: Backport
+on:
+  pull_request_target:
+    types: [ closed ]
+  issue_comment:
+    types: [ created ]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+    if: >
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.merged
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.user.id != 97796249 &&
+        startsWith(github.event.comment.body, '/backport')
+      )
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v3
+        with:
+          merge_commits: skip


### PR DESCRIPTION
solves https://github.com/trustification/trustify-ui/issues/336

Any PR that needs to be backported to the branch release/0.2.z need to add the label "backport release/0.2.z" manually, then a backport PR should be created by gh actions.

I tested it in my own account see:
- https://github.com/carlosthe19916/trustify-ui/pull/22 is a PR opened from a forked repository
- a backport https://github.com/carlosthe19916/trustify-ui/pull/23 was created automatically