### PR TITLE
ci: include release/* branch for gh action executions

### DIFF
--- a/.github/workflows/ci-image-build.yaml
+++ b/.github/workflows/ci-image-build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - "main"
-      - "release-*"
+      - "release/*"
 
 jobs:
   checks:

--- a/.github/workflows/ci-repo.yaml
+++ b/.github/workflows/ci-repo.yaml
@@ -3,12 +3,12 @@ name: CI (repo level)
 on:
   push:
     branches:
-      - main
-      - "release-*"
+      - "main"
+      - "release/*"
   pull_request:
     branches:
-      - main
-      - "release-*"
+      - "main"
+      - "release/*"
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - "main"
-      - "release-*"
+      - "release/*"
     tags:
       - "v*"
 

--- a/.github/workflows/tag-dist.yaml
+++ b/.github/workflows/tag-dist.yaml
@@ -3,7 +3,7 @@ name: Tag Dist Build
 on:
   push:
     branches:
-      - main
+      - "main"
       - "release/*"
     tags:
       - "v*"


### PR DESCRIPTION
As from now on we need to actively backport things to the branch "release/0.2.z", ideally this PR should be merged after https://github.com/trustification/trustify-ui/pull/341