### PR TITLE
:sparkles:  add importer filters

### DIFF
--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -63,6 +63,21 @@ import { ANSICOLOR } from "@app/Constants";
 import { ImporterProgress } from "./components/importer-progress";
 import { ImporterStatusIcon } from "./components/importer-status-icon";
 
+type ImporterStatus = "enabled" | "disabled" | "scheduled" | "running";
+
+const getImporterStatus = (importer: Importer): ImporterStatus => {
+  const importerType = Object.keys(importer.configuration ?? {})[0];
+  const configValues = (importer.configuration as any)[
+    importerType
+  ] as SbomImporter;
+  const isImporterEnabled = configValues?.disabled === false;
+  if (!isImporterEnabled) {
+    return "disabled";
+  } else {
+    return importer.state === "running" ? "running" : "scheduled";
+  }
+};
+
 export const ImporterList: React.FC = () => {
   const { pushNotification } = React.useContext(NotificationsContext);
 
@@ -182,6 +197,31 @@ export const ImporterList: React.FC = () => {
         type: FilterType.search,
         placeholderText: "Search by name...",
         getItemValue: (item) => item.name || "",
+      },
+      {
+        categoryKey: "status",
+        title: "Status",
+        type: FilterType.multiselect,
+        logicOperator: "OR",
+        selectOptions: [
+          {
+            value: "scheduled",
+            label: "Scheduled",
+          },
+          {
+            value: "running",
+            label: "Running",
+          },
+          {
+            value: "disabled",
+            label: "Disabled",
+          },
+        ],
+        placeholderText: "Status",
+        matcher: (filter, item) => {
+          console.log(filter, item);
+          return filter === getImporterStatus(item);
+        },
       },
     ],
   });

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -219,7 +219,6 @@ export const ImporterList: React.FC = () => {
         ],
         placeholderText: "Status",
         matcher: (filter, item) => {
-          console.log(filter, item);
           return filter === getImporterStatus(item);
         },
       },


### PR DESCRIPTION
Related to #149

As expressed at https://github.com/trustification/trustify-ui/issues/149 , users find difficult to see the importers when they are too many.

This PR adds a filter to the importers table so users can define which status of importers they want to see.

https://github.com/user-attachments/assets/f5cbf1b4-d47f-41ab-bdec-4f693e9dd659


> further enhancements will be needed like the one proposed at https://github.com/trustification/trustify-ui/issues/149#issuecomment-2657181396 . But they can come in PR chunks and iterate over it.
