### PR TITLE
:seedling:  setup PR title verification

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,16 @@
+name: PR Checks
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    name: Verify PR contents
+    steps:
+      - name: Check Title
+        id: verifier
+        uses: trustification/release-tools/cmd/verify-pr@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Trustify UI
+
+Thank you for considering contributing to Trustify UI! We appreciate your time and effort in improving the project. Please follow these guidelines to make the contribution process smooth and effective.
+
+## How to Contribute
+
+### 1. Reporting Issues
+
+- If you find a bug or have a feature request, please create an issue:
+- Check the existing issues to avoid duplicates.
+- Use a clear and descriptive title.
+- Provide as much detail as possible, including steps to reproduce (if applicable).
+
+### 2. Submitting Pull Requests (PRs)
+
+Before submitting a PR:
+
+- Write meaningful commit messages.
+- Include relevant tests and documentation updates.
+- Link the PR to the corresponding issue (if applicable).
+
+Every PR should be annotated with an icon indicating whether it's
+a:
+
+- Breaking change: :warning: (`:warning:`)
+- Non-breaking feature: :sparkles: (`:sparkles:`)
+- Patch fix: :bug: (`:bug:`)
+- Docs: :book: (`:book:`)
+- Infra/Tests/Other: :seedling: (`:seedling:`)
+- No release note: :ghost: (`:ghost:`)
+
+For more information read [Trustification Versioning](https://github.com/trustification/release-tools/blob/main/VERSIONING.md).
+
+### 3. Documentation Updates
+
+If your contribution affects user behavior, update the README.md or relevant documentation.
+
+Use clear, concise language and follow existing documentation patterns.
+
+## Getting Help
+
+If you need help with anything, feel free to ask in Discussions or reach out via GitHub issues.
+
+Thank you for contributing! 🚀

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thank you for considering contributing to Trustify UI! We appreciate your time a
 - If you find a bug or have a feature request, please create an issue:
 - Check the existing issues to avoid duplicates.
 - Use a clear and descriptive title.
-- Provide as much detail as possible, including steps to reproduce (if applicable).
+- Provide as much details as possible, including steps to reproduce (if applicable).
 
 ### 2. Submitting Pull Requests (PRs)
 

--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ Open browser at <http://localhost:3000>
 
 > [!NOTE]
 > When using the crate it is expected to build the UI always in Prod mode
+
+## Contributing
+
+We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING.md) before submitting changes.


### PR DESCRIPTION
Recently https://github.com/trustification/release-tools/ added a set of reusable action mainly inspired in the automation used at https://github.com/konveyor/ 

This PR setup a PR title verification for each PR so appropriate titles are always set. This will help to create accurate release notes when we start creating tags/releases. 