### PR TITLE
:seedling:  remove mocks/browser from index.tsx

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -4,7 +4,6 @@ import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
-import ENV from "@app/env";
 import App from "@app/App";
 import reportWebVitals from "@app/reportWebVitals";
 import "@app/dayjs";
@@ -28,16 +27,7 @@ const renderApp = () => {
   );
 };
 
-if (ENV.NODE_ENV === "development") {
-  import("./mocks/browser").then((browserMocks) => {
-    if (browserMocks.config.enabled) {
-      browserMocks.worker.start();
-    }
-    renderApp();
-  });
-} else {
-  renderApp();
-}
+renderApp();
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))


### PR DESCRIPTION
It has been reported, internally, that some dependencies are being part of the final minimized bundles. E.g.

- If in the current main branch we execute `npm run build` and then `grep -r "myjino" client/dist/` we will see some results
- With the current PR we will avoid dependencies comming from `mocks/browser` being injected in the final bundles

We are not using the mocks/browser anyway. And it was originally intended to speed up the very first phase of development in the UI 1 year ago (when there was not backend therefore some mock api was needed to progress the UI).