### PR TITLE
:sparkles: Stop fetching data every X seconds and do it only when requested 

### DIFF
--- a/client/src/app/Constants.ts
+++ b/client/src/app/Constants.ts
@@ -6,6 +6,8 @@ export const RENDER_DATE_FORMAT = "MMM DD, YYYY";
 export const RENDER_DATETIME_FORMAT = "MMM DD, YYYY | HH:mm:ss";
 export const FILTER_DATE_FORMAT = "YYYY-MM-DD";
 
+export const DEFAULT_REFETCH_INTERVAL = 0;
+
 export const TablePersistenceKeyPrefixes = {
   products: "pd",
   advisories: "ad",

--- a/client/src/app/Constants.ts
+++ b/client/src/app/Constants.ts
@@ -6,7 +6,7 @@ export const RENDER_DATE_FORMAT = "MMM DD, YYYY";
 export const RENDER_DATETIME_FORMAT = "MMM DD, YYYY | HH:mm:ss";
 export const FILTER_DATE_FORMAT = "YYYY-MM-DD";
 
-export const DEFAULT_REFETCH_INTERVAL = 0;
+export const DEFAULT_REFETCH_INTERVAL = 5000;
 
 export const TablePersistenceKeyPrefixes = {
   products: "pd",

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -59,7 +59,7 @@ import {
 } from "@app/components/TableControls";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 
-import { ANSICOLOR, DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
+import { ANSICOLOR } from "@app/Constants";
 import { ImporterProgress } from "./components/importer-progress";
 import { ImporterStatusIcon } from "./components/importer-status-icon";
 
@@ -78,8 +78,6 @@ const getImporterStatus = (importer: Importer): ImporterStatus => {
   }
 };
 
-const slowRefetchInterval = DEFAULT_REFETCH_INTERVAL * 2;
-
 export const ImporterList: React.FC = () => {
   const { pushNotification } = React.useContext(NotificationsContext);
 
@@ -94,23 +92,7 @@ export const ImporterList: React.FC = () => {
     setSelectedRow(row);
   };
 
-  const [refetchInterval, setRefetchInterval] = React.useState(10000);
-  const { importers, isFetching, fetchError } = useFetchImporters(
-    false,
-    refetchInterval
-  );
-
-  // Fetch importers with more frecuency in case any is "running"
-  React.useEffect(() => {
-    const isSomeTaskRunning = importers.some(
-      (item) => item.state === "running"
-    );
-    if (isSomeTaskRunning) {
-      setRefetchInterval(DEFAULT_REFETCH_INTERVAL);
-    } else if (refetchInterval !== slowRefetchInterval) {
-      setRefetchInterval(slowRefetchInterval);
-    }
-  }, [importers]);
+  const { importers, isFetching, fetchError } = useFetchImporters();
 
   // Enable/Disable Importer
 

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -59,9 +59,11 @@ import {
 } from "@app/components/TableControls";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 
-import { ANSICOLOR } from "@app/Constants";
+import { ANSICOLOR, DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { ImporterProgress } from "./components/importer-progress";
 import { ImporterStatusIcon } from "./components/importer-status-icon";
+
+const slowRefetchInterval = DEFAULT_REFETCH_INTERVAL * 2;
 
 export const ImporterList: React.FC = () => {
   const { pushNotification } = React.useContext(NotificationsContext);
@@ -89,9 +91,9 @@ export const ImporterList: React.FC = () => {
       (item) => item.state === "running"
     );
     if (isSomeTaskRunning) {
-      setRefetchInterval(5000);
-    } else if (refetchInterval !== 10000) {
-      setRefetchInterval(10000);
+      setRefetchInterval(DEFAULT_REFETCH_INTERVAL);
+    } else if (refetchInterval !== slowRefetchInterval) {
+      setRefetchInterval(slowRefetchInterval);
     }
   }, [importers]);
 

--- a/client/src/app/pages/search/components/SearchMenu.tsx
+++ b/client/src/app/pages/search/components/SearchMenu.tsx
@@ -65,22 +65,22 @@ function useAllEntities(filterText: string, disableSearch: boolean) {
   const {
     isFetching: isFetchingAdvisories,
     result: { data: advisories },
-  } = useFetchAdvisories({ ...params }, true, disableSearch);
+  } = useFetchAdvisories({ ...params }, disableSearch);
 
   const {
     isFetching: isFetchingPackages,
     result: { data: packages },
-  } = useFetchPackages({ ...params }, true, disableSearch);
+  } = useFetchPackages({ ...params }, disableSearch);
 
   const {
     isFetching: isFetchingSBOMs,
     result: { data: sboms },
-  } = useFetchSBOMs({ ...params }, true, disableSearch);
+  } = useFetchSBOMs({ ...params }, disableSearch);
 
   const {
     isFetching: isFetchingVulnerabilities,
     result: { data: vulnerabilities },
-  } = useFetchVulnerabilities({ ...params }, true, disableSearch);
+  } = useFetchVulnerabilities({ ...params }, disableSearch);
 
   const transformedAdvisories: IEntity[] = advisories.map((item) => ({
     id: `advisory-${item.uuid}`,

--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -14,7 +14,6 @@ import {
 } from "@app/client";
 
 import { uploadAdvisory } from "@app/api/rest";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { requestParamsQuery } from "@app/hooks/table-controls";
 import { useUpload } from "@app/hooks/useUpload";
 
@@ -29,7 +28,6 @@ export const AdvisoriesQueryKey = "advisories";
 
 export const useFetchAdvisories = (
   params: HubRequestParams = {},
-  refetchDisabled: boolean = false,
   disableQuery: boolean = false
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
@@ -40,7 +38,6 @@ export const useFetchAdvisories = (
         query: { ...requestParamsQuery(params) },
       });
     },
-    refetchInterval: !refetchDisabled ? DEFAULT_REFETCH_INTERVAL : false,
     enabled: !disableQuery,
   });
   return {

--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -14,6 +14,7 @@ import {
 } from "@app/client";
 
 import { uploadAdvisory } from "@app/api/rest";
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { requestParamsQuery } from "@app/hooks/table-controls";
 import { useUpload } from "@app/hooks/useUpload";
 
@@ -39,7 +40,7 @@ export const useFetchAdvisories = (
         query: { ...requestParamsQuery(params) },
       });
     },
-    refetchInterval: !refetchDisabled ? 5000 : false,
+    refetchInterval: !refetchDisabled ? DEFAULT_REFETCH_INTERVAL : false,
     enabled: !disableQuery,
   });
   return {

--- a/client/src/app/queries/importers.ts
+++ b/client/src/app/queries/importers.ts
@@ -15,14 +15,11 @@ import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const ImportersQueryKey = "importers";
 
-export const useFetchImporters = (
-  refetchDisabled: boolean = false,
-  interval = DEFAULT_REFETCH_INTERVAL
-) => {
+export const useFetchImporters = (refetchDisabled: boolean = false) => {
   const { isLoading, error, refetch, data } = useQuery({
     queryKey: [ImportersQueryKey],
     queryFn: () => listImporters({ client }),
-    refetchInterval: !refetchDisabled ? interval : false,
+    refetchInterval: !refetchDisabled ? DEFAULT_REFETCH_INTERVAL : false,
   });
 
   return {

--- a/client/src/app/queries/importers.ts
+++ b/client/src/app/queries/importers.ts
@@ -11,12 +11,13 @@ import {
   listImporters,
   updateImporter,
 } from "@app/client";
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 
 export const ImportersQueryKey = "importers";
 
 export const useFetchImporters = (
   refetchDisabled: boolean = false,
-  interval = 5000
+  interval = DEFAULT_REFETCH_INTERVAL
 ) => {
   const { isLoading, error, refetch, data } = useQuery({
     queryKey: [ImportersQueryKey],
@@ -136,7 +137,7 @@ export const useFetchImporterReports = (
   const { data, isLoading, refetch, error } = useQuery({
     queryKey: [ImportersQueryKey, id, "reports"],
     queryFn: () => listImporterReports({ client, path: { name: id } }),
-    refetchInterval: !refetchDisabled ? 5000 : false,
+    refetchInterval: !refetchDisabled ? DEFAULT_REFETCH_INTERVAL : false,
   });
 
   return {

--- a/client/src/app/queries/packages.ts
+++ b/client/src/app/queries/packages.ts
@@ -3,7 +3,6 @@ import { AxiosError } from "axios";
 
 import { HubRequestParams } from "@app/api/models";
 
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { client } from "../axios-config/apiInit";
 import { getPurl, listPackages, listPurl } from "../client";
 import { requestParamsQuery } from "../hooks/table-controls";
@@ -12,7 +11,6 @@ export const PackagesQueryKey = "packages";
 
 export const useFetchPackages = (
   params: HubRequestParams = {},
-  refetchDisabled: boolean = false,
   disableQuery: boolean = false
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
@@ -23,7 +21,6 @@ export const useFetchPackages = (
         query: { ...requestParamsQuery(params) },
       });
     },
-    refetchInterval: !refetchDisabled ? DEFAULT_REFETCH_INTERVAL : false,
     enabled: !disableQuery,
   });
 

--- a/client/src/app/queries/packages.ts
+++ b/client/src/app/queries/packages.ts
@@ -3,6 +3,7 @@ import { AxiosError } from "axios";
 
 import { HubRequestParams } from "@app/api/models";
 
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { client } from "../axios-config/apiInit";
 import { getPurl, listPackages, listPurl } from "../client";
 import { requestParamsQuery } from "../hooks/table-controls";
@@ -22,7 +23,7 @@ export const useFetchPackages = (
         query: { ...requestParamsQuery(params) },
       });
     },
-    refetchInterval: !refetchDisabled ? 5000 : false,
+    refetchInterval: !refetchDisabled ? DEFAULT_REFETCH_INTERVAL : false,
     enabled: !disableQuery,
   });
 

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -22,14 +22,12 @@ import {
 import { useUpload } from "@app/hooks/useUpload";
 
 import { uploadSbom } from "@app/api/rest";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { requestParamsQuery } from "../hooks/table-controls";
 
 export const SBOMsQueryKey = "sboms";
 
 export const useFetchSBOMs = (
   params: HubRequestParams = {},
-  refetchDisabled: boolean = false,
   disableQuery: boolean = false
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
@@ -39,7 +37,6 @@ export const useFetchSBOMs = (
         client,
         query: { ...requestParamsQuery(params) },
       }),
-    refetchInterval: !refetchDisabled ? DEFAULT_REFETCH_INTERVAL : false,
     enabled: !disableQuery,
   });
   return {

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -22,6 +22,7 @@ import {
 import { useUpload } from "@app/hooks/useUpload";
 
 import { uploadSbom } from "@app/api/rest";
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { requestParamsQuery } from "../hooks/table-controls";
 
 export const SBOMsQueryKey = "sboms";
@@ -38,7 +39,7 @@ export const useFetchSBOMs = (
         client,
         query: { ...requestParamsQuery(params) },
       }),
-    refetchInterval: !refetchDisabled ? 5000 : false,
+    refetchInterval: !refetchDisabled ? DEFAULT_REFETCH_INTERVAL : false,
     enabled: !disableQuery,
   });
   return {

--- a/client/src/app/queries/vulnerabilities.ts
+++ b/client/src/app/queries/vulnerabilities.ts
@@ -9,14 +9,12 @@ import {
   listVulnerabilities,
   VulnerabilityDetails,
 } from "@app/client";
-import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { requestParamsQuery } from "@app/hooks/table-controls";
 
 export const VulnerabilitiesQueryKey = "vulnerabilities";
 
 export const useFetchVulnerabilities = (
   params: HubRequestParams = {},
-  refetchDisabled: boolean = false,
   disableQuery: boolean = false
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
@@ -27,7 +25,6 @@ export const useFetchVulnerabilities = (
         query: { ...requestParamsQuery(params) },
       });
     },
-    refetchInterval: !refetchDisabled ? DEFAULT_REFETCH_INTERVAL : false,
     enabled: !disableQuery,
   });
   return {

--- a/client/src/app/queries/vulnerabilities.ts
+++ b/client/src/app/queries/vulnerabilities.ts
@@ -9,6 +9,7 @@ import {
   listVulnerabilities,
   VulnerabilityDetails,
 } from "@app/client";
+import { DEFAULT_REFETCH_INTERVAL } from "@app/Constants";
 import { requestParamsQuery } from "@app/hooks/table-controls";
 
 export const VulnerabilitiesQueryKey = "vulnerabilities";
@@ -26,7 +27,7 @@ export const useFetchVulnerabilities = (
         query: { ...requestParamsQuery(params) },
       });
     },
-    refetchInterval: !refetchDisabled ? 5000 : false,
+    refetchInterval: !refetchDisabled ? DEFAULT_REFETCH_INTERVAL : false,
     enabled: !disableQuery,
   });
   return {


### PR DESCRIPTION
Fixes: https://github.com/trustification/trustify-ui/issues/325

Removes all the re-fetch logic with the exception of the Importers as we still need to follow the progress of an importer

- Moves the fetch interval value to a single place (Contants)
- This way we can change the intervals at one shot in a single place
