### PR TITLE
:sparkles: sbom details page - filter out duplicate packages

### DIFF
--- a/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
@@ -92,7 +92,16 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
 
   const tableData = React.useMemo(() => {
     return affectedVulnerabilities.map((item) => {
-      const allPackages = item.relatedPackages.flatMap((i) => i.packages);
+      const allPackages = item.relatedPackages
+        .flatMap((i) => i.packages)
+        .reduce((prev, current) => {
+          const existingElement = prev.find((item) => item.id === current.id);
+          if (existingElement) {
+            return prev;
+          } else {
+            return [...prev, current];
+          }
+        }, [] as SbomPackage[]);
       const result: TableData = {
         ...item,
         summary: {


### PR DESCRIPTION
Fixes https://github.com/trustification/trustify-ui/issues/369

The SBOM Details page / Vulnerability Tab contains duplicate packages. This PR just filters them out.

To compare the main Results vs this PR results we can import the 2 files attached to the issue https://github.com/trustification/trustify-ui/issues/369 and then go to the "The SBOM Details page / Vulnerability Tab"

This is what I see with this PR 
![image](https://github.com/user-attachments/assets/a013271c-ce6a-41e9-923d-23544d1c3977)

Note that there are 4 libnghttp2 but all of them belong to a different purl (you can see they have different architecture)