### PR TITLE
:sparkles: Set default sorting to main tables

### DIFF
--- a/client/src/app/pages/advisory-list/advisory-context.tsx
+++ b/client/src/app/pages/advisory-list/advisory-context.tsx
@@ -59,7 +59,7 @@ export const AdvisorySearchProvider: React.FunctionComponent<
     sortableColumns: ["identifier", "severity", "modified"],
     initialSort: {
       columnKey: "modified",
-      direction: "desc"
+      direction: "desc",
     },
     isFilterEnabled: true,
     filterCategories: [

--- a/client/src/app/pages/advisory-list/advisory-context.tsx
+++ b/client/src/app/pages/advisory-list/advisory-context.tsx
@@ -57,6 +57,10 @@ export const AdvisorySearchProvider: React.FunctionComponent<
     isPaginationEnabled: true,
     isSortEnabled: true,
     sortableColumns: ["identifier", "severity", "modified"],
+    initialSort: {
+      columnKey: "modified",
+      direction: "desc"
+    },
     isFilterEnabled: true,
     filterCategories: [
       {

--- a/client/src/app/pages/sbom-list/sbom-context.tsx
+++ b/client/src/app/pages/sbom-list/sbom-context.tsx
@@ -65,7 +65,7 @@ export const SbomSearchProvider: React.FunctionComponent<ISbomProvider> = ({
     sortableColumns: ["name", "published"],
     initialSort: {
       columnKey: "published",
-      direction: "desc"
+      direction: "desc",
     },
     isFilterEnabled: true,
     filterCategories: [

--- a/client/src/app/pages/sbom-list/sbom-context.tsx
+++ b/client/src/app/pages/sbom-list/sbom-context.tsx
@@ -63,6 +63,10 @@ export const SbomSearchProvider: React.FunctionComponent<ISbomProvider> = ({
     isPaginationEnabled: true,
     isSortEnabled: true,
     sortableColumns: ["name", "published"],
+    initialSort: {
+      columnKey: "published",
+      direction: "desc"
+    },
     isFilterEnabled: true,
     filterCategories: [
       {

--- a/client/src/app/pages/vulnerability-list/vulnerability-context.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-context.tsx
@@ -57,6 +57,10 @@ export const VulnerabilitySearchProvider: React.FunctionComponent<
     isPaginationEnabled: true,
     isSortEnabled: true,
     sortableColumns: ["published", "severity"],
+    initialSort: {
+      columnKey: "published",
+      direction: "desc"
+    },
     isFilterEnabled: true,
     filterCategories: [
       {

--- a/client/src/app/pages/vulnerability-list/vulnerability-context.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-context.tsx
@@ -59,7 +59,7 @@ export const VulnerabilitySearchProvider: React.FunctionComponent<
     sortableColumns: ["published", "severity"],
     initialSort: {
       columnKey: "published",
-      direction: "desc"
+      direction: "desc",
     },
     isFilterEnabled: true,
     filterCategories: [


### PR DESCRIPTION
Fixes https://github.com/trustification/trustify-ui/issues/116

Set default sorting to always see the latest entities in the table.

- Advisory table sorted by "modified" date by default
- Sbom table sorted by "published" date by default
- Vulnerability sorted by "published" date by default