### PR TITLE
:sparkles: Add download license report buttons

### DIFF
--- a/client/openapi/trustd.yaml
+++ b/client/openapi/trustd.yaml
@@ -717,52 +717,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_ImporterReport'
-  /api/v2/license:
-    get:
-      tags:
-      - license
-      summary: List licenses
-      operationId: listLicenses
-      parameters:
-      - name: q
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: offset
-        in: query
-        description: |-
-          The first item to return, skipping all that come before it.
-
-          NOTE: The order of items is defined by the API being called.
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: limit
-        in: query
-        description: |-
-          The maximum number of entries to return.
-
-          Zero means: no limit
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      responses:
-        '200':
-          description: Matching licenses
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedResults_LicenseSummary'
   /api/v2/license/spdx/license:
     get:
       tags:
@@ -828,77 +782,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SpdxLicenseDetails'
-  /api/v2/license/{uuid}:
-    get:
-      tags:
-      - license
-      summary: Retrieve license details
-      operationId: getLicenses
-      parameters:
-      - name: uuid
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      responses:
-        '200':
-          description: The license
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LicenseSummary'
-  /api/v2/license/{uuid}/purl:
-    get:
-      tags:
-      - license
-      summary: Retrieve pURLs covered by a license
-      operationId: getLicensePurls
-      parameters:
-      - name: q
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: offset
-        in: query
-        description: |-
-          The first item to return, skipping all that come before it.
-
-          NOTE: The order of items is defined by the API being called.
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: limit
-        in: query
-        description: |-
-          The maximum number of entries to return.
-
-          Zero means: no limit
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: uuid
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: The versioned pURLs allowing the license
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LicenseSummary'
   /api/v2/organization:
     get:
       tags:
@@ -1646,6 +1529,31 @@ paths:
           description: Modified the labels of the SBOM
         '404':
           description: The SBOM could not be found
+  /api/v2/sbom/{id}/license-export:
+    get:
+      tags:
+      - sbom
+      operationId: getLicenseExport
+      parameters:
+      - name: id
+        in: path
+        description: Digest/hash of the document, prefixed by hash type, such as 'sha256:<hash>' or 'urn:uuid:<uuid>'
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: license zip file
+          content:
+            application/octet-stream:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: int32
+                  minimum: 0
+        '404':
+          description: The document could not be found
   /api/v2/sbom/{id}/packages:
     get:
       tags:

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -71,6 +71,8 @@ export const uploadSbom = (formData: FormData, config?: AxiosRequestConfig) => {
   });
 };
 
+// Using our own definition of the endpoint rather than the `hey-api` auto generated
+// We could replace this one once https://github.com/hey-api/openapi-ts/issues/1803 is fixed
 export const downloadSbomLicense = (sbomId: string) => {
   return axios.get<number[]>(`${SBOMS}/${sbomId}/license-export`, {
     responseType: "arraybuffer",

--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -70,3 +70,10 @@ export const uploadSbom = (formData: FormData, config?: AxiosRequestConfig) => {
     headers: { "Content-Type": getContentTypeFromFile(file) },
   });
 };
+
+export const downloadSbomLicense = (sbomId: string) => {
+  return axios.get<number[]>(`${SBOMS}/${sbomId}/license-export`, {
+    responseType: "arraybuffer",
+    headers: { Accept: "text/plain", responseType: "blob" },
+  });
+};

--- a/client/src/app/hooks/domain-controls/useDownload.ts
+++ b/client/src/app/hooks/domain-controls/useDownload.ts
@@ -1,7 +1,9 @@
 import { saveAs } from "file-saver";
 
+import { downloadSbomLicense } from "@app/api/rest";
 import { client } from "@app/axios-config/apiInit";
 import { downloadAdvisory, downloadSbom } from "@app/client";
+import { getFilenameFromContentDisposition } from "@app/utils/utils";
 
 export const useDownload = () => {
   const onDownloadAdvisory = (id: string, filename?: string) => {
@@ -26,5 +28,24 @@ export const useDownload = () => {
     });
   };
 
-  return { downloadAdvisory: onDownloadAdvisory, downloadSBOM: onDownloadSBOM };
+  const onDownloadSBOMLicenses = (id: string) => {
+    // Using our own definition of the endpoint rather than the `hey-api` auto generated
+    // We could replace this one once https://github.com/hey-api/openapi-ts/issues/1803 is fixed
+    downloadSbomLicense(id).then((response) => {
+      let filename: string | null = null;
+
+      const header = response.headers?.["content-disposition"]?.toString();
+      if (header) {
+        filename = getFilenameFromContentDisposition(header);
+      }
+
+      saveAs(new Blob([response.data as any]), filename || `${id}.tar.gz`);
+    });
+  };
+
+  return {
+    downloadAdvisory: onDownloadAdvisory,
+    downloadSBOM: onDownloadSBOM,
+    downloadSBOMLicenses: onDownloadSBOMLicenses,
+  };
 };

--- a/client/src/app/hooks/domain-controls/useDownload.ts
+++ b/client/src/app/hooks/domain-controls/useDownload.ts
@@ -29,8 +29,6 @@ export const useDownload = () => {
   };
 
   const onDownloadSBOMLicenses = (id: string) => {
-    // Using our own definition of the endpoint rather than the `hey-api` auto generated
-    // We could replace this one once https://github.com/hey-api/openapi-ts/issues/1803 is fixed
     downloadSbomLicense(id).then((response) => {
       let filename: string | null = null;
 

--- a/client/src/app/pages/sbom-list/sbom-table.tsx
+++ b/client/src/app/pages/sbom-list/sbom-table.tsx
@@ -40,7 +40,7 @@ export const SbomTable: React.FC = ({}) => {
     expansionDerivedState: { isCellExpanded },
   } = tableControls;
 
-  const { downloadSBOM } = useDownload();
+  const { downloadSBOM, downloadSBOMLicenses } = useDownload();
 
   return (
     <>
@@ -116,9 +116,15 @@ export const SbomTable: React.FC = ({}) => {
                       <ActionsColumn
                         items={[
                           {
-                            title: "Download",
+                            title: "Download SBOM",
                             onClick: () => {
                               downloadSBOM(item.id, `${item.name}.json`);
+                            },
+                          },
+                          {
+                            title: "Download License Report",
+                            onClick: () => {
+                              downloadSBOMLicenses(item.id);
                             },
                           },
                         ]}

--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -108,3 +108,10 @@ export const decomposePurl = (purl: string) => {
     return undefined;
   }
 };
+
+export const getFilenameFromContentDisposition = (
+  contentDisposition: string
+): string | null => {
+  const match = contentDisposition.match(/filename="?([^"]+)"?/);
+  return match ? match[1] : null;
+};


### PR DESCRIPTION
UI counter part of https://github.com/trustification/trustify/pull/1331

This add UI compatibility with V1 UI in terms of having buttons to download the License report for each SBOM

Setting this PR as a Draft as the backend PR has not been merged yet.

![Screenshot From 2025-03-12 16-32-10](https://github.com/user-attachments/assets/eacb2787-2daa-4de2-8a52-237bad6006a7)
![Screenshot From 2025-03-12 16-32-02](https://github.com/user-attachments/assets/0d848aac-d44f-4130-8515-bd439ec6ae48)

Note: This PR requires UI Tests PR: 33
https://github.com/trustification/trustify-tests/pull/33 for the Global Tests to pass