### PR TITLE
:bug: SBOM/Package table renders 'undefined' if namespace doesn't exist

### DIFF
--- a/client/src/app/pages/sbom-details/packages-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/packages-by-sbom.tsx
@@ -167,7 +167,7 @@ export const PackagesBySbom: React.FC<PackagesProps> = ({ sbomId }) => {
                       <Flex>
                         <FlexItem
                           spacer={{ default: "spacerSm" }}
-                        >{`${item.decomposedPurl?.name}/${item.decomposedPurl?.namespace}`}</FlexItem>
+                        >{`${item.decomposedPurl?.name}${item.decomposedPurl?.namespace ? "/" + item.decomposedPurl?.namespace : ""}`}</FlexItem>
                         <FlexItem>
                           <Label isCompact color="blue">
                             {item.decomposedPurl?.type}


### PR DESCRIPTION
The namespace should be rendered only if it is different than undefined.

Before

![image](https://github.com/user-attachments/assets/10beca0a-2e76-459e-83cc-a527d0509cb6)

After

![image](https://github.com/user-attachments/assets/708b4900-be0a-4090-a11e-934206a92c2f)
