### PR TITLE
:bug:  searchtabs filterCategories being hardcoded

### DIFF
--- a/client/src/app/pages/search/components/SearchTabs.tsx
+++ b/client/src/app/pages/search/components/SearchTabs.tsx
@@ -117,7 +117,6 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
               <FilterPanel
                 omitFilterCategoryKeys={[""]}
                 {...advisoryFilterPanelProps}
-                filterCategories={[]}
               />
             ) : null}
           </CardBody>


### PR DESCRIPTION
While doing the massive recent changes to apply the linting rules of Biome, this unwanted line has been introduced