### PR TITLE
:sparkles: [TC-2203] add sorting to SBOMs using package table

### DIFF
--- a/client/src/app/pages/package-details/sboms-by-package.tsx
+++ b/client/src/app/pages/package-details/sboms-by-package.tsx
@@ -55,7 +55,7 @@ export const SbomsByPackage: React.FC<SbomsByPackageProps> = ({ purl }) => {
     getHubRequestParams({
       ...tableControlState,
       hubSortFieldKeys: {
-        name: "name"
+        name: "name",
       },
     }),
   );

--- a/client/src/app/pages/package-details/sboms-by-package.tsx
+++ b/client/src/app/pages/package-details/sboms-by-package.tsx
@@ -34,7 +34,7 @@ export const SbomsByPackage: React.FC<SbomsByPackageProps> = ({ purl }) => {
     },
     isPaginationEnabled: true,
     isSortEnabled: true,
-    sortableColumns: [],
+    sortableColumns: ["name"],
     isFilterEnabled: true,
     filterCategories: [
       {
@@ -54,7 +54,9 @@ export const SbomsByPackage: React.FC<SbomsByPackageProps> = ({ purl }) => {
     purl,
     getHubRequestParams({
       ...tableControlState,
-      hubSortFieldKeys: {},
+      hubSortFieldKeys: {
+        name: "name"
+      },
     }),
   );
 


### PR DESCRIPTION
Originally requested by https://issues.redhat.com/browse/TC-2203

The SBOMs using Package Table should be sorted alphabetically by default.

Waiting for https://github.com/trustification/trustify/issues/1476 to be solved