### PR TITLE
:sparkles: add table tooltips

### DIFF
--- a/client/src/app/components/TdWithFocusStatus.tsx
+++ b/client/src/app/components/TdWithFocusStatus.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export interface TdWithFocusStatusProps {
+  children: (
+    isFocused: boolean,
+    setIsFocused: (value: boolean) => void,
+  ) => React.ReactNode;
+}
+
+export const TdWithFocusStatus: React.FC<TdWithFocusStatusProps> = ({
+  children,
+}) => {
+  const [isFocused, setIsFocused] = React.useState(false);
+  return <>{children(isFocused, setIsFocused)}</>;
+};

--- a/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
+++ b/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
@@ -4,7 +4,15 @@ import { Link } from "react-router-dom";
 import type { AxiosError } from "axios";
 
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import {
+  Table,
+  TableText,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@patternfly/react-table";
 
 import type { AdvisoryVulnerabilitySummary } from "@app/client";
 import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
@@ -14,6 +22,7 @@ import {
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
+import { TdWithFocusStatus } from "@app/components/TdWithFocusStatus";
 import { VulnerabilityDescription } from "@app/components/VulnerabilityDescription";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { formatDate } from "@app/utils/utils";
@@ -111,13 +120,25 @@ export const VulnerabilitiesByAdvisory: React.FC<
                         {item.identifier}
                       </Link>
                     </Td>
-                    <Td
-                      width={40}
-                      modifier="truncate"
-                      {...getTdProps({ columnKey: "title" })}
-                    >
-                      <VulnerabilityDescription vulnerability={item} />
-                    </Td>
+                    <TdWithFocusStatus>
+                      {(isFocused, setIsFocused) => (
+                        <Td
+                          width={40}
+                          modifier="truncate"
+                          onFocus={() => setIsFocused(true)}
+                          onBlur={() => setIsFocused(false)}
+                          tabIndex={0}
+                          {...getTdProps({ columnKey: "title" })}
+                        >
+                          <TableText
+                            focused={isFocused}
+                            wrapModifier="truncate"
+                          >
+                            <VulnerabilityDescription vulnerability={item} />
+                          </TableText>
+                        </Td>
+                      )}
+                    </TdWithFocusStatus>
                     <Td width={15} {...getTdProps({ columnKey: "discovery" })}>
                       {formatDate(item.discovered)}
                     </Td>

--- a/client/src/app/pages/advisory-list/advisory-table.tsx
+++ b/client/src/app/pages/advisory-list/advisory-table.tsx
@@ -128,7 +128,11 @@ export const AdvisoryTable: React.FC = () => {
                         />
                       )}
                     </Td>
-                    <Td width={10} {...getTdProps({ columnKey: "modified" })}>
+                    <Td
+                      width={10}
+                      modifier="truncate"
+                      {...getTdProps({ columnKey: "modified" })}
+                    >
                       {formatDate(item.modified)}
                     </Td>
                     <Td

--- a/client/src/app/pages/package-details/vulnerabilities-by-package.tsx
+++ b/client/src/app/pages/package-details/vulnerabilities-by-package.tsx
@@ -4,7 +4,15 @@ import { Link } from "react-router-dom";
 import dayjs from "dayjs";
 
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import {
+  Table,
+  TableText,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@patternfly/react-table";
 
 import { getSeverityPriority } from "@app/api/model-utils";
 import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
@@ -14,6 +22,7 @@ import {
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
+import { TdWithFocusStatus } from "@app/components/TdWithFocusStatus";
 import { VulnerabilityDescription } from "@app/components/VulnerabilityDescription";
 import { useVulnerabilitiesOfPackage } from "@app/hooks/domain-controls/useVulnerabilitiesOfPackage";
 import { useLocalTableControls } from "@app/hooks/table-controls";
@@ -137,17 +146,29 @@ export const VulnerabilitiesByPackage: React.FC<
                         {item.vulnerability.identifier}
                       </Link>
                     </Td>
-                    <Td
-                      width={60}
-                      modifier="truncate"
-                      {...getTdProps({ columnKey: "description" })}
-                    >
-                      {item.vulnerability && (
-                        <VulnerabilityDescription
-                          vulnerability={item.vulnerability}
-                        />
+                    <TdWithFocusStatus>
+                      {(isFocused, setIsFocused) => (
+                        <Td
+                          width={60}
+                          modifier="truncate"
+                          onFocus={() => setIsFocused(true)}
+                          onBlur={() => setIsFocused(false)}
+                          tabIndex={0}
+                          {...getTdProps({ columnKey: "description" })}
+                        >
+                          <TableText
+                            focused={isFocused}
+                            wrapModifier="truncate"
+                          >
+                            {item.vulnerability && (
+                              <VulnerabilityDescription
+                                vulnerability={item.vulnerability}
+                              />
+                            )}
+                          </TableText>
+                        </Td>
                       )}
-                    </Td>
+                    </TdWithFocusStatus>
                     <Td width={15} {...getTdProps({ columnKey: "severity" })}>
                       {item.vulnerability?.average_severity && (
                         <SeverityShieldAndText

--- a/client/src/app/pages/sbom-details/packages-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/packages-by-sbom.tsx
@@ -182,7 +182,11 @@ export const PackagesBySbom: React.FC<PackagesProps> = ({ sbomId }) => {
                         </FlexItem>
                       </Flex>
                     </Td>
-                    <Td width={20} {...getTdProps({ columnKey: "version" })}>
+                    <Td
+                      width={20}
+                      modifier="truncate"
+                      {...getTdProps({ columnKey: "version" })}
+                    >
                       {item.decomposedPurl?.version}
                     </Td>
                     <Td width={50} {...getTdProps({ columnKey: "qualifiers" })}>

--- a/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
@@ -21,6 +21,7 @@ import {
 import {
   ExpandableRowContent,
   Table,
+  TableText,
   Tbody,
   Td,
   Th,
@@ -49,6 +50,7 @@ import {
   TableHeaderContentWithControls,
   TableRowContentWithControls,
 } from "@app/components/TableControls";
+import { TdWithFocusStatus } from "@app/components/TdWithFocusStatus";
 import { VulnerabilityDescription } from "@app/components/VulnerabilityDescription";
 import { useVulnerabilitiesOfSbom } from "@app/hooks/domain-controls/useVulnerabilitiesOfSbom";
 import { useLocalTableControls } from "@app/hooks/table-controls";
@@ -274,17 +276,29 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
                             {item.vulnerability.identifier}
                           </Link>
                         </Td>
-                        <Td
-                          width={35}
-                          modifier="truncate"
-                          {...getTdProps({ columnKey: "description" })}
-                        >
-                          {item.vulnerability && (
-                            <VulnerabilityDescription
-                              vulnerability={item.vulnerability}
-                            />
+                        <TdWithFocusStatus>
+                          {(isFocused, setIsFocused) => (
+                            <Td
+                              width={35}
+                              modifier="truncate"
+                              onFocus={() => setIsFocused(true)}
+                              onBlur={() => setIsFocused(false)}
+                              tabIndex={0}
+                              {...getTdProps({ columnKey: "description" })}
+                            >
+                              <TableText
+                                focused={isFocused}
+                                wrapModifier="truncate"
+                              >
+                                {item.vulnerability && (
+                                  <VulnerabilityDescription
+                                    vulnerability={item.vulnerability}
+                                  />
+                                )}
+                              </TableText>
+                            </Td>
                           )}
-                        </Td>
+                        </TdWithFocusStatus>
                         <Td width={10} {...getTdProps({ columnKey: "cvss" })}>
                           <SeverityShieldAndText
                             value={extendedSeverityFromSeverity(

--- a/client/src/app/pages/sbom-list/sbom-table.tsx
+++ b/client/src/app/pages/sbom-list/sbom-table.tsx
@@ -100,7 +100,11 @@ export const SbomTable: React.FC = () => {
                     >
                       {item.authors.join(", ")}
                     </Td>
-                    <Td width={10} {...getTdProps({ columnKey: "published" })}>
+                    <Td
+                      width={10}
+                      modifier="truncate"
+                      {...getTdProps({ columnKey: "published" })}
+                    >
                       {formatDate(item.published)}
                     </Td>
                     <Td width={10} {...getTdProps({ columnKey: "packages" })}>

--- a/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
@@ -147,14 +147,14 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
                         {item?.sbom?.name}
                       </Link>
                     </Td>
-                    <Td width={10} {...getTdProps({ columnKey: "version" })}>
-                      {item.sbom?.version}
-                    </Td>
                     <Td
                       width={10}
                       modifier="truncate"
-                      {...getTdProps({ columnKey: "status" })}
+                      {...getTdProps({ columnKey: "version" })}
                     >
+                      {item.sbom?.version}
+                    </Td>
+                    <Td width={10} {...getTdProps({ columnKey: "status" })}>
                       <VulnerabilityStatusLabel value={item.sbomStatus} />
                     </Td>
                     <Td
@@ -168,7 +168,11 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
                     >
                       {item.relatedPackages.length}
                     </Td>
-                    <Td width={10} {...getTdProps({ columnKey: "supplier" })}>
+                    <Td
+                      width={10}
+                      modifier="truncate"
+                      {...getTdProps({ columnKey: "supplier" })}
+                    >
                       {item?.sbom?.authors.join(", ")}
                     </Td>
                     <Td

--- a/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
@@ -1,7 +1,15 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
 
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import {
+  Table,
+  TableText,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@patternfly/react-table";
 
 import { extendedSeverityFromSeverity } from "@app/api/models";
 import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
@@ -14,6 +22,7 @@ import {
 import { VulnerabilityDescription } from "@app/components/VulnerabilityDescription";
 import { formatDate } from "@app/utils/utils";
 
+import { TdWithFocusStatus } from "@app/components/TdWithFocusStatus";
 import { SbomsCount } from "./components/SbomsCount";
 import { VulnerabilitySearchContext } from "./vulnerability-context";
 
@@ -74,13 +83,25 @@ export const VulnerabilityTable: React.FC = () => {
                         {item.identifier}
                       </NavLink>
                     </Td>
-                    <Td
-                      width={45}
-                      modifier="truncate"
-                      {...getTdProps({ columnKey: "title" })}
-                    >
-                      <VulnerabilityDescription vulnerability={item} />
-                    </Td>
+                    <TdWithFocusStatus>
+                      {(isFocused, setIsFocused) => (
+                        <Td
+                          width={45}
+                          modifier="truncate"
+                          onFocus={() => setIsFocused(true)}
+                          onBlur={() => setIsFocused(false)}
+                          tabIndex={0}
+                          {...getTdProps({ columnKey: "title" })}
+                        >
+                          <TableText
+                            focused={isFocused}
+                            wrapModifier="truncate"
+                          >
+                            <VulnerabilityDescription vulnerability={item} />
+                          </TableText>
+                        </Td>
+                      )}
+                    </TdWithFocusStatus>
                     <Td width={10} {...getTdProps({ columnKey: "severity" })}>
                       <SeverityShieldAndText
                         value={extendedSeverityFromSeverity(


### PR DESCRIPTION
Resolves: https://github.com/trustification/trustify-ui/issues/422

- Added the "truncate" modifier to some columns "td". It was easy, just to add `modifier=truncate`
- If a column renders another component that is not a String, then `modifier=truncate` won't work. So following the docs from https://v5-archive.patternfly.org/components/table#modifiers-with-table-text . I created the Component `TdWithFocusStatus` and apply tooltips for those special columns

