### PR TITLE
:sparkles: Add Spinner to Search Page Tabs

### DIFF
--- a/client/src/app/pages/search/components/SearchTabs.tsx
+++ b/client/src/app/pages/search/components/SearchTabs.tsx
@@ -4,6 +4,7 @@ import {
   Badge,
   Card,
   CardBody,
+  Icon,
   Popover,
   Split,
   SplitItem,
@@ -13,6 +14,7 @@ import {
   Tabs,
 } from "@patternfly/react-core";
 import HelpIcon from "@patternfly/react-icons/dist/esm/icons/help-icon";
+import SpinnerIcon from "@patternfly/react-icons/dist/esm/icons/spinner-icon";
 
 import type {
   AdvisorySummary,
@@ -45,14 +47,22 @@ export interface SearchTabsProps {
       "" | "average_severity" | "published"
     >;
   };
+
   packageTable?: ReactElement;
   packageTotalCount: number;
+  isFetchingPackages: boolean;
+
   sbomTable?: ReactElement;
   sbomTotalCount: number;
+  isFetchingSboms: boolean;
+
   vulnerabilityTable?: ReactElement;
   vulnerabilityTotalCount: number;
+  isFetchingVulnerabilities: boolean;
+
   advisoryTable?: ReactNode;
   advisoryTotalCount: number;
+  isFetchingAdvisories: boolean;
 }
 
 export const SearchTabs: React.FC<SearchTabsProps> = ({
@@ -65,6 +75,10 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
   vulnerabilityTotalCount,
   advisoryTable,
   advisoryTotalCount,
+  isFetchingPackages,
+  isFetchingSboms,
+  isFetchingVulnerabilities,
+  isFetchingAdvisories,
 }) => {
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
   const {
@@ -138,7 +152,13 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
               <TabTitleText>
                 SBOMs{"  "}
                 <Badge screenReaderText="Search Result Count">
-                  {sbomTotalCount}
+                  {isFetchingSboms ? (
+                    <Icon size="sm">
+                      <SpinnerIcon />
+                    </Icon>
+                  ) : (
+                    sbomTotalCount
+                  )}
                 </Badge>
               </TabTitleText>
             }
@@ -159,7 +179,13 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
               <TabTitleText>
                 Packages{"  "}
                 <Badge screenReaderText="Search Result Count">
-                  {packageTotalCount}
+                  {isFetchingPackages ? (
+                    <Icon size="sm">
+                      <SpinnerIcon />
+                    </Icon>
+                  ) : (
+                    packageTotalCount
+                  )}
                 </Badge>
               </TabTitleText>
             }
@@ -172,7 +198,13 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
               <TabTitleText>
                 Vulnerabilities{"  "}
                 <Badge screenReaderText="Search Result Count">
-                  {vulnerabilityTotalCount}
+                  {isFetchingVulnerabilities ? (
+                    <Icon size="sm">
+                      <SpinnerIcon />
+                    </Icon>
+                  ) : (
+                    vulnerabilityTotalCount
+                  )}
                 </Badge>
               </TabTitleText>
             }
@@ -185,7 +217,13 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
               <TabTitleText>
                 Advisories{"  "}
                 <Badge screenReaderText="Advisory Result Count">
-                  {advisoryTotalCount}
+                  {isFetchingAdvisories ? (
+                    <Icon size="sm">
+                      <SpinnerIcon />
+                    </Icon>
+                  ) : (
+                    advisoryTotalCount
+                  )}
                 </Badge>
               </TabTitleText>
             }

--- a/client/src/app/pages/search/search.tsx
+++ b/client/src/app/pages/search/search.tsx
@@ -49,6 +49,7 @@ export const Search: React.FC<SearchPageProps> = ({ searchBodyOverride }) => {
   );
 
   const {
+    isFetching: isFetchingSboms,
     totalItemCount: sbomTotalCount,
     tableControls: {
       propHelpers: { filterPanelProps: sbomFilterPanelProps },
@@ -56,6 +57,7 @@ export const Search: React.FC<SearchPageProps> = ({ searchBodyOverride }) => {
   } = React.useContext(SbomSearchContext);
 
   const {
+    isFetching: isFetchingPackages,
     totalItemCount: packageTotalCount,
     tableControls: {
       propHelpers: { filterPanelProps: packageFilterPanelProps },
@@ -63,6 +65,7 @@ export const Search: React.FC<SearchPageProps> = ({ searchBodyOverride }) => {
   } = React.useContext(PackageSearchContext);
 
   const {
+    isFetching: isFetchingVulnerabilities,
     totalItemCount: vulnerabilityTotalCount,
     tableControls: {
       propHelpers: { filterPanelProps: vulnerabilityFilterPanelProps },
@@ -70,6 +73,7 @@ export const Search: React.FC<SearchPageProps> = ({ searchBodyOverride }) => {
   } = React.useContext(VulnerabilitySearchContext);
 
   const {
+    isFetching: isFetchingAdvisories,
     totalItemCount: advisoryTotalCount,
     tableControls: {
       propHelpers: { filterPanelProps: advisoryFilterPanelProps },
@@ -112,6 +116,10 @@ export const Search: React.FC<SearchPageProps> = ({ searchBodyOverride }) => {
       sbomTotalCount={sbomTotalCount}
       vulnerabilityTotalCount={vulnerabilityTotalCount}
       advisoryTotalCount={advisoryTotalCount}
+      isFetchingPackages={isFetchingPackages}
+      isFetchingSboms={isFetchingSboms}
+      isFetchingVulnerabilities={isFetchingVulnerabilities}
+      isFetchingAdvisories={isFetchingAdvisories}
     />
   );
 


### PR DESCRIPTION
Resolves https://github.com/trustification/trustify-ui/issues/352

The Search page now has Spinners on the Tabs

![image](https://github.com/user-attachments/assets/09624044-294f-466a-b4d0-2535f29f6eee)
