### PR TITLE
:sparkles: apply breakword to long names on main table column

### DIFF
--- a/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
+++ b/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
@@ -106,7 +106,11 @@ export const VulnerabilitiesByAdvisory: React.FC<
                     item={item}
                     rowIndex={rowIndex}
                   >
-                    <Td width={15} {...getTdProps({ columnKey: "identifier" })}>
+                    <Td
+                      width={15}
+                      modifier="breakWord"
+                      {...getTdProps({ columnKey: "identifier" })}
+                    >
                       <Link to={`/vulnerabilities/${item.identifier}`}>
                         {item.identifier}
                       </Link>

--- a/client/src/app/pages/advisory-list/advisory-table.tsx
+++ b/client/src/app/pages/advisory-list/advisory-table.tsx
@@ -99,6 +99,7 @@ export const AdvisoryTable: React.FC = () => {
                   >
                     <Td
                       width={15}
+                      modifier="breakWord"
                       {...getTdProps({
                         columnKey: "identifier",
                         isCompoundExpandToggle: true,

--- a/client/src/app/pages/package-details/sboms-by-package.tsx
+++ b/client/src/app/pages/package-details/sboms-by-package.tsx
@@ -118,7 +118,11 @@ export const SbomsByPackage: React.FC<SbomsByPackageProps> = ({ purl }) => {
             return (
               <Tbody key={item.id}>
                 <Tr {...getTrProps({ item })}>
-                  <Td width={35} {...getTdProps({ columnKey: "name" })}>
+                  <Td
+                    width={35}
+                    modifier="breakWord"
+                    {...getTdProps({ columnKey: "name" })}
+                  >
                     <Link to={`/sboms/${item.id}`}>{item.name}</Link>
                   </Td>
                   <Td

--- a/client/src/app/pages/package-details/vulnerabilities-by-package.tsx
+++ b/client/src/app/pages/package-details/vulnerabilities-by-package.tsx
@@ -130,7 +130,11 @@ export const VulnerabilitiesByPackage: React.FC<
                     item={item}
                     rowIndex={rowIndex}
                   >
-                    <Td width={15} {...getTdProps({ columnKey: "identifier" })}>
+                    <Td
+                      width={15}
+                      modifier="breakWord"
+                      {...getTdProps({ columnKey: "identifier" })}
+                    >
                       <Link
                         to={`/vulnerabilities/${item.vulnerability.identifier}`}
                       >

--- a/client/src/app/pages/package-list/package-table.tsx
+++ b/client/src/app/pages/package-list/package-table.tsx
@@ -61,7 +61,11 @@ export const PackageTable: React.FC = () => {
                     item={item}
                     rowIndex={rowIndex}
                   >
-                    <Td width={15} {...getTdProps({ columnKey: "name" })}>
+                    <Td
+                      width={15}
+                      modifier="breakWord"
+                      {...getTdProps({ columnKey: "name" })}
+                    >
                       <NavLink to={`/packages/${item.uuid}`}>
                         {item.decomposedPurl
                           ? item.decomposedPurl?.name

--- a/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
@@ -267,7 +267,11 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
                         item={item}
                         rowIndex={rowIndex}
                       >
-                        <Td width={15} {...getTdProps({ columnKey: "id" })}>
+                        <Td
+                          width={15}
+                          modifier="breakWord"
+                          {...getTdProps({ columnKey: "id" })}
+                        >
                           <Link
                             to={`/vulnerabilities/${item.vulnerability.identifier}`}
                           >

--- a/client/src/app/pages/sbom-list/sbom-table.tsx
+++ b/client/src/app/pages/sbom-list/sbom-table.tsx
@@ -74,6 +74,7 @@ export const SbomTable: React.FC = () => {
                   >
                     <Td
                       width={25}
+                      modifier="breakWord"
                       {...getTdProps({
                         columnKey: "name",
                         isCompoundExpandToggle: true,

--- a/client/src/app/pages/vulnerability-details/advisories-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/advisories-by-vulnerability.tsx
@@ -108,7 +108,11 @@ export const AdvisoriesByVulnerability: React.FC<
             {currentPageItems?.map((item) => {
               return (
                 <Tr key={item.identifier} {...getTrProps({ item })}>
-                  <Td width={15} {...getTdProps({ columnKey: "identifier" })}>
+                  <Td
+                    width={15}
+                    modifier="breakWord"
+                    {...getTdProps({ columnKey: "identifier" })}
+                  >
                     <Link to={`/advisories/${item.uuid}`}>
                       {item.document_id}
                     </Link>

--- a/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
@@ -142,7 +142,11 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
                     item={item}
                     rowIndex={rowIndex}
                   >
-                    <Td width={25} {...getTdProps({ columnKey: "name" })}>
+                    <Td
+                      width={25}
+                      modifier="breakWord"
+                      {...getTdProps({ columnKey: "name" })}
+                    >
                       <Link to={`/sboms/${item.sbom.id}`}>
                         {item?.sbom?.name}
                       </Link>

--- a/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
@@ -64,6 +64,7 @@ export const VulnerabilityTable: React.FC = () => {
                   >
                     <Td
                       width={15}
+                      modifier="breakWord"
                       {...getTdProps({
                         columnKey: "identifier",
                         item: item,


### PR DESCRIPTION
Resolves https://github.com/trustification/trustify-ui/issues/395

If the table contains a link to another page then we should not truncate the column as tooltips won't popup. We should render the whole word instead even if it increases the vertical size of the row.