### PR TITLE
:seedling:  Introduce TS Checking on building

### DIFF
--- a/client/rsbuild.config.ts
+++ b/client/rsbuild.config.ts
@@ -96,9 +96,9 @@ export default defineConfig({
             ({ file = "" }) => /\/stories\//.test(file),
             ({ file = "" }) => /\/mocks\//.test(file),
             ({ file = "" }) => /\/src\/app\/client\/[^/]+\.ts$/.test(file),
-          ]
-        }
-      }
+          ],
+        },
+      },
     }),
     renameIndex(),
     ignoreProcessEnv(),

--- a/client/rsbuild.config.ts
+++ b/client/rsbuild.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from "@rsbuild/core";
 import { pluginReact } from "@rsbuild/plugin-react";
 
 import type { RsbuildPlugin } from "@rsbuild/core";
+import { pluginTypeCheck } from "@rsbuild/plugin-type-check";
 
 import {
   SERVER_ENV_KEYS,
@@ -83,7 +84,25 @@ export const ignoreProcessEnv = (): RsbuildPlugin => ({
 });
 
 export default defineConfig({
-  plugins: [pluginReact(), renameIndex(), ignoreProcessEnv()],
+  plugins: [
+    pluginReact(),
+    pluginTypeCheck({
+      enable: process.env.NODE_ENV === "production",
+      tsCheckerOptions: {
+        issue: {
+          exclude: [
+            ({ file = "" }) => /[\\/]node_modules[\\/]/.test(file),
+            ({ file = "" }) => /^.*\/[^/]+\.stories\.tsx$/.test(file),
+            ({ file = "" }) => /\/stories\//.test(file),
+            ({ file = "" }) => /\/mocks\//.test(file),
+            ({ file = "" }) => /\/src\/app\/client\/[^/]+\.ts$/.test(file),
+          ]
+        }
+      }
+    }),
+    renameIndex(),
+    ignoreProcessEnv(),
+  ],
   html: {
     template: path.join(__dirname, "index.html"),
     templateParameters: {

--- a/client/src/app/components/VulnerabilityGallery.tsx
+++ b/client/src/app/components/VulnerabilityGallery.tsx
@@ -50,7 +50,7 @@ export const VulnerabilityGallery: React.FC<VulnerabilityGalleryProps> = ({
                   <FlexItem>
                     <SeverityShieldAndText
                       value={severity as ExtendedSeverity}
-                      hideLabel
+                      score={null}
                     />
                   </FlexItem>
                   <FlexItem>{count}</FlexItem>


### PR DESCRIPTION
RSBuild does not do deep checking by default. See docs here https://rsbuild.dev/guide/basic/typescript#type-checking

- Checking types at buildtime will help us identify errors like the `client/src/app/components/VulnerabilityGallery.tsx` change this PR includes
- This PR enables it only to `npm run build` and not to `npm run start:dev`.
  - I played with enabling it for dev mode and it becomes annoying the compiler to keep throwing errors when you are create big chunks of code as of course there is gonna be plenty of code that might contain minor breaking rules. 
  - Leaving things as they are for dev mode and only enforcing to building will help us IMO