### PR TITLE
:bug: [TC-2353] fix reduce function on fixUseVulnerabilitiesOfSbom

### DIFF
--- a/client/src/app/hooks/domain-controls/useSbomsOfVulnerability.ts
+++ b/client/src/app/hooks/domain-controls/useSbomsOfVulnerability.ts
@@ -42,67 +42,65 @@ const DEFAULT_SUMMARY: SbomOfVulnerabilitySummary = {
 };
 
 const advisoryToModels = (advisories: VulnerabilityAdvisorySummary[]) => {
-  const sboms = advisories.flatMap((advisory) => {
-    return (
-      (advisory.sboms ?? [])
-        .flatMap((sbomStatuses) => {
-          return Object.entries(sbomStatuses.purl_statuses || {}).map(
-            ([status, packages]) => {
-              const result: FlatSbomOfVulnerability = {
-                sbom: {
-                  ...sbomStatuses,
-                },
-                sbomStatus: status as VulnerabilityStatus,
-                advisory: advisory,
-                packages: packages,
-              };
-              return result;
+  const sboms = advisories
+    .flatMap((advisory) => {
+      return (advisory.sboms ?? []).flatMap((sbomStatuses) => {
+        return Object.entries(sbomStatuses.purl_statuses || {}).map(
+          ([status, packages]) => {
+            const result: FlatSbomOfVulnerability = {
+              sbom: {
+                ...sbomStatuses,
+              },
+              sbomStatus: status as VulnerabilityStatus,
+              advisory: advisory,
+              packages: packages,
+            };
+            return result;
+          },
+        );
+      });
+    })
+    // group
+    .reduce((prev, current) => {
+      const existingElement = prev.find((item) => {
+        return areSbomOfVulnerabilityEqual(item, current);
+      });
+
+      let result: SbomOfVulnerability[];
+
+      if (existingElement) {
+        const arrayWithoutExistingItem = prev.filter(
+          (item) => !areSbomOfVulnerabilityEqual(item, existingElement),
+        );
+
+        const updatedItemInArray: SbomOfVulnerability = {
+          ...existingElement,
+          relatedPackages: [
+            ...existingElement.relatedPackages,
+            {
+              advisory: current.advisory,
+              packages: current.packages,
             },
-          );
-        })
-        // group
-        .reduce((prev, current) => {
-          const existingElement = prev.find((item) => {
-            return areSbomOfVulnerabilityEqual(item, current);
-          });
+          ],
+        };
 
-          let result: SbomOfVulnerability[];
+        result = [...arrayWithoutExistingItem, updatedItemInArray];
+      } else {
+        const newItemInArray: SbomOfVulnerability = {
+          sbom: current.sbom,
+          sbomStatus: current.sbomStatus,
+          relatedPackages: [
+            {
+              advisory: current.advisory,
+              packages: current.packages,
+            },
+          ],
+        };
+        result = [...prev.slice(), newItemInArray];
+      }
 
-          if (existingElement) {
-            const arrayWithoutExistingItem = prev.filter(
-              (item) => !areSbomOfVulnerabilityEqual(item, existingElement),
-            );
-
-            const updatedItemInArray: SbomOfVulnerability = {
-              ...existingElement,
-              relatedPackages: [
-                ...existingElement.relatedPackages,
-                {
-                  advisory: current.advisory,
-                  packages: current.packages,
-                },
-              ],
-            };
-
-            result = [...arrayWithoutExistingItem, updatedItemInArray];
-          } else {
-            const newItemInArray: SbomOfVulnerability = {
-              sbom: current.sbom,
-              sbomStatus: current.sbomStatus,
-              relatedPackages: [
-                {
-                  advisory: current.advisory,
-                  packages: current.packages,
-                },
-              ],
-            };
-            result = [...prev.slice(), newItemInArray];
-          }
-
-          return result;
-        }, [] as SbomOfVulnerability[])
-    );
-  });
+      return result;
+    }, [] as SbomOfVulnerability[]);
 
   const summary = sboms.reduce(
     (prev, current) => {

--- a/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
+++ b/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
@@ -63,61 +63,59 @@ const DEFAULT_SUMMARY: VulnerabilityOfSbomSummary = {
 };
 
 const advisoryToModels = (advisories: SbomAdvisory[]) => {
-  const vulnerabilities = advisories.flatMap((advisory) => {
-    return (
-      (advisory.status ?? [])
-        .map((sbomStatus) => {
-          const result: FlatVulnerabilityOfSbom = {
-            vulnerability: sbomStatus,
-            vulnerabilityStatus: sbomStatus.status as VulnerabilityStatus,
-            advisory: advisory,
-            packages: sbomStatus.packages,
-          };
-          return result;
-        })
-        // group
-        .reduce((prev, current) => {
-          const existingElement = prev.find((item) => {
-            return areVulnerabilityOfSbomEqual(item, current);
-          });
+  const vulnerabilities = advisories
+    .flatMap((advisory) => {
+      return (advisory.status ?? []).map((sbomStatus) => {
+        const result: FlatVulnerabilityOfSbom = {
+          vulnerability: sbomStatus,
+          vulnerabilityStatus: sbomStatus.status as VulnerabilityStatus,
+          advisory: advisory,
+          packages: sbomStatus.packages,
+        };
+        return result;
+      });
+    })
+    // group
+    .reduce((prev, current) => {
+      const existingElement = prev.find((item) => {
+        return areVulnerabilityOfSbomEqual(item, current);
+      });
 
-          let result: VulnerabilityOfSbom[];
+      let result: VulnerabilityOfSbom[];
 
-          if (existingElement) {
-            const arrayWithoutExistingItem = prev.filter(
-              (item) => !areVulnerabilityOfSbomEqual(item, existingElement),
-            );
+      if (existingElement) {
+        const arrayWithoutExistingItem = prev.filter(
+          (item) => !areVulnerabilityOfSbomEqual(item, existingElement),
+        );
 
-            const updatedItemInArray: VulnerabilityOfSbom = {
-              ...existingElement,
-              relatedPackages: [
-                ...existingElement.relatedPackages,
-                {
-                  advisory: current.advisory,
-                  packages: current.packages,
-                },
-              ],
-            };
+        const updatedItemInArray: VulnerabilityOfSbom = {
+          ...existingElement,
+          relatedPackages: [
+            ...existingElement.relatedPackages,
+            {
+              advisory: current.advisory,
+              packages: current.packages,
+            },
+          ],
+        };
 
-            result = [...arrayWithoutExistingItem, updatedItemInArray];
-          } else {
-            const newItemInArray: VulnerabilityOfSbom = {
-              vulnerability: current.vulnerability,
-              vulnerabilityStatus: current.vulnerabilityStatus,
-              relatedPackages: [
-                {
-                  advisory: current.advisory,
-                  packages: current.packages,
-                },
-              ],
-            };
-            result = [...prev.slice(), newItemInArray];
-          }
+        result = [...arrayWithoutExistingItem, updatedItemInArray];
+      } else {
+        const newItemInArray: VulnerabilityOfSbom = {
+          vulnerability: current.vulnerability,
+          vulnerabilityStatus: current.vulnerabilityStatus,
+          relatedPackages: [
+            {
+              advisory: current.advisory,
+              packages: current.packages,
+            },
+          ],
+        };
+        result = [...prev.slice(), newItemInArray];
+      }
 
-          return result;
-        }, [] as VulnerabilityOfSbom[])
-    );
-  });
+      return result;
+    }, [] as VulnerabilityOfSbom[]);
 
   const summary = vulnerabilities.reduce(
     (prev, current) => {


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2353

I discovered that all `reduce` functions associated to the files touched in the PR were applied to the wrong level causing the wrong results. Besides moving the `reduce` level this PR does not touch any other code.

Before:
```ts
array.flatMap(() => {
   return anotherArray
              // group
               .reduce(() => {});
})
```

After 

```ts
array.flatMap(() => {
   return anotherArray
})
// group
.reduce(() => {});
```