### PR TITLE
:bug: [TC-2374] dashboard - add advisory link

### DIFF
--- a/client/src/app/pages/home/components/MonitoringSection.tsx
+++ b/client/src/app/pages/home/components/MonitoringSection.tsx
@@ -294,7 +294,13 @@ export const MonitoringSection: React.FC = () => {
                           <StackItem>
                             {formatDateTime(advisories?.[0]?.ingested)}
                           </StackItem>
-                          <StackItem>{advisories?.[0]?.identifier}</StackItem>
+                          <StackItem>
+                            <Link
+                              to={`/advisories/${advisories?.[0]?.uuid}`}
+                            >
+                              {advisories?.[0]?.document_id}
+                            </Link>
+                          </StackItem>
                         </Stack>
                       </DescriptionListDescription>
                     </DescriptionListGroup>

--- a/client/src/app/pages/home/components/MonitoringSection.tsx
+++ b/client/src/app/pages/home/components/MonitoringSection.tsx
@@ -295,9 +295,7 @@ export const MonitoringSection: React.FC = () => {
                             {formatDateTime(advisories?.[0]?.ingested)}
                           </StackItem>
                           <StackItem>
-                            <Link
-                              to={`/advisories/${advisories?.[0]?.uuid}`}
-                            >
+                            <Link to={`/advisories/${advisories?.[0]?.uuid}`}>
                               {advisories?.[0]?.document_id}
                             </Link>
                           </StackItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2374

- Add a Link to the advisory name to allow navigation
- Switch `advisories?.[0]?.identifier` by `advisories?.[0]?.document_id` as `document_id` is what we are using in the Advisory List Page and also because `advisories?.[0]?.identifier` can sometimes contain values as a URL which is not what we want to render