### PR TITLE
:sparkles: add top pagination to tables in search page & disable compact pagination on bottom tables

### DIFF
--- a/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
+++ b/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
@@ -184,7 +184,6 @@ export const VulnerabilitiesByAdvisory: React.FC<
       <SimplePagination
         idPrefix="vulnerability-table"
         isTop={false}
-        isCompact
         paginationProps={paginationProps}
       />
     </>

--- a/client/src/app/pages/advisory-list/advisory-list.tsx
+++ b/client/src/app/pages/advisory-list/advisory-list.tsx
@@ -26,7 +26,7 @@ export const AdvisoryList: React.FC = () => {
           }}
         >
           <AdvisorySearchProvider>
-            <AdvisoryToolbar />
+            <AdvisoryToolbar showFilters />
             <AdvisoryTable />
           </AdvisorySearchProvider>
         </div>

--- a/client/src/app/pages/advisory-list/advisory-table.tsx
+++ b/client/src/app/pages/advisory-list/advisory-table.tsx
@@ -174,7 +174,6 @@ export const AdvisoryTable: React.FC = () => {
       <SimplePagination
         idPrefix="advisory-table"
         isTop={false}
-        isCompact
         paginationProps={paginationProps}
       />
     </>

--- a/client/src/app/pages/advisory-list/advisory-toolbar.tsx
+++ b/client/src/app/pages/advisory-list/advisory-toolbar.tsx
@@ -7,7 +7,13 @@ import { SimplePagination } from "@app/components/SimplePagination";
 
 import { AdvisorySearchContext } from "./advisory-context";
 
-export const AdvisoryToolbar: React.FC = () => {
+interface AdvisoryToolbarProps {
+  showFilters?: boolean;
+}
+
+export const AdvisoryToolbar: React.FC<AdvisoryToolbarProps> = ({
+  showFilters,
+}) => {
   const { tableControls } = React.useContext(AdvisorySearchContext);
 
   const {
@@ -23,7 +29,7 @@ export const AdvisoryToolbar: React.FC = () => {
     <>
       <Toolbar {...toolbarProps}>
         <ToolbarContent>
-          <FilterToolbar {...filterToolbarProps} />
+          {showFilters && <FilterToolbar {...filterToolbarProps} />}
           <ToolbarItem {...paginationToolbarItemProps}>
             <SimplePagination
               idPrefix="advisory-table"

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -437,7 +437,6 @@ export const ImporterList: React.FC = () => {
           <SimplePagination
             idPrefix="importer-table"
             isTop={false}
-            isCompact
             paginationProps={paginationProps}
           />
         </div>
@@ -753,7 +752,6 @@ export const ImporterExpandedArea: React.FC<ImporterExpandedAreaProps> = ({
       <SimplePagination
         idPrefix="report-table"
         isTop={false}
-        isCompact
         paginationProps={paginationProps}
       />
 

--- a/client/src/app/pages/package-details/sboms-by-package.tsx
+++ b/client/src/app/pages/package-details/sboms-by-package.tsx
@@ -148,7 +148,6 @@ export const SbomsByPackage: React.FC<SbomsByPackageProps> = ({ purl }) => {
       <SimplePagination
         idPrefix="sbom-table"
         isTop={false}
-        isCompact
         paginationProps={paginationProps}
       />
     </>

--- a/client/src/app/pages/package-details/vulnerabilities-by-package.tsx
+++ b/client/src/app/pages/package-details/vulnerabilities-by-package.tsx
@@ -200,7 +200,6 @@ export const VulnerabilitiesByPackage: React.FC<
       <SimplePagination
         idPrefix="vulnerability-table"
         isTop={false}
-        isCompact
         paginationProps={paginationProps}
       />
     </>

--- a/client/src/app/pages/package-list/package-list.tsx
+++ b/client/src/app/pages/package-list/package-list.tsx
@@ -26,7 +26,7 @@ export const PackageList: React.FC = () => {
           }}
         >
           <PackageSearchProvider>
-            <PackageToolbar />
+            <PackageToolbar showFilters />
             <PackageTable />
           </PackageSearchProvider>
         </div>

--- a/client/src/app/pages/package-list/package-table.tsx
+++ b/client/src/app/pages/package-list/package-table.tsx
@@ -123,7 +123,6 @@ export const PackageTable: React.FC = () => {
       <SimplePagination
         idPrefix="package-table"
         isTop={false}
-        isCompact
         paginationProps={paginationProps}
       />
     </>

--- a/client/src/app/pages/package-list/package-toolbar.tsx
+++ b/client/src/app/pages/package-list/package-toolbar.tsx
@@ -7,7 +7,13 @@ import { SimplePagination } from "@app/components/SimplePagination";
 
 import { PackageSearchContext } from "./package-context";
 
-export const PackageToolbar: React.FC = () => {
+interface PackageToolbarProps {
+  showFilters?: boolean;
+}
+
+export const PackageToolbar: React.FC<PackageToolbarProps> = ({
+  showFilters,
+}) => {
   const { tableControls } = React.useContext(PackageSearchContext);
 
   const {
@@ -22,7 +28,7 @@ export const PackageToolbar: React.FC = () => {
   return (
     <Toolbar {...toolbarProps}>
       <ToolbarContent>
-        <FilterToolbar {...filterToolbarProps} />
+        {showFilters && <FilterToolbar {...filterToolbarProps} />}
         <ToolbarItem {...paginationToolbarItemProps}>
           <SimplePagination
             idPrefix="package-table"

--- a/client/src/app/pages/sbom-details/packages-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/packages-by-sbom.tsx
@@ -200,7 +200,6 @@ export const PackagesBySbom: React.FC<PackagesProps> = ({ sbomId }) => {
       <SimplePagination
         idPrefix="package-table"
         isTop={false}
-        isCompact
         paginationProps={paginationProps}
       />
     </>

--- a/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
@@ -451,7 +451,6 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
           <SimplePagination
             idPrefix="vulnerability-table"
             isTop={false}
-            isCompact
             paginationProps={paginationProps}
           />
         </StackItem>

--- a/client/src/app/pages/sbom-list/sbom-list.tsx
+++ b/client/src/app/pages/sbom-list/sbom-list.tsx
@@ -26,7 +26,7 @@ export const SbomList: React.FC = () => {
           }}
         >
           <SbomSearchProvider>
-            <SbomToolbar />
+            <SbomToolbar showFilters />
             <SbomTable />
           </SbomSearchProvider>
         </div>

--- a/client/src/app/pages/sbom-list/sbom-table.tsx
+++ b/client/src/app/pages/sbom-list/sbom-table.tsx
@@ -145,7 +145,6 @@ export const SbomTable: React.FC = () => {
       <SimplePagination
         idPrefix="sbom-table"
         isTop={false}
-        isCompact
         paginationProps={paginationProps}
       />
     </>

--- a/client/src/app/pages/sbom-list/sbom-toolbar.tsx
+++ b/client/src/app/pages/sbom-list/sbom-toolbar.tsx
@@ -7,7 +7,11 @@ import { SimplePagination } from "@app/components/SimplePagination";
 
 import { SbomSearchContext } from "./sbom-context";
 
-export const SbomToolbar: React.FC = () => {
+interface SbomToolbarProps {
+  showFilters?: boolean;
+}
+
+export const SbomToolbar: React.FC<SbomToolbarProps> = ({ showFilters }) => {
   const { tableControls } = React.useContext(SbomSearchContext);
 
   const {
@@ -23,7 +27,7 @@ export const SbomToolbar: React.FC = () => {
     <>
       <Toolbar {...toolbarProps}>
         <ToolbarContent>
-          <FilterToolbar {...filterToolbarProps} />
+          {showFilters && <FilterToolbar {...filterToolbarProps} />}
           <ToolbarItem {...paginationToolbarItemProps}>
             <SimplePagination
               idPrefix="sbom-table"

--- a/client/src/app/pages/search/components/SearchTabs.tsx
+++ b/client/src/app/pages/search/components/SearchTabs.tsx
@@ -26,10 +26,14 @@ import {
   type IFilterPanelProps,
 } from "@app/components/FilterPanel";
 import { AdvisoryTable } from "@app/pages/advisory-list/advisory-table";
+import { AdvisoryToolbar } from "@app/pages/advisory-list/advisory-toolbar";
 import type { PackageTableData } from "@app/pages/package-list/package-context";
 import { PackageTable } from "@app/pages/package-list/package-table";
+import { PackageToolbar } from "@app/pages/package-list/package-toolbar";
 import { SbomTable } from "@app/pages/sbom-list/sbom-table";
+import { SbomToolbar } from "@app/pages/sbom-list/sbom-toolbar";
 import { VulnerabilityTable } from "@app/pages/vulnerability-list/vulnerability-table";
+import { VulnerabilityToolbar } from "@app/pages/vulnerability-list/vulnerability-toolbar";
 
 export interface SearchTabsProps {
   filterPanelProps: {
@@ -170,6 +174,7 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
               </>
             }
           >
+            <SbomToolbar />
             {sbomTable ?? <SbomTable />}
           </Tab>
           <Tab
@@ -189,6 +194,7 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
               </TabTitleText>
             }
           >
+            <PackageToolbar />
             {packageTable ?? <PackageTable />}
           </Tab>
           <Tab
@@ -208,6 +214,7 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
               </TabTitleText>
             }
           >
+            <VulnerabilityToolbar />
             {vulnerabilityTable ?? <VulnerabilityTable />}
           </Tab>
           <Tab
@@ -227,6 +234,7 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
               </TabTitleText>
             }
           >
+            <AdvisoryToolbar />
             {advisoryTable ?? <AdvisoryTable />}
           </Tab>
         </Tabs>

--- a/client/src/app/pages/vulnerability-details/advisories-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/advisories-by-vulnerability.tsx
@@ -164,7 +164,6 @@ export const AdvisoriesByVulnerability: React.FC<
       <SimplePagination
         idPrefix="advisory-table"
         isTop={false}
-        isCompact
         paginationProps={paginationProps}
       />
     </>

--- a/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
@@ -253,7 +253,6 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
       <SimplePagination
         idPrefix="sboms-table"
         isTop={false}
-        isCompact
         paginationProps={paginationProps}
       />
     </>

--- a/client/src/app/pages/vulnerability-list/vulnerability-list.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-list.tsx
@@ -26,7 +26,7 @@ export const VulnerabilityList: React.FC = () => {
           }}
         >
           <VulnerabilitySearchProvider>
-            <VulnerabilityToolbar />
+            <VulnerabilityToolbar showFilters />
             <VulnerabilityTable />
           </VulnerabilitySearchProvider>
         </div>

--- a/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
@@ -136,7 +136,6 @@ export const VulnerabilityTable: React.FC = () => {
       <SimplePagination
         idPrefix="vulnerability-table"
         isTop={false}
-        isCompact
         paginationProps={paginationProps}
       />
     </>

--- a/client/src/app/pages/vulnerability-list/vulnerability-toolbar.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-toolbar.tsx
@@ -7,7 +7,13 @@ import { SimplePagination } from "@app/components/SimplePagination";
 
 import { VulnerabilitySearchContext } from "./vulnerability-context";
 
-export const VulnerabilityToolbar: React.FC = () => {
+interface VulnerabilityToolbarProps {
+  showFilters?: boolean;
+}
+
+export const VulnerabilityToolbar: React.FC<VulnerabilityToolbarProps> = ({
+  showFilters,
+}) => {
   const { tableControls } = React.useContext(VulnerabilitySearchContext);
 
   const {
@@ -22,7 +28,7 @@ export const VulnerabilityToolbar: React.FC = () => {
   return (
     <Toolbar {...toolbarProps}>
       <ToolbarContent>
-        <FilterToolbar {...filterToolbarProps} />
+        {showFilters && <FilterToolbar {...filterToolbarProps} />}
         <ToolbarItem {...paginationToolbarItemProps}>
           <SimplePagination
             idPrefix="vulnerability-table"


### PR DESCRIPTION
- Now all tables within the Search page should have pagination on top of the table.
- Also all paginations in the bottom do not have the COMPACT variant any more as requested at https://issues.redhat.com/browse/TC-2348

![image](https://github.com/user-attachments/assets/e6a2d81e-a074-451f-8213-e836ee293845)
