### PR TITLE
:bug: [TC-2390] fix vulnerability-sboms table count of dependencies & render unique dependencies

### DIFF
--- a/client/src/app/hooks/domain-controls/useSbomsOfVulnerability.ts
+++ b/client/src/app/hooks/domain-controls/useSbomsOfVulnerability.ts
@@ -22,7 +22,7 @@ interface FlatSbomOfVulnerability {
   packages: PurlSummary[];
 }
 
-interface SbomOfVulnerability {
+export interface SbomOfVulnerability {
   sbom: VulnerabilitySbomStatus;
   sbomStatus: VulnerabilityStatus;
   relatedPackages: {

--- a/client/src/app/hooks/domain-controls/useSbomsOfVulnerability.ts
+++ b/client/src/app/hooks/domain-controls/useSbomsOfVulnerability.ts
@@ -42,67 +42,65 @@ const DEFAULT_SUMMARY: SbomOfVulnerabilitySummary = {
 };
 
 const advisoryToModels = (advisories: VulnerabilityAdvisorySummary[]) => {
-  const sboms = advisories.flatMap((advisory) => {
-    return (
-      (advisory.sboms ?? [])
-        .flatMap((sbomStatuses) => {
-          return Object.entries(sbomStatuses.purl_statuses || {}).map(
-            ([status, packages]) => {
-              const result: FlatSbomOfVulnerability = {
-                sbom: {
-                  ...sbomStatuses,
-                },
-                sbomStatus: status as VulnerabilityStatus,
-                advisory: advisory,
-                packages: packages,
-              };
-              return result;
+  const sboms = advisories
+    .flatMap((advisory) => {
+      return (advisory.sboms ?? []).flatMap((sbomStatuses) => {
+        return Object.entries(sbomStatuses.purl_statuses || {}).map(
+          ([status, packages]) => {
+            const result: FlatSbomOfVulnerability = {
+              sbom: {
+                ...sbomStatuses,
+              },
+              sbomStatus: status as VulnerabilityStatus,
+              advisory: advisory,
+              packages: packages,
+            };
+            return result;
+          },
+        );
+      });
+    })
+    // group
+    .reduce((prev, current) => {
+      const existingElement = prev.find((item) => {
+        return areSbomOfVulnerabilityEqual(item, current);
+      });
+
+      let result: SbomOfVulnerability[];
+
+      if (existingElement) {
+        const arrayWithoutExistingItem = prev.filter(
+          (item) => !areSbomOfVulnerabilityEqual(item, existingElement),
+        );
+
+        const updatedItemInArray: SbomOfVulnerability = {
+          ...existingElement,
+          relatedPackages: [
+            ...existingElement.relatedPackages,
+            {
+              advisory: current.advisory,
+              packages: current.packages,
             },
-          );
-        })
-        // group
-        .reduce((prev, current) => {
-          const existingElement = prev.find((item) => {
-            return areSbomOfVulnerabilityEqual(item, current);
-          });
+          ],
+        };
 
-          let result: SbomOfVulnerability[];
+        result = [...arrayWithoutExistingItem, updatedItemInArray];
+      } else {
+        const newItemInArray: SbomOfVulnerability = {
+          sbom: current.sbom,
+          sbomStatus: current.sbomStatus,
+          relatedPackages: [
+            {
+              advisory: current.advisory,
+              packages: current.packages,
+            },
+          ],
+        };
+        result = [...prev.slice(), newItemInArray];
+      }
 
-          if (existingElement) {
-            const arrayWithoutExistingItem = prev.filter(
-              (item) => !areSbomOfVulnerabilityEqual(item, existingElement),
-            );
-
-            const updatedItemInArray: SbomOfVulnerability = {
-              ...existingElement,
-              relatedPackages: [
-                ...existingElement.relatedPackages,
-                {
-                  advisory: current.advisory,
-                  packages: current.packages,
-                },
-              ],
-            };
-
-            result = [...arrayWithoutExistingItem, updatedItemInArray];
-          } else {
-            const newItemInArray: SbomOfVulnerability = {
-              sbom: current.sbom,
-              sbomStatus: current.sbomStatus,
-              relatedPackages: [
-                {
-                  advisory: current.advisory,
-                  packages: current.packages,
-                },
-              ],
-            };
-            result = [...prev.slice(), newItemInArray];
-          }
-
-          return result;
-        }, [] as SbomOfVulnerability[])
-    );
-  });
+      return result;
+    }, [] as SbomOfVulnerability[]);
 
   const summary = sboms.reduce(
     (prev, current) => {

--- a/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
+++ b/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
@@ -63,61 +63,59 @@ const DEFAULT_SUMMARY: VulnerabilityOfSbomSummary = {
 };
 
 const advisoryToModels = (advisories: SbomAdvisory[]) => {
-  const vulnerabilities = advisories.flatMap((advisory) => {
-    return (
-      (advisory.status ?? [])
-        .map((sbomStatus) => {
-          const result: FlatVulnerabilityOfSbom = {
-            vulnerability: sbomStatus,
-            vulnerabilityStatus: sbomStatus.status as VulnerabilityStatus,
-            advisory: advisory,
-            packages: sbomStatus.packages,
-          };
-          return result;
-        })
-        // group
-        .reduce((prev, current) => {
-          const existingElement = prev.find((item) => {
-            return areVulnerabilityOfSbomEqual(item, current);
-          });
+  const vulnerabilities = advisories
+    .flatMap((advisory) => {
+      return (advisory.status ?? []).map((sbomStatus) => {
+        const result: FlatVulnerabilityOfSbom = {
+          vulnerability: sbomStatus,
+          vulnerabilityStatus: sbomStatus.status as VulnerabilityStatus,
+          advisory: advisory,
+          packages: sbomStatus.packages,
+        };
+        return result;
+      });
+    })
+    // group
+    .reduce((prev, current) => {
+      const existingElement = prev.find((item) => {
+        return areVulnerabilityOfSbomEqual(item, current);
+      });
 
-          let result: VulnerabilityOfSbom[];
+      let result: VulnerabilityOfSbom[];
 
-          if (existingElement) {
-            const arrayWithoutExistingItem = prev.filter(
-              (item) => !areVulnerabilityOfSbomEqual(item, existingElement),
-            );
+      if (existingElement) {
+        const arrayWithoutExistingItem = prev.filter(
+          (item) => !areVulnerabilityOfSbomEqual(item, existingElement),
+        );
 
-            const updatedItemInArray: VulnerabilityOfSbom = {
-              ...existingElement,
-              relatedPackages: [
-                ...existingElement.relatedPackages,
-                {
-                  advisory: current.advisory,
-                  packages: current.packages,
-                },
-              ],
-            };
+        const updatedItemInArray: VulnerabilityOfSbom = {
+          ...existingElement,
+          relatedPackages: [
+            ...existingElement.relatedPackages,
+            {
+              advisory: current.advisory,
+              packages: current.packages,
+            },
+          ],
+        };
 
-            result = [...arrayWithoutExistingItem, updatedItemInArray];
-          } else {
-            const newItemInArray: VulnerabilityOfSbom = {
-              vulnerability: current.vulnerability,
-              vulnerabilityStatus: current.vulnerabilityStatus,
-              relatedPackages: [
-                {
-                  advisory: current.advisory,
-                  packages: current.packages,
-                },
-              ],
-            };
-            result = [...prev.slice(), newItemInArray];
-          }
+        result = [...arrayWithoutExistingItem, updatedItemInArray];
+      } else {
+        const newItemInArray: VulnerabilityOfSbom = {
+          vulnerability: current.vulnerability,
+          vulnerabilityStatus: current.vulnerabilityStatus,
+          relatedPackages: [
+            {
+              advisory: current.advisory,
+              packages: current.packages,
+            },
+          ],
+        };
+        result = [...prev.slice(), newItemInArray];
+      }
 
-          return result;
-        }, [] as VulnerabilityOfSbom[])
-    );
-  });
+      return result;
+    }, [] as VulnerabilityOfSbom[]);
 
   const summary = vulnerabilities.reduce(
     (prev, current) => {

--- a/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
+++ b/client/src/app/pages/vulnerability-details/sboms-by-vulnerability.tsx
@@ -1,4 +1,4 @@
-import type React from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 
 import dayjs from "dayjs";
@@ -14,6 +14,8 @@ import {
   Tr,
 } from "@patternfly/react-table";
 
+import type { DecomposedPurl } from "@app/api/models";
+import type { PurlSummary } from "@app/client";
 import { FilterType } from "@app/components/FilterToolbar";
 import { PackageQualifiers } from "@app/components/PackageQualifiers";
 import { SimplePagination } from "@app/components/SimplePagination";
@@ -23,10 +25,22 @@ import {
   TableRowContentWithControls,
 } from "@app/components/TableControls";
 import { VulnerabilityStatusLabel } from "@app/components/VulnerabilityStatusLabel";
-import { useSbomsOfVulnerability } from "@app/hooks/domain-controls/useSbomsOfVulnerability";
+import {
+  type SbomOfVulnerability,
+  useSbomsOfVulnerability,
+} from "@app/hooks/domain-controls/useSbomsOfVulnerability";
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { useWithUiId } from "@app/utils/query-utils";
 import { decomposePurl, formatDate } from "@app/utils/utils";
+
+type PurlData = {
+  purlSummary: PurlSummary;
+  decomposedPurl?: DecomposedPurl;
+};
+
+type TableData = SbomOfVulnerability & {
+  allUniquePackages: PurlData[];
+};
 
 interface SbomsByVulnerabilityProps {
   vulnerabilityId: string;
@@ -41,8 +55,33 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
     fetchError,
   } = useSbomsOfVulnerability(vulnerabilityId);
 
+  const tableData = React.useMemo(() => {
+    return sboms.map((item) => {
+      const allUniquePackages = item.relatedPackages
+        .flatMap((relatedPackages) => relatedPackages.packages)
+        .reduce((prev, current) => {
+          const existingElement = prev.find((e) => e.uuid === current.uuid);
+          return existingElement ? prev : [...prev.slice(), current];
+        }, new Array<PurlSummary>())
+        .map((purlSummary) => {
+          const decomposedPurl = decomposePurl(purlSummary.purl);
+          const result: PurlData = {
+            purlSummary,
+            decomposedPurl,
+          };
+          return result;
+        });
+
+      const result: TableData = {
+        ...item,
+        allUniquePackages,
+      };
+      return result;
+    });
+  }, [sboms]);
+
   const tableDataWithUiId = useWithUiId(
-    sboms,
+    tableData,
     (d) => `${d.sbom.id}-${d.sbomStatus}`,
   );
 
@@ -170,7 +209,7 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
                         rowIndex,
                       })}
                     >
-                      {item.relatedPackages.length}
+                      {item.allUniquePackages.length}
                     </Td>
                     <Td
                       width={10}
@@ -210,33 +249,32 @@ export const SbomsByVulnerability: React.FC<SbomsByVulnerabilityProps> = ({
                                 </Tr>
                               </Thead>
                               <Tbody>
-                                {item.relatedPackages
-                                  .flatMap((item) => item.packages)
-                                  .map((purl) => {
-                                    const decomposedPurl = decomposePurl(
-                                      purl.purl,
-                                    );
-                                    return (
-                                      <Tr key={purl.uuid}>
-                                        <Td>{decomposedPurl?.type}</Td>
-                                        <Td>{decomposedPurl?.namespace}</Td>
-                                        <Td>
-                                          <Link to={`/packages/${purl.uuid}`}>
-                                            {decomposedPurl?.name}
-                                          </Link>
-                                        </Td>
-                                        <Td>{decomposedPurl?.version}</Td>
-                                        <Td>{decomposedPurl?.path}</Td>
-                                        <Td>
-                                          {decomposedPurl?.qualifiers && (
-                                            <PackageQualifiers
-                                              value={decomposedPurl?.qualifiers}
-                                            />
-                                          )}
-                                        </Td>
-                                      </Tr>
-                                    );
-                                  })}
+                                {item.allUniquePackages.map((purl) => {
+                                  return (
+                                    <Tr key={purl.purlSummary.uuid}>
+                                      <Td>{purl.decomposedPurl?.type}</Td>
+                                      <Td>{purl.decomposedPurl?.namespace}</Td>
+                                      <Td>
+                                        <Link
+                                          to={`/packages/${purl.purlSummary.uuid}`}
+                                        >
+                                          {purl.decomposedPurl?.name}
+                                        </Link>
+                                      </Td>
+                                      <Td>{purl.decomposedPurl?.version}</Td>
+                                      <Td>{purl.decomposedPurl?.path}</Td>
+                                      <Td>
+                                        {purl.decomposedPurl?.qualifiers && (
+                                          <PackageQualifiers
+                                            value={
+                                              purl.decomposedPurl?.qualifiers
+                                            }
+                                          />
+                                        )}
+                                      </Td>
+                                    </Tr>
+                                  );
+                                })}
                               </Tbody>
                             </Table>
                           </>


### PR DESCRIPTION
Depends on https://github.com/trustification/trustify-ui/pull/436

https://issues.redhat.com/browse/TC-2390

In the Vulnerability - Sboms table:
-  Fix the total count of dependencies
- When the user clicks in the total count of dependencies, there were duplicate packages being rendered so with this PR also the expanded area should render unique packages.