### PR TITLE
:bug: fix Donut Chart Legend Order

### DIFF
--- a/client/src/app/components/SbomVulnerabilitiesDonutChart.tsx
+++ b/client/src/app/components/SbomVulnerabilitiesDonutChart.tsx
@@ -26,7 +26,8 @@ export const SbomVulnerabilitiesDonutChart: React.FC<
           color: severityProps.color.value,
         };
       })
-      .sort(compareBySeverityFn((item) => item.severity));
+      .sort(compareBySeverityFn((item) => item.severity))
+      .reverse();
   }, [vulnerabilitiesSummary]);
 
   return (


### PR DESCRIPTION
The Donut Chart in the Dashboard page has the legends starting from Low to Critical (top to bottom) but it should be the opposite. This PR reverses the order of legends

Before
![Screenshot From 2025-04-03 13-01-02](https://github.com/user-attachments/assets/5dc9d052-7b47-442f-bece-dbe4eff14fd2)

After
![Screenshot From 2025-04-03 13-01-12](https://github.com/user-attachments/assets/6baff40c-29b5-4778-9add-c8f8acfe6c92)