### PR TITLE
:bug: [TC-2397] Run should only appear if importer is scheduled

### DIFF
--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -104,7 +104,7 @@ export const ImporterList: React.FC = () => {
   };
 
   const { mutate: updateImporter } = useUpdateImporterMutation(
-    () => { },
+    () => {},
     onEnableDisableError,
   );
 
@@ -387,29 +387,28 @@ export const ImporterList: React.FC = () => {
                             items={[
                               ...(isImporterDisabled
                                 ? [
-                                  {
-                                    title: "Enable",
-                                    onClick: () => {
-                                      prepareActionOnRow("enable", item);
+                                    {
+                                      title: "Enable",
+                                      onClick: () => {
+                                        prepareActionOnRow("enable", item);
+                                      },
                                     },
-                                  },
-                                ]
+                                  ]
                                 : [
-                                  {
-                                    title: "Run",
-                                    onClick: () => {
-                                      prepareActionOnRow("run", item);
+                                    {
+                                      title: "Run",
+                                      onClick: () => {
+                                        prepareActionOnRow("run", item);
+                                      },
+                                      isDisabled: importerStatus === "running",
                                     },
-                                    isDisabled:
-                                      importerStatus === "running",
-                                  },
-                                  {
-                                    title: "Disable",
-                                    onClick: () => {
-                                      prepareActionOnRow("disable", item);
+                                    {
+                                      title: "Disable",
+                                      onClick: () => {
+                                        prepareActionOnRow("disable", item);
+                                      },
                                     },
-                                  },
-                                ]),
+                                  ]),
                             ]}
                           />
                         </Td>

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -104,7 +104,7 @@ export const ImporterList: React.FC = () => {
   };
 
   const { mutate: updateImporter } = useUpdateImporterMutation(
-    () => {},
+    () => { },
     onEnableDisableError,
   );
 
@@ -385,34 +385,31 @@ export const ImporterList: React.FC = () => {
                         <Td isActionCell>
                           <ActionsColumn
                             items={[
-                              ...(importerStatus === "scheduled"
-                                ? [
-                                    {
-                                      title: "Run",
-                                      onClick: () => {
-                                        prepareActionOnRow("run", item);
-                                      },
-                                    },
-                                  ]
-                                : []),
-
                               ...(isImporterDisabled
                                 ? [
-                                    {
-                                      title: "Enable",
-                                      onClick: () => {
-                                        prepareActionOnRow("enable", item);
-                                      },
+                                  {
+                                    title: "Enable",
+                                    onClick: () => {
+                                      prepareActionOnRow("enable", item);
                                     },
-                                  ]
+                                  },
+                                ]
                                 : [
-                                    {
-                                      title: "Disable",
-                                      onClick: () => {
-                                        prepareActionOnRow("disable", item);
-                                      },
+                                  {
+                                    title: "Run",
+                                    onClick: () => {
+                                      prepareActionOnRow("run", item);
                                     },
-                                  ]),
+                                    isDisabled:
+                                      importerStatus === "running",
+                                  },
+                                  {
+                                    title: "Disable",
+                                    onClick: () => {
+                                      prepareActionOnRow("disable", item);
+                                    },
+                                  },
+                                ]),
                             ]}
                           />
                         </Td>

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -63,7 +63,7 @@ import { ANSICOLOR } from "@app/Constants";
 import { ImporterProgress } from "./components/importer-progress";
 import { ImporterStatusIcon } from "./components/importer-status-icon";
 
-type ImporterStatus = "enabled" | "disabled" | "scheduled" | "running";
+type ImporterStatus = "disabled" | "scheduled" | "running";
 
 const getImporterStatus = (importer: Importer): ImporterStatus => {
   const importerType = Object.keys(importer.configuration ?? {})[0];
@@ -323,8 +323,9 @@ export const ImporterList: React.FC = () => {
                 const configValues = (item.configuration as any)[
                   importerType
                 ] as SbomImporter;
-                const isImporterEnabled = configValues?.disabled === false;
 
+                const importerStatus = getImporterStatus(item);
+                const isImporterDisabled = importerStatus === "disabled";
                 return (
                   <Tbody key={item.name}>
                     <Tr {...getTrProps({ item })}>
@@ -373,20 +374,18 @@ export const ImporterList: React.FC = () => {
                           modifier="truncate"
                           {...getTdProps({ columnKey: "state" })}
                         >
-                          {item.state && isImporterEnabled ? (
-                            item.state === "running" && item.progress ? (
-                              <ImporterProgress value={item.progress} />
-                            ) : (
-                              <ImporterStatusIcon state={item.state} />
-                            )
-                          ) : (
+                          {importerStatus === "disabled" ? (
                             <Label color="orange">Disabled</Label>
+                          ) : importerStatus === "running" && item.progress ? (
+                            <ImporterProgress value={item.progress} />
+                          ) : (
+                            <ImporterStatusIcon state={item.state} />
                           )}
                         </Td>
                         <Td isActionCell>
                           <ActionsColumn
                             items={[
-                              ...(isImporterEnabled
+                              ...(importerStatus === "scheduled"
                                 ? [
                                     {
                                       title: "Run",
@@ -396,7 +395,8 @@ export const ImporterList: React.FC = () => {
                                     },
                                   ]
                                 : []),
-                              ...(!isImporterEnabled
+
+                              ...(isImporterDisabled
                                 ? [
                                     {
                                       title: "Enable",


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2397

An Importer can have only 3 statuses:

- "disabled"
- "scheduled" -> means it is enabled but waiting to be executed
- "running"

This will allow the RUN action to appear only when the Importer is scheduled but disappear when the Importer is either running or disabled