### PR TITLE
:sparkles: [TC-2412] Vulnerability Details - header use top margin

### DIFF
--- a/client/src/app/pages/vulnerability-details/vulnerability-details.tsx
+++ b/client/src/app/pages/vulnerability-details/vulnerability-details.tsx
@@ -64,7 +64,7 @@ export const VulnerabilityDetails: React.FC = () => {
             )}
           </FlexItem>
         </Flex>
-        <div className="pf-v5-u-m-md">
+        <div className="pf-v5-u-mt-sm">
           <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
             {vulnerability && <Overview vulnerability={vulnerability} />}
           </LoadingWrapper>


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2412

Based on https://v5-archive.patternfly.org/utility-classes/spacing/#overview

To make the Vulnerability description being aligned with the header, this PR applies margin only to the TOP