### PR TITLE
:sparkles: [TC-2434] Add TableCellError component

### DIFF
--- a/client/src/app/components/LoadingWrapper.tsx
+++ b/client/src/app/components/LoadingWrapper.tsx
@@ -1,14 +1,16 @@
 import type React from "react";
 
+import type { AxiosError } from "axios";
+
 import { Bullseye, Spinner } from "@patternfly/react-core";
 
 import { StateError } from "./StateError";
 
 export const LoadingWrapper = (props: {
   isFetching: boolean;
-  fetchError?: Error | null;
+  fetchError?: AxiosError | null;
   isFetchingState?: React.ReactNode;
-  fetchErrorState?: React.ReactNode;
+  fetchErrorState?: (error: AxiosError) => React.ReactNode;
   children: React.ReactNode;
 }) => {
   if (props.isFetching) {
@@ -21,7 +23,11 @@ export const LoadingWrapper = (props: {
     );
   }
   if (props.fetchError) {
-    return props.fetchErrorState || <StateError />;
+    return props.fetchErrorState ? (
+      props.fetchErrorState(props.fetchError)
+    ) : (
+      <StateError />
+    );
   }
   return props.children;
 };

--- a/client/src/app/components/TableCellError.tsx
+++ b/client/src/app/components/TableCellError.tsx
@@ -1,0 +1,13 @@
+import type React from "react";
+
+import type { AxiosError } from "axios";
+
+import { Label } from "@patternfly/react-core";
+
+interface TableCellErrorProps {
+  error: AxiosError;
+}
+
+export const TableCellError: React.FC<TableCellErrorProps> = ({ error }) => {
+  return <Label color="red">{error.code} Error</Label>;
+};

--- a/client/src/app/pages/package-list/components/PackageVulnerabilities.tsx
+++ b/client/src/app/pages/package-list/components/PackageVulnerabilities.tsx
@@ -1,8 +1,9 @@
 import type React from "react";
 
-import { Label, Skeleton } from "@patternfly/react-core";
+import { Skeleton } from "@patternfly/react-core";
 
 import { LoadingWrapper } from "@app/components/LoadingWrapper";
+import { TableCellError } from "@app/components/TableCellError";
 import { VulnerabilityGallery } from "@app/components/VulnerabilityGallery";
 import { useVulnerabilitiesOfPackage } from "@app/hooks/domain-controls/useVulnerabilitiesOfPackage";
 
@@ -21,7 +22,7 @@ export const PackageVulnerabilities: React.FC<PackageVulnerabilitiesProps> = ({
       isFetching={isFetching}
       fetchError={fetchError}
       isFetchingState={<Skeleton screenreaderText="Loading contents" />}
-      fetchErrorState={<Label color="red">Error</Label>}
+      fetchErrorState={(error) => <TableCellError error={error} />}
     >
       <VulnerabilityGallery
         severities={data.summary.vulnerabilityStatus.affected.severities}

--- a/client/src/app/pages/sbom-list/components/SbomVulnerabilities.tsx
+++ b/client/src/app/pages/sbom-list/components/SbomVulnerabilities.tsx
@@ -1,8 +1,9 @@
 import type React from "react";
 
-import { Label, Skeleton } from "@patternfly/react-core";
+import { Skeleton } from "@patternfly/react-core";
 
 import { LoadingWrapper } from "@app/components/LoadingWrapper";
+import { TableCellError } from "@app/components/TableCellError";
 import { VulnerabilityGallery } from "@app/components/VulnerabilityGallery";
 import { useVulnerabilitiesOfSbom } from "@app/hooks/domain-controls/useVulnerabilitiesOfSbom";
 
@@ -20,7 +21,7 @@ export const SBOMVulnerabilities: React.FC<SBOMVulnerabilitiesProps> = ({
       isFetching={isFetching}
       fetchError={fetchError}
       isFetchingState={<Skeleton screenreaderText="Loading contents" />}
-      fetchErrorState={<Label color="red">Error</Label>}
+      fetchErrorState={(error) => <TableCellError error={error} />}
     >
       <VulnerabilityGallery
         severities={data.summary.vulnerabilityStatus.affected.severities}

--- a/client/src/app/pages/vulnerability-list/components/SbomsCount.tsx
+++ b/client/src/app/pages/vulnerability-list/components/SbomsCount.tsx
@@ -1,8 +1,9 @@
 import type React from "react";
 
-import { Label, Skeleton } from "@patternfly/react-core";
+import { Skeleton } from "@patternfly/react-core";
 
 import { LoadingWrapper } from "@app/components/LoadingWrapper";
+import { TableCellError } from "@app/components/TableCellError";
 import { useSbomsOfVulnerability } from "@app/hooks/domain-controls/useSbomsOfVulnerability";
 
 interface SbomsCountProps {
@@ -18,7 +19,7 @@ export const SbomsCount: React.FC<SbomsCountProps> = ({ vulnerabilityId }) => {
       isFetching={isFetching}
       fetchError={fetchError}
       isFetchingState={<Skeleton screenreaderText="Loading contents" />}
-      fetchErrorState={<Label color="red">Error</Label>}
+      fetchErrorState={(error) => <TableCellError error={error} />}
     >
       {data.summary.sbomStatus.affected}
     </LoadingWrapper>


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2434

Currently, tables like the SBOM List table fetches data for counting Vulnerabilities and render it under the Vulnerabilities Column. When there is an error (like timeout error) we only render the word `Error` wrapped in a Red Label.

With this PR we will also render the Error Code. E.g. `500 Error` so at least the it is more clear what type of error was generated.