### PR TITLE
:sparkles: [TC-2435] avoid uploading .gz files

### DIFF
--- a/client/src/app/api/rest.ts
+++ b/client/src/app/api/rest.ts
@@ -42,8 +42,6 @@ const getContentTypeFromFile = (file: File) => {
   let contentType = "application/json";
   if (file.name.endsWith(".bz2")) {
     contentType = "application/json+bzip2";
-  } else if (file.name.endsWith(".gz")) {
-    contentType = "application/json+bzip2";
   }
   return contentType;
 };

--- a/client/src/app/pages/upload/components/upload-file.tsx
+++ b/client/src/app/pages/upload/components/upload-file.tsx
@@ -93,7 +93,7 @@ export const UploadFiles: React.FC<IUploadFilesProps> = ({
         onFileDrop={handleFileDrop}
         dropzoneProps={{
           accept: {
-            "application/xml": [".json", ".bz2", ".gz"],
+            "application/xml": [".json", ".bz2"],
           },
           onDropRejected: handleDropRejected,
           useFsAccessApi: false, // Required to make playwright work
@@ -103,7 +103,7 @@ export const UploadFiles: React.FC<IUploadFilesProps> = ({
           titleIcon={<UploadIcon />}
           titleText="Drag and drop files here"
           titleTextSeparator="or"
-          infoText="Accepted file types: .json, .bz2, .gz"
+          infoText="Accepted file types: .json, .bz2"
         />
         {showStatus && (
           <MultipleFileUploadStatus


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2435

Files with the extension .gz cannot be uploaded since they are not supported by the backend yet. 

This PR avoids mentioning .gz files in the Upload Page 