### PR TITLE
:seedling: align cherry-pick action with release-tools

### DIFF
--- a/.github/workflows/pr-closed.yaml
+++ b/.github/workflows/pr-closed.yaml
@@ -14,4 +14,4 @@ jobs:
       contents: write
     if: github.event.pull_request.merged == true
     secrets: inherit
-    uses: trustification/release-tools/.github/workflows/cherry-pick.yaml@main
+    uses: trustification/release-tools/.github/workflows/backport.yaml@main


### PR DESCRIPTION
The release-tools repository renamed the workflow `cherry-pick.yaml` by `backport.yaml` so we align the change in this PR