### PR TITLE
:bug: TableCellError should render numeric error

### DIFF
--- a/client/src/app/components/TableCellError.tsx
+++ b/client/src/app/components/TableCellError.tsx
@@ -9,5 +9,5 @@ interface TableCellErrorProps {
 }
 
 export const TableCellError: React.FC<TableCellErrorProps> = ({ error }) => {
-  return <Label color="red">{error.code} Error</Label>;
+  return <Label color="red">{error.status} Error</Label>;
 };


### PR DESCRIPTION
Currently the TableCellError component renders a string rather than the numeric error code.
This PR should make sure it is the numeric error code what is being rendered.

![0 2 16-sbom-vuln-error-column](https://github.com/user-attachments/assets/64545588-fd2a-43cf-b867-74e9d6257763)
