### PR TITLE
:bug: align Severity & Score nullable fields

### DIFF
--- a/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
+++ b/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
@@ -14,6 +14,7 @@ import {
   Tr,
 } from "@patternfly/react-table";
 
+import { extendedSeverityFromSeverity } from "@app/api/models";
 import type { AdvisoryVulnerabilitySummary } from "@app/client";
 import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
 import { SimplePagination } from "@app/components/SimplePagination";
@@ -160,8 +161,8 @@ export const VulnerabilitiesByAdvisory: React.FC<
                     >
                       {item.severity && (
                         <SeverityShieldAndText
-                          value={item.severity}
-                          score={item.score}
+                          value={extendedSeverityFromSeverity(item.severity)}
+                          score={item.score ?? null}
                           showLabel
                           showScore
                         />

--- a/client/src/app/pages/advisory-list/advisory-table.tsx
+++ b/client/src/app/pages/advisory-list/advisory-table.tsx
@@ -126,7 +126,9 @@ export const AdvisoryTable: React.FC = () => {
                     >
                       {item.average_severity && (
                         <SeverityShieldAndText
-                          value={item.average_severity as Severity}
+                          value={extendedSeverityFromSeverity(
+                            item.average_severity as Severity,
+                          )}
                           score={item.average_score}
                           showLabel
                           showScore

--- a/client/src/stories/v2.1/pages/search.tsx
+++ b/client/src/stories/v2.1/pages/search.tsx
@@ -321,7 +321,7 @@ export const SearchPage: React.FC = () => {
           <Split>
             <SplitItem isFilled>{item.name}</SplitItem>
             <SplitItem>
-              <SeverityShieldAndText value="medium" hideLabel />
+              <SeverityShieldAndText value="medium" score={5} />
             </SplitItem>
           </Split>
         </CardTitle>

--- a/client/src/stories/v2.1/product-list.stories.tsx
+++ b/client/src/stories/v2.1/product-list.stories.tsx
@@ -281,6 +281,7 @@ const ProductList: React.FC<{ products: IProduct[] }> = ({ products }) => {
                           {vuln.average_severity && (
                             <SeverityShieldAndText
                               value={vuln.average_severity}
+                              score={5}
                             />
                           )}
                         </Td>
@@ -311,6 +312,7 @@ const ProductList: React.FC<{ products: IProduct[] }> = ({ products }) => {
                           {adv.average_severity && (
                             <SeverityShieldAndText
                               value={adv.average_severity}
+                              score={5}
                             />
                           )}
                         </Td>


### PR DESCRIPTION
https://github.com/trustification/trustify-ui/pull/478 Evidenced that in the component client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx the `score` can be a null value. 

This PR makes sure client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx passes a possible null score and makes sure the severity is converted to `ExtendedSeverity` before it is being passed to the `SeverityShieldAndText` component.

Also removes some warnings from the storybook fields.