### PR TITLE
:sparkles: Enhance invalidation of queries readability

### DIFF
--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -102,8 +102,8 @@ export const useUploadAdvisory = () => {
     uploadFn: (formData, config) => {
       return uploadAdvisory(formData, config);
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: [AdvisoriesQueryKey],
       });
     },
@@ -123,9 +123,9 @@ export const useUpdateAdvisoryLabelsMutation = (
         body: obj.labels ?? {},
       });
     },
-    onSuccess: (_res, _payload) => {
+    onSuccess: async (_res, _payload) => {
       onSuccess();
-      queryClient.invalidateQueries({ queryKey: [AdvisoriesQueryKey] });
+      await queryClient.invalidateQueries({ queryKey: [AdvisoriesQueryKey] });
     },
     onError: onError,
   });

--- a/client/src/app/queries/dashboard.ts
+++ b/client/src/app/queries/dashboard.ts
@@ -54,9 +54,9 @@ export const useUpdateWatchedSbomsMutation = (
         body: obj,
       });
     },
-    onSuccess: (_res, _payload) => {
+    onSuccess: async (_res, _payload) => {
       onSuccess();
-      queryClient.invalidateQueries({
+      await queryClient.invalidateQueries({
         queryKey: [DashboardQueryKey, WATCHED_SBOMS_KEY],
       });
     },

--- a/client/src/app/queries/importers.ts
+++ b/client/src/app/queries/importers.ts
@@ -53,9 +53,9 @@ export const useCreateImporterMutation = (
         body: payload.configuration,
       });
     },
-    onSuccess: (_, _payload) => {
+    onSuccess: async (_, _payload) => {
       onSuccess();
-      queryClient.invalidateQueries({ queryKey: [ImportersQueryKey] });
+      await queryClient.invalidateQueries({ queryKey: [ImportersQueryKey] });
     },
     onError,
   });
@@ -94,9 +94,9 @@ export const useUpdateImporterMutation = (
         body: payload.configuration,
       });
     },
-    onSuccess: (_res, _payload) => {
+    onSuccess: async (_res, _payload) => {
       onSuccess();
-      queryClient.invalidateQueries({ queryKey: [ImportersQueryKey] });
+      await queryClient.invalidateQueries({ queryKey: [ImportersQueryKey] });
     },
     onError: onError,
   });
@@ -110,13 +110,13 @@ export const useDeleteIporterMutation = (
 
   const { isPending, mutate, error } = useMutation({
     mutationFn: (id: string) => deleteImporter({ client, path: { name: id } }),
-    onSuccess: (_res, id) => {
+    onSuccess: async (_res, id) => {
       onSuccess(id);
-      queryClient.invalidateQueries({ queryKey: [ImportersQueryKey] });
+      await queryClient.invalidateQueries({ queryKey: [ImportersQueryKey] });
     },
-    onError: (err: AxiosError, id) => {
+    onError: async (err: AxiosError, id) => {
       onError(err, id);
-      queryClient.invalidateQueries({ queryKey: [ImportersQueryKey] });
+      await queryClient.invalidateQueries({ queryKey: [ImportersQueryKey] });
     },
   });
 

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -79,9 +79,9 @@ export const useDeleteSbomMutation = (
       const response = await deleteSbom({ client, path: { id } });
       return response.data as SbomSummary;
     },
-    onSuccess: (response, id) => {
+    onSuccess: async (response, id) => {
       onSuccess(response, id);
-      queryClient.invalidateQueries({ queryKey: [SBOMsQueryKey] });
+      await queryClient.invalidateQueries({ queryKey: [SBOMsQueryKey] });
     },
     onError: onError,
   });
@@ -108,8 +108,8 @@ export const useUploadSBOM = () => {
     uploadFn: (formData, config) => {
       return uploadSbom(formData, config);
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: [SBOMsQueryKey],
       });
     },
@@ -129,9 +129,9 @@ export const useUpdateSbomLabelsMutation = (
         body: obj.labels,
       });
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       onSuccess();
-      queryClient.invalidateQueries({ queryKey: [SBOMsQueryKey] });
+      await queryClient.invalidateQueries({ queryKey: [SBOMsQueryKey] });
     },
     onError: onError,
   });
@@ -142,7 +142,7 @@ export const useFetchSbomsByPackageId = (
   params: HubRequestParams = {},
 ) => {
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ["SBOMsQueryKeysss", "by-package", purl, params],
+    queryKey: [SBOMsQueryKey, "by-package", purl, params],
     queryFn: () => {
       return listRelatedSboms({
         client,


### PR DESCRIPTION
The function `invalidateQueries` from react query is a function that returns a Promise and should be appropriately handled with an "await" syntax or similar alternatives.

The function `invalidateQueries` will be executed anyways regardless of whether or not we use `await` (that is why it works in the main branch). But it is good for good code practices to use `await` in those situations