### PR TITLE
:sparkles: Add breadcrumbs to all Details page

### DIFF
--- a/client/src/app/pages/advisory-details/advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/advisory-details.tsx
@@ -1,6 +1,9 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 import {
+  Breadcrumb,
+  BreadcrumbItem,
   Button,
   Content,
   Flex,
@@ -47,6 +50,14 @@ export const AdvisoryDetails: React.FC = () => {
 
   return (
     <>
+      <PageSection type="breadcrumb">
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to="/advisories">Advisories</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isActive>Advisory details</BreadcrumbItem>
+        </Breadcrumb>
+      </PageSection>
       <PageSection>
         <Split>
           <SplitItem isFilled>
@@ -88,7 +99,7 @@ export const AdvisoryDetails: React.FC = () => {
           </SplitItem>
         </Split>
       </PageSection>
-      <PageSection type="tabs">
+      <PageSection>
         <Tabs
           mountOnEnter
           activeKey={activeTabKey}

--- a/client/src/app/pages/package-details/package-details.tsx
+++ b/client/src/app/pages/package-details/package-details.tsx
@@ -1,6 +1,9 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 import {
+  Breadcrumb,
+  BreadcrumbItem,
   Content,
   Flex,
   FlexItem,
@@ -50,7 +53,15 @@ export const PackageDetails: React.FC = () => {
 
   return (
     <>
-      <PageSection hasBodyWrapper={false}>
+      <PageSection type="breadcrumb">
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to="/packages">Packages</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isActive>Package details</BreadcrumbItem>
+        </Breadcrumb>
+      </PageSection>
+      <PageSection>
         <Stack>
           <StackItem>
             <Content>
@@ -73,7 +84,7 @@ export const PackageDetails: React.FC = () => {
           </StackItem>
         </Stack>
       </PageSection>
-      <PageSection hasBodyWrapper={false}>
+      <PageSection>
         <Tabs
           mountOnEnter
           activeKey={activeTabKey}
@@ -106,7 +117,7 @@ export const PackageDetails: React.FC = () => {
           />
         </Tabs>
       </PageSection>
-      <PageSection hasBodyWrapper={false}>
+      <PageSection>
         <TabContent
           eventKey={0}
           id="refTabVulnerabilitiesSection"

--- a/client/src/app/pages/sbom-details/sbom-details.tsx
+++ b/client/src/app/pages/sbom-details/sbom-details.tsx
@@ -1,6 +1,9 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 import {
+  Breadcrumb,
+  BreadcrumbItem,
   Content,
   Dropdown,
   DropdownItem,
@@ -64,7 +67,15 @@ export const SbomDetails: React.FC = () => {
 
   return (
     <>
-      <PageSection hasBodyWrapper={false}>
+      <PageSection type="breadcrumb">
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to="/sboms">SBOMs</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isActive>SBOM details</BreadcrumbItem>
+        </Breadcrumb>
+      </PageSection>
+      <PageSection>
         <Split>
           <SplitItem isFilled>
             <Flex>
@@ -129,7 +140,7 @@ export const SbomDetails: React.FC = () => {
           </SplitItem>
         </Split>
       </PageSection>
-      <PageSection hasBodyWrapper={false}>
+      <PageSection>
         <Tabs
           mountOnEnter
           activeKey={activeTabKey}
@@ -173,7 +184,7 @@ export const SbomDetails: React.FC = () => {
           />
         </Tabs>
       </PageSection>
-      <PageSection hasBodyWrapper={false}>
+      <PageSection>
         <TabContent
           eventKey={0}
           id="refTabInfoSection"

--- a/client/src/app/pages/vulnerability-details/vulnerability-details.tsx
+++ b/client/src/app/pages/vulnerability-details/vulnerability-details.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 
 import {
+  Breadcrumb,
+  BreadcrumbItem,
   Content,
   Flex,
   FlexItem,
@@ -42,7 +45,15 @@ export const VulnerabilityDetails: React.FC = () => {
 
   return (
     <>
-      <PageSection hasBodyWrapper={false}>
+      <PageSection type="breadcrumb">
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to="/vulnerabilities">Vulnerabilities</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isActive>Vulnerability details</BreadcrumbItem>
+        </Breadcrumb>
+      </PageSection>
+      <PageSection>
         <Flex>
           <FlexItem>
             <Content>
@@ -70,7 +81,7 @@ export const VulnerabilityDetails: React.FC = () => {
           </LoadingWrapper>
         </div>
       </PageSection>
-      <PageSection type="tabs">
+      <PageSection>
         <Tabs
           mountOnEnter
           activeKey={activeTabKey}


### PR DESCRIPTION
Is is a common practice to have Breadcums when navigating deep into pages so the user does not lose sense of the page where he is currently at.