### PR TITLE
:warning: adapt vulnerability cvss search to the new parameters

### DIFF
--- a/client/src/app/pages/vulnerability-list/vulnerability-context.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-context.tsx
@@ -70,7 +70,7 @@ export const VulnerabilitySearchProvider: React.FunctionComponent<
         type: FilterType.search,
       },
       {
-        categoryKey: "average_severity",
+        categoryKey: "base_severity",
         title: "CVSS",
         placeholderText: "CVSS",
         type: FilterType.multiselect,
@@ -101,7 +101,7 @@ export const VulnerabilitySearchProvider: React.FunctionComponent<
     getHubRequestParams({
       ...tableControlState,
       hubSortFieldKeys: {
-        severity: "average_severity",
+        severity: "base_severity",
         published: "published",
       },
     }),


### PR DESCRIPTION
This PR accompanies the https://github.com/trustification/trustify/pull/1640 and changes filter to use `base_severity`