### PR TITLE
:sparkles: Use Patternfly Severity icons

### DIFF
--- a/client/src/app/api/model-utils.ts
+++ b/client/src/app/api/model-utils.ts
@@ -1,11 +1,21 @@
+import type React from "react";
+
 import type { ProgressProps } from "@patternfly/react-core";
+import {
+  SeverityCriticalIcon,
+  SeverityImportantIcon,
+  SeverityMinorIcon,
+  SeverityModerateIcon,
+  SeverityNoneIcon,
+  SeverityUndefinedIcon,
+} from "@patternfly/react-icons";
 import {
   t_global_icon_color_severity_critical_default as criticalColor,
   t_global_icon_color_severity_important_default as importantColor,
-  t_global_icon_color_severity_minor_default as lowColor,
+  t_global_icon_color_severity_minor_default as minorColor,
   t_global_icon_color_severity_moderate_default as moderateColor,
   t_global_icon_color_severity_none_default as noneColor,
-  t_global_icon_color_severity_undefined_default as unknownColor,
+  t_global_icon_color_severity_undefined_default as undefinedColor,
 } from "@patternfly/react-tokens";
 
 import type { ExtendedSeverity } from "./models";
@@ -15,39 +25,48 @@ type ListType = {
     name: string;
     color: { name: string; value: string; var: string };
     progressProps: Pick<ProgressProps, "variant">;
+
+    // biome-ignore lint/suspicious/noExplicitAny:
+    icon: React.ComponentType<any>;
   };
 };
 
 export const severityList: ListType = {
   unknown: {
     name: "Unknown",
-    color: unknownColor,
+    color: undefinedColor,
     progressProps: { variant: undefined },
+    icon: SeverityUndefinedIcon,
   },
   none: {
     name: "None",
     color: noneColor,
     progressProps: { variant: undefined },
+    icon: SeverityNoneIcon,
   },
   low: {
     name: "Low",
-    color: lowColor,
+    color: minorColor,
     progressProps: { variant: undefined },
+    icon: SeverityMinorIcon,
   },
   medium: {
     name: "Medium",
     color: moderateColor,
     progressProps: { variant: "warning" },
+    icon: SeverityModerateIcon,
   },
   high: {
     name: "High",
     color: importantColor,
     progressProps: { variant: "danger" },
+    icon: SeverityImportantIcon,
   },
   critical: {
     name: "Critical",
     color: criticalColor,
     progressProps: { variant: "danger" },
+    icon: SeverityCriticalIcon,
   },
 };
 

--- a/client/src/app/components/SeverityShieldAndText.tsx
+++ b/client/src/app/components/SeverityShieldAndText.tsx
@@ -1,7 +1,6 @@
 import type React from "react";
 
-import { Flex, FlexItem, Tooltip } from "@patternfly/react-core";
-import ShieldIcon from "@patternfly/react-icons/dist/esm/icons/shield-alt-icon";
+import { Flex, FlexItem, Icon, Tooltip } from "@patternfly/react-core";
 
 import { severityList } from "@app/api/model-utils";
 import type { ExtendedSeverity } from "@app/api/models";
@@ -21,6 +20,7 @@ export const SeverityShieldAndText: React.FC<SeverityShieldAndTextProps> = ({
 }) => {
   const severityProps = severityList[value];
   const label = severityProps.name;
+  const SeverityIcon = severityProps.icon;
 
   return (
     <Flex
@@ -31,10 +31,14 @@ export const SeverityShieldAndText: React.FC<SeverityShieldAndTextProps> = ({
     >
       <FlexItem>
         {showLabel ? (
-          <ShieldIcon color={severityProps.color.value} />
+          <Icon>
+            <SeverityIcon color={severityProps.color.value} />
+          </Icon>
         ) : (
           <Tooltip content={label}>
-            <ShieldIcon color={severityProps.color.value} />
+            <Icon>
+              <SeverityIcon color={severityProps.color.value} />
+            </Icon>
           </Tooltip>
         )}
       </FlexItem>


### PR DESCRIPTION
Fixes https://github.com/trustification/trustify-ui/issues/387

Patternfly has an standard way for coloring an rendering Severities using a different Icon for each one. See https://www.patternfly.org/patterns/status-and-severity/#severity-icons

This PR replaces the SHIELD icons for Severities and replace them by the Patternfly Icons and Colors
![image](https://github.com/user-attachments/assets/ead6e198-b890-4c74-971a-fc1a583bc8b5)
