### PR TITLE
ci: add upload of coverage data

### DIFF
--- a/.github/workflows/ci-repo.yaml
+++ b/.github/workflows/ci-repo.yaml
@@ -37,6 +37,11 @@ jobs:
         run: npm run test -- --coverage --watchAll=false
       - name: Check
         run: npm run check
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: trustification/trustify-ui
       - name: Crate Format
         working-directory: ./crate
         run: cargo fmt --check


### PR DESCRIPTION
To my understanding the UI CI already creates coverage data. This PR should upload those to the codecov.io as well.