### PR TITLE
:bug: Use vulnerability average_score on sorting tables

### DIFF
--- a/client/src/app/pages/package-details/vulnerabilities-by-package.tsx
+++ b/client/src/app/pages/package-details/vulnerabilities-by-package.tsx
@@ -14,7 +14,6 @@ import {
   Tr,
 } from "@patternfly/react-table";
 
-import { getSeverityPriority } from "@app/api/model-utils";
 import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
@@ -70,9 +69,7 @@ export const VulnerabilitiesByPackage: React.FC<
     getSortValues: (item) => {
       return {
         identifier: item.vulnerability.identifier,
-        severity: item.vulnerability?.average_severity
-          ? getSeverityPriority(item.vulnerability?.average_severity)
-          : 0,
+        severity: item.vulnerability?.average_score || 0,
         published: item.vulnerability?.published
           ? dayjs(item.vulnerability?.published).valueOf()
           : 0,

--- a/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
@@ -29,7 +29,6 @@ import {
   Tr,
 } from "@patternfly/react-table";
 
-import { getSeverityPriority } from "@app/api/model-utils";
 import {
   type VulnerabilityStatus,
   extendedSeverityFromSeverity,
@@ -147,7 +146,7 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
     ],
     getSortValues: (item) => ({
       id: item.vulnerability.identifier,
-      cvss: getSeverityPriority(item.vulnerability.average_severity),
+      cvss: item.vulnerability.average_score,
       affectedDependencies: item.summary.totalPackages,
       published: item.vulnerability?.published
         ? dayjs(item.vulnerability.published).valueOf()

--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -140,4 +140,9 @@ export const universalComparator = (
   // biome-ignore lint/suspicious/noExplicitAny: allowed
   b: any,
   locale: string,
-) => localeNumericCompare(String(a ?? ""), String(b ?? ""), locale);
+) => {
+  if (typeof a === "number" && typeof b === "number") {
+    return a - b;
+  }
+  return localeNumericCompare(String(a ?? ""), String(b ?? ""), locale);
+};


### PR DESCRIPTION
- Use average_score in sorting tables. A numeric value is more accurate and avoids the issue described at https://issues.redhat.com/browse/TC-2598
- Makes sure our Utils function used for sorting does not convert numbers to string when it is not needed.

## Summary by Sourcery

Improve sorting accuracy by using the vulnerability’s average_score for severity and CVSS columns and optimizing the universalComparator to handle numeric comparisons natively.

Enhancements:
- Enhance universalComparator to perform direct numeric subtraction when both values are numbers
- Switch sorting values in vulnerabilities tables (package and SBOM) to use average_score for severity/CVSS columns