### PR TITLE
:seedling: replace operator by compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,10 @@
+TRUSTIFY_IMAGE=ghcr.io/trustification/trustd:latest
+TRUSTIFY_UI_IMAGE=ghcr.io/trustification/trustify-ui:latest
+
+POSTGRESQL_IMAGE=postgres:16
+
+PLAYWRIGHT_IMAGE=mcr.microsoft.com/playwright
+PLAYWRIGHT_VERSION=v1.49.1
+UBUNTU_VERSION_ALIAS=-jammy
+PLAYWRIGHT_PORT=5000
+PLAYWRIGHT_HOME=/home/pwuser

--- a/.github/actions/start-trustify/action.yml
+++ b/.github/actions/start-trustify/action.yml
@@ -1,0 +1,64 @@
+name: Start trustify
+description: Start trustify using docker compose.
+inputs:
+  ui_image:
+    description: image uri for the ui (ie. ghcr.io/<namespace>/<image-name>:<tag>)
+    type: string
+    required: false
+    default: ""
+  server_image:
+    description: image uri for the server (ie. ghcr.io/<namespace>/<image-name>:<tag>)
+    type: string
+    required: false
+    default: ""
+  server_db_image:
+    description: image uri for server-postgres (ie. ghcr.io/<namespace>/<image-name>:<tag>)
+    type: string
+    required: false
+    default: ""
+outputs:
+  server_port:
+    description: Port where the server is running
+    value: ${{ steps.set-output.outputs.server_port }}
+  ui_port:
+    description: Port where the UI is running
+    value: ${{ steps.set-output.outputs.ui_port }}
+  playwright_port:
+    description: Port where the UI is running
+    value: ${{ steps.set-output.outputs.playwright_port }}
+runs:
+  using: "composite"
+  steps:
+    - name: Start trustify
+      working-directory: ${{ github.action_path }}/../../..
+      shell: bash
+      run: |
+        images=""
+        if [ -n "${{ inputs.server_image }}" ]; then
+          images="${images} TRUSTIFY_IMAGE=${{ inputs.server_image }}"
+        elif [ -n "${{ inputs.ui_image }}" ]; then
+          images="${images} TRUSTIFY_UI_IMAGE=${{ inputs.ui_image }}"
+        elif [ -n "${{ inputs.server_db_image }}" ]; then
+          images="${images} POSTGRESQL_IMAGE=${{ inputs.server_db_image }}"
+        fi
+
+        echo "images to overwrite: $images"
+
+        eval "${images} docker compose up -d"
+
+    - name: Wait for services to be ready
+      shell: bash
+      run: |
+        for port in "8080" "8081"; do
+          until curl -s http://localhost:$port | grep -qi "<html"; do
+            echo "Waiting for HTML page on port $port..."
+            sleep 2
+          done
+        done
+    
+    - id: set-output
+      shell: bash
+      run: |
+        echo "server_port=8080" >> $GITHUB_OUTPUT
+        echo "ui_port=8080" >> $GITHUB_OUTPUT
+        echo "playwright_port=5000" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-global-template.yaml
+++ b/.github/workflows/ci-global-template.yaml
@@ -1,0 +1,231 @@
+name: Run global Trustify CI tests
+
+on:
+  workflow_call:
+    inputs:
+      artifact:
+        description: |
+          The name of the component being tested, ie server etc.
+          Must correspond to an artifact storing the custom built image, named <artifact>,
+          and should contain the file <artifact>.tar inside.
+        required: false
+        type: string
+      ui_image:
+        description: image uri for the ui (ie. ghcr.io/<namespace>/<image-name>:<tag>)
+        type: string
+        required: false
+        default: ""
+      server_image:
+        description: image uri for the server (ie. ghcr.io/<namespace>/<image-name>:<tag>)
+        type: string
+        required: false
+        default: ""
+      server_db_image:
+        description: image uri for server-postgres (ie. ghcr.io/<namespace>/<image-name>:<tag>)
+        type: string
+        required: false
+        default: ""
+      run_api_tests:
+        description: |
+          A flag that determines whether the API tests should be run or not
+        type: boolean
+        required: false
+        default: true
+      run_ui_tests:
+        description: |
+          A flag that determines whether the UI tests should be run or not
+        type: boolean
+        required: false
+        default: true
+      tests_ref:
+        description: |
+          The branch or PR of the trustify-tests repository to clone.
+          For a pull request, the reference format would be "refs/pull/${PR_NUMBER}/merge".
+          For a branch, the reference format would just be the branch name.
+          This input can be set automatically on a pull request by adding a string of the format:
+            UI tests PR: 140
+          replacing "140" with the appropriate PR number. This will make it easier to coordinate changes
+          that require updating the global tests as well.
+        required: false
+        type: string
+        default: main
+  workflow_dispatch:
+    inputs:
+      artifact:
+        description: |
+          The name of the component being tested, ie server etc.
+          Must correspond to an artifact storing the custom built image, named <artifact>,
+          and should contain the file <artifact>.tar inside.
+        required: false
+        type: string
+      ui_image:
+        description: image uri for the ui (ie. ghcr.io/<namespace>/<image-name>:<tag>)
+        type: string
+        required: false
+        default: ""
+      server_image:
+        description: image uri for the server (ie. ghcr.io/<namespace>/<image-name>:<tag>)
+        type: string
+        required: false
+        default: ""
+      server_db_image:
+        description: image uri for server-postgres (ie. ghcr.io/<namespace>/<image-name>:<tag>)
+        type: string
+        required: false
+        default: ""
+      run_api_tests:
+        description: |
+          A flag that determines whether the API tests should be run or not
+        type: boolean
+        required: false
+        default: true
+      run_ui_tests:
+        description: |
+          A flag that determines whether the UI tests should be run or not
+        type: boolean
+        required: false
+        default: true
+      tests_ref:
+        description: |
+          The branch or PR of the trustify-tests repository to clone.
+          For a pull request, the reference format would be "refs/pull/${PR_NUMBER}/merge".
+          For a branch, the reference format would just be the branch name.
+          This input can be set automatically on a pull request by adding a string of the format:
+            UI tests PR: 140
+          replacing "140" with the appropriate PR number. This will make it easier to coordinate changes
+          that require updating the global tests as well.
+        required: false
+        type: string
+        default: main
+
+jobs:
+  check-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        if: "${{ inputs.artifact != '' }}"
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact }}
+          path: /tmp
+      - name: Load images
+        if: ${{ inputs.artifact != '' }}
+        run: |
+          docker load --input /tmp/${{ inputs.artifact }}.tar
+      - name: Check ui image exists
+        if: ${{ inputs.ui_image != '' }}
+        run: |
+          if docker image inspect ${{ inputs.ui_image }} >/dev/null 2>&1; then
+              echo "Image exists locally"
+              docker image inspect ${{ inputs.ui_image }}
+          else
+              echo "Image does not exist locally"
+              docker manifest inspect ${{ inputs.ui_image }}
+          fi
+      - name: Check server image exists
+        if: ${{ inputs.server_image != '' }}
+        run: |
+          if docker image inspect ${{ inputs.server_image }} >/dev/null 2>&1; then
+              echo "Image exists locally"
+              docker image inspect ${{ inputs.server_image }}
+          else
+              echo "Image does not exist locally"
+              docker manifest inspect ${{ inputs.server_image }}
+          fi
+      - name: Check server_db_image image exists
+        if: ${{ inputs.server_db_image != '' }}
+        run: |
+          if docker image inspect ${{ inputs.server_db_image }} >/dev/null 2>&1; then
+              echo "Image exists locally"
+              docker image inspect ${{ inputs.server_db_image }}
+          else
+              echo "Image does not exist locally"
+              docker manifest inspect ${{ inputs.server_db_image }}
+          fi
+
+  e2e-integration-tests:
+    needs: check-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract pull request number from inputs or PR description
+        env:
+          body: ${{ github.event.pull_request.body }}
+        run: |
+          PULL_REQUEST_NUMBER=$(echo ${body} | grep -oP '[T|t]ests [P|p][R|r]: \K\d+' || true)
+          [ -z "$PULL_REQUEST_NUMBER" ] \
+            && TESTS_REF=${{ inputs.tests_ref }} \
+            || TESTS_REF=refs/pull/$PULL_REQUEST_NUMBER/merge
+
+          echo "TESTS_REF=${TESTS_REF}" >>"$GITHUB_ENV"
+          echo "Using TESTS_REF \`${TESTS_REF}\`" >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Checkout tests repo
+        uses: actions/checkout@v4
+        with:
+          repository: trustification/trustify-tests
+          path: trustify-tests
+          ref: "${{ env.TESTS_REF }}"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: "trustify-tests/package-lock.json"
+      - name: Install dependencies
+        run: npm ci
+        working-directory: trustify-tests
+
+      - name: Download artifact
+        if: "${{ inputs.artifact != '' }}"
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact }}
+          path: /tmp
+      - name: Load images
+        if: ${{ inputs.artifact != '' }}
+        run: |
+          docker load --input /tmp/${{ inputs.artifact }}.tar
+
+      - name: Checkout ui repo
+        uses: actions/checkout@v4
+        with:
+          path: trustify-ui
+      - name: Start trustify
+        working-directory: trustify-ui
+        run: |
+          images=""
+          if [ -n "${{ inputs.server_image }}" ]; then
+            images="${images} TRUSTIFY_IMAGE=${{ inputs.server_image }}"
+          elif [ -n "${{ inputs.ui_image }}" ]; then
+            images="${images} TRUSTIFY_UI_IMAGE=${{ inputs.ui_image }}"
+          elif [ -n "${{ inputs.server_db_image }}" ]; then
+            images="${images} POSTGRESQL_IMAGE=${{ inputs.server_db_image }}"
+          fi
+
+          echo "images to overwrite: $images"
+
+          eval "${images} docker compose up -d"
+      - name: Wait for services to be ready
+        working-directory: trustify-ui
+        run: |
+          for port in "8080" "8081"; do
+            until curl -s http://localhost:$port | grep -qi "<html"; do
+              echo "Waiting for HTML page on port $port..."
+              sleep 2
+            done
+          done
+
+      - name: Run Playwright tests
+        working-directory: trustify-tests
+        run: |
+          script=""
+          if [ "${{ inputs.run_api_tests }}" = "true" ] && [ "${{ inputs.run_ui_tests }}" = "true" ]; then
+            script="test"
+          elif [ "${{ inputs.run_api_tests }}" = "true" ]; then
+            script="test:api"
+          elif [ "${{ inputs.run_ui_tests }}" = "true" ]; then
+            script="test:ui"
+          fi
+
+          echo "script to run: ${script}"
+
+          PW_TEST_CONNECT_WS_ENDPOINT=ws://localhost:5000/ TRUSTIFY_URL=http://trustify-ui:8080 TRUSTIFY_AUTH_ENABLED=false npm run $script

--- a/.github/workflows/ci-global-template.yaml
+++ b/.github/workflows/ci-global-template.yaml
@@ -190,29 +190,11 @@ jobs:
         with:
           path: trustify-ui
       - name: Start trustify
-        working-directory: trustify-ui
-        run: |
-          images=""
-          if [ -n "${{ inputs.server_image }}" ]; then
-            images="${images} TRUSTIFY_IMAGE=${{ inputs.server_image }}"
-          elif [ -n "${{ inputs.ui_image }}" ]; then
-            images="${images} TRUSTIFY_UI_IMAGE=${{ inputs.ui_image }}"
-          elif [ -n "${{ inputs.server_db_image }}" ]; then
-            images="${images} POSTGRESQL_IMAGE=${{ inputs.server_db_image }}"
-          fi
-
-          echo "images to overwrite: $images"
-
-          eval "${images} docker compose up -d"
-      - name: Wait for services to be ready
-        working-directory: trustify-ui
-        run: |
-          for port in "8080" "8081"; do
-            until curl -s http://localhost:$port | grep -qi "<html"; do
-              echo "Waiting for HTML page on port $port..."
-              sleep 2
-            done
-          done
+        uses: ./trustify-ui/.github/actions/start-trustify
+        with:
+          ui_image: ${{ inputs.ui_image }}
+          server_image: ${{ inputs.server_image }}
+          server_db_image: ${{ inputs.server_db_image }}
 
       - name: Run Playwright tests
         working-directory: trustify-tests
@@ -228,4 +210,4 @@ jobs:
 
           echo "script to run: ${script}"
 
-          PW_TEST_CONNECT_WS_ENDPOINT=ws://localhost:5000/ TRUSTIFY_URL=http://trustify-ui:8080 TRUSTIFY_AUTH_ENABLED=false npm run $script
+          PW_TEST_CONNECT_WS_ENDPOINT=ws://localhost:5000/ TRUSTIFY_URL=http://localhost:8081 TRUSTIFY_AUTH_ENABLED=false npm run $script

--- a/.github/workflows/ci-global.yaml
+++ b/.github/workflows/ci-global.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-  
+
       - name: save trustify-ui image
         run: |
           docker build . -t ghcr.io/trustification/trustify-ui:pr-test -f Dockerfile
@@ -34,7 +34,7 @@ jobs:
 
   run-global-ci:
     needs: build-and-upload-for-global-ci
-    uses: trustification/trustify-ci/.github/workflows/global-ci.yml@main
+    uses: ./.github/workflows/ci-global-template.yaml
     with:
       artifact: trustify-ui
       ui_image: ghcr.io/trustification/trustify-ui:pr-test

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,7 +62,7 @@ services:
     entrypoint: /usr/local/bin/trustd
     command: api --sample-data
     ports:
-      - "8081:8080"
+      - "8080:8080"
     volumes:
       - trustify-storage-data:/opt/trustify/storage
     networks:
@@ -77,7 +77,7 @@ services:
       TRUSTIFY_API_URL: http://trustify:8080
       AUTH_REQUIRED: false
     ports:
-      - "8080:8080"
+      - "8081:8080"
     networks:
       - trustify
     depends_on:
@@ -88,8 +88,7 @@ services:
     image: ${PLAYWRIGHT_IMAGE:?PLAYWRIGHT_IMAGE is required}:${PLAYWRIGHT_VERSION:?PLAYWRIGHT_VERSION is required}${UBUNTU_VERSION_ALIAS}
     ports:
       - "5000:5000"
-    networks:
-      - trustify
+    network_mode: host
     working_dir: ${PLAYWRIGHT_HOME:-/home/pwuser}
     command:
       - /bin/sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,97 @@
+networks:
+  trustify:
+
+volumes:
+  trustify-importer-data:
+  trustify-storage-data:
+  trustify-postgres-data:
+
+services:
+  trustify-db:
+    image: ${POSTGRESQL_IMAGE}
+    volumes:
+      - trustify-postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: trustify
+      POSTGRES_DB: trustify
+      POSTGRES_HOSTNAME: localhost
+      POSTGRES_PORT: 5432
+    networks:
+      - trustify
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres -d trustify" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  trustify-migrate:
+    image: ${TRUSTIFY_IMAGE}
+    environment:
+      TRUSTD_DB_HOST: trustify-db
+    entrypoint: /usr/local/bin/trustd
+    command: db migrate
+    networks:
+      - trustify
+    depends_on:
+      trustify-db:
+        condition: service_healthy
+
+  trustify-importer:
+    image: ${TRUSTIFY_IMAGE}
+    environment:
+      TRUSTD_DB_HOST: trustify-db
+      RUST_LOG: "error"
+    entrypoint: /usr/local/bin/trustd
+    command: importer --working-dir /data/workdir
+    volumes:
+      - trustify-importer-data:/data/workdir
+    networks:
+      - trustify
+    depends_on:
+      trustify-migrate:
+        condition: service_completed_successfully
+
+  trustify:
+    image: ${TRUSTIFY_IMAGE}
+    environment:
+      TRUSTD_DB_HOST: trustify-db
+      HTTP_SERVER_BIND_ADDR: "::"
+      AUTH_DISABLED: true
+      RUST_LOG: "error"    
+    entrypoint: /usr/local/bin/trustd
+    command: api --sample-data
+    ports:
+      - "8081:8080"
+    volumes:
+      - trustify-storage-data:/opt/trustify/storage
+    networks:
+      - trustify
+    depends_on:
+      trustify-migrate:
+        condition: service_completed_successfully
+  
+  trustify-ui:
+    image: ${TRUSTIFY_UI_IMAGE}
+    environment:
+      TRUSTIFY_API_URL: http://trustify:8080
+      AUTH_REQUIRED: false
+    ports:
+      - "8080:8080"
+    networks:
+      - trustify
+    depends_on:
+      trustify:
+        condition: service_started
+  
+  playwright:
+    image: ${PLAYWRIGHT_IMAGE:?PLAYWRIGHT_IMAGE is required}:${PLAYWRIGHT_VERSION:?PLAYWRIGHT_VERSION is required}${UBUNTU_VERSION_ALIAS}
+    ports:
+      - "5000:5000"
+    networks:
+      - trustify
+    working_dir: ${PLAYWRIGHT_HOME:-/home/pwuser}
+    command:
+      - /bin/sh
+      - -c
+      - npx -y playwright@${PLAYWRIGHT_VERSION:?PLAYWRIGHT_VERSION is required} run-server --port ${PLAYWRIGHT_PORT:-5000}


### PR DESCRIPTION
- Drops the Operator in favor of docker compose

## Summary by Sourcery

Replace the custom Operator in CI with Docker Compose and a reusable GitHub Actions workflow

New Features:
- Add ci-global-template.yaml as a reusable workflow that checks images, loads artifacts, and runs end-to-end tests

Enhancements:
- Introduce docker-compose.yaml to define Trustify services and Playwright test environment for integration tests

CI:
- Update ci-global.yaml to invoke the local ci-global-template instead of the external operator workflow

Chores:
- Add .env placeholder for Docker Compose environment variables