### PR TITLE
:seedling: increase interval of dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: ":ghost: "
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: ":ghost: "
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust Dependabot schedule to run monthly instead of weekly for both GitHub Actions and npm updates

Chores:
- Increase Dependabot check interval for GitHub Actions updates to monthly
- Increase Dependabot check interval for npm updates to monthly