### PR TITLE
:ghost: Bump actions/checkout from 4 to 5 [Backport release/0.3.z]

### DIFF
--- a/.github/workflows/ci-global-template.yaml
+++ b/.github/workflows/ci-global-template.yaml
@@ -160,7 +160,7 @@ jobs:
           echo "Using TESTS_REF \`${TESTS_REF}\`" >>"$GITHUB_STEP_SUMMARY"
 
       - name: Checkout tests repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: trustification/trustify-tests
           path: trustify-tests
@@ -186,7 +186,7 @@ jobs:
           docker load --input /tmp/${{ inputs.artifact }}.tar
 
       - name: Checkout ui repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: trustify-ui
       - name: Start trustify

--- a/.github/workflows/ci-global.yaml
+++ b/.github/workflows/ci-global.yaml
@@ -18,7 +18,7 @@ jobs:
   build-and-upload-for-global-ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: save trustify-ui image
         run: |

--- a/.github/workflows/ci-image-build.yaml
+++ b/.github/workflows/ci-image-build.yaml
@@ -13,7 +13,7 @@ jobs:
       should-test: ${{ steps.check-changes.outputs.should-test }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: What files changed?
         id: changed
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout merge commit for PR${{ github.event.pull_request.number }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup QEMU to be able to build on ${{ matrix.architecture }}
         if: ${{ matrix.architecture != 'amd64' }}

--- a/.github/workflows/ci-repo.yaml
+++ b/.github/workflows/ci-repo.yaml
@@ -17,7 +17,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/tag-dist.yaml
+++ b/.github/workflows/tag-dist.yaml
@@ -16,7 +16,7 @@ jobs:
   tag-dist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: build
       - name: Use Node.js


### PR DESCRIPTION
Backport of https://github.com/trustification/trustify-ui/pull/645

## Summary by Sourcery

CI:
- Update actions/checkout usage from v4 to v5 in all CI workflow configurations