### PR TITLE
:seedling: add date filter and replace dateRange

### DIFF
--- a/client/src/app/components/FilterPanel/DateFilter.tsx
+++ b/client/src/app/components/FilterPanel/DateFilter.tsx
@@ -1,0 +1,61 @@
+import React, { type FormEvent, useState } from "react";
+
+import { DatePicker, Form, FormGroup } from "@patternfly/react-core";
+
+import {
+  americanDateFormat,
+  isValidAmericanShortDate,
+  parseAmericanDate,
+} from "../FilterToolbar/dateUtils";
+import type { IFilterControlProps } from "./FilterControl";
+
+export const DateFilter = <TItem,>({
+  filterValue,
+  setFilterValue,
+  isDisabled = false,
+}: React.PropsWithChildren<
+  IFilterControlProps<TItem, string>
+>): React.JSX.Element | null => {
+  const [date, setDate] = useState<Date>();
+
+  // Update it if it changes externally
+  React.useEffect(() => {
+    if (filterValue?.[0]) {
+      const date = parseAmericanDate(filterValue?.[0]);
+      setDate(date);
+    } else {
+      setDate(undefined);
+    }
+  }, [filterValue]);
+
+  const onDateChange = (_event: FormEvent<HTMLInputElement>, value: string) => {
+    if (isValidAmericanShortDate(value)) {
+      const newDate = parseAmericanDate(value);
+      setDate(newDate);
+      const target = americanDateFormat(newDate);
+      if (target) {
+        setFilterValue([target]);
+      }
+    }
+  };
+
+  return (
+    <Form>
+      <FormGroup role="group" isInline>
+        <DatePicker
+          value={date ? americanDateFormat(date) : ""}
+          dateFormat={americanDateFormat}
+          dateParse={parseAmericanDate}
+          onChange={onDateChange}
+          aria-label="Date"
+          placeholder="MM/DD/YYYY"
+          // disable error text (no space in toolbar scenario)
+          invalidFormatText={""}
+          // default value ("parent") creates collision with sticky table header
+          appendTo={document.body}
+          isDisabled={isDisabled}
+        />
+      </FormGroup>
+    </Form>
+  );
+};

--- a/client/src/app/components/FilterPanel/FilterControl.tsx
+++ b/client/src/app/components/FilterPanel/FilterControl.tsx
@@ -10,6 +10,7 @@ import {
 } from "../FilterToolbar";
 import { AutocompleteLabelFilterControl } from "./AutocompleteLabelFilterControl";
 import { CheckboxFilterControl } from "./CheckboxFilterControl";
+import { DateFilter } from "./DateFilter";
 import { DateRangeFilter } from "./DateRangeFilter";
 import { RadioFilterControl } from "./RadioFilterControl";
 import { SearchFilterControl } from "./SearchFilterControl";
@@ -57,6 +58,9 @@ export const FilterControl = <TItem, TFilterCategoryKey extends string>({
         {...props}
       />
     );
+  }
+  if (category.type === FilterType.date) {
+    return <DateFilter category={category} {...props} />;
   }
   if (category.type === FilterType.dateRange) {
     return <DateRangeFilter category={category} {...props} />;

--- a/client/src/app/components/FilterToolbar/DateFilter.tsx
+++ b/client/src/app/components/FilterToolbar/DateFilter.tsx
@@ -1,0 +1,76 @@
+import React, { type FormEvent, useState } from "react";
+
+import { DatePicker, InputGroup, ToolbarFilter } from "@patternfly/react-core";
+
+import type { IFilterControlProps } from "./FilterControl";
+import {
+  americanDateFormat,
+  isValidAmericanShortDate,
+  parseAmericanDate,
+} from "./dateUtils";
+
+export const DateFilter = <TItem,>({
+  category,
+  filterValue,
+  setFilterValue,
+  showToolbarItem,
+  isDisabled = false,
+}: React.PropsWithChildren<
+  IFilterControlProps<TItem, string>
+>): React.JSX.Element | null => {
+  const selectedFilters = filterValue ?? [];
+  const validFilters =
+    selectedFilters?.filter((value) => isValidAmericanShortDate(value)) ?? [];
+
+  const [date, setDate] = useState<Date>();
+
+  // Update it if it changes externally
+  React.useEffect(() => {
+    if (filterValue?.[0]) {
+      const date = parseAmericanDate(filterValue?.[0]);
+      setDate(date);
+    } else {
+      setDate(undefined);
+    }
+  }, [filterValue]);
+
+  const onDateChange = (_event: FormEvent<HTMLInputElement>, value: string) => {
+    if (isValidAmericanShortDate(value)) {
+      const newDate = parseAmericanDate(value);
+      setDate(newDate);
+      const target = americanDateFormat(newDate);
+      if (target) {
+        setFilterValue([target]);
+      }
+    }
+  };
+
+  return (
+    <ToolbarFilter
+      key={category.categoryKey}
+      labels={validFilters.map((value) => ({
+        key: value,
+        node: value,
+      }))}
+      deleteLabel={() => setFilterValue([])}
+      categoryName={category.title}
+      showToolbarItem={showToolbarItem}
+    >
+      <InputGroup>
+        <DatePicker
+          value={date ? americanDateFormat(date) : ""}
+          dateFormat={americanDateFormat}
+          dateParse={parseAmericanDate}
+          onChange={onDateChange}
+          aria-label="Date"
+          placeholder="MM/DD/YYYY"
+          // disable error text (no space in toolbar scenario)
+          invalidFormatText={""}
+          // default value ("parent") creates collision with sticky table header
+          appendTo={document.body}
+          isDisabled={isDisabled}
+        />
+      </InputGroup>
+    </ToolbarFilter>
+  );
+};

--- a/client/src/app/components/FilterToolbar/FilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/FilterControl.tsx
@@ -1,6 +1,7 @@
 import type * as React from "react";
 
 import { AutocompleteLabelFilterControl } from "./AutocompleteLabelFilterControl";
+import { DateFilter } from "./DateFilter";
 import { DateRangeFilter } from "./DateRangeFilter";
 import {
   type FilterCategory,
@@ -59,6 +60,9 @@ export const FilterControl = <TItem, TFilterCategoryKey extends string>({
         {...props}
       />
     );
+  }
+  if (category.type === FilterType.date) {
+    return <DateFilter category={category} {...props} />;
   }
   if (category.type === FilterType.dateRange) {
     return <DateRangeFilter category={category} {...props} />;

--- a/client/src/app/components/FilterToolbar/FilterToolbar.tsx
+++ b/client/src/app/components/FilterToolbar/FilterToolbar.tsx
@@ -19,6 +19,7 @@ export enum FilterType {
   multiselect = "multiselect",
   search = "search",
   numsearch = "numsearch",
+  date = "date",
   dateRange = "dateRange",
   autocompleteLabel = "autocompleteLabel",
 }

--- a/client/src/app/hooks/table-controls/filtering/getFilterHubRequestParams.ts
+++ b/client/src/app/hooks/table-controls/filtering/getFilterHubRequestParams.ts
@@ -3,7 +3,10 @@ import {
   type FilterCategory,
   getFilterLogicOperator,
 } from "@app/components/FilterToolbar";
-import { parseInterval } from "@app/components/FilterToolbar/dateUtils";
+import {
+  parseAmericanDate,
+  parseInterval,
+} from "@app/components/FilterToolbar/dateUtils";
 import { objectKeys } from "@app/utils/utils";
 import type { IFilterState } from "./useFilterState";
 
@@ -17,7 +20,7 @@ const pushOrMergeFilter = (
   newFilter: HubFilter,
 ) => {
   const existingFilterIndex = existingFilters.findIndex(
-    (f) => f.field === newFilter.field,
+    (f) => f.field === newFilter.field && f.operator === newFilter.operator,
   );
   const existingFilter =
     existingFilterIndex === -1 ? null : existingFilters[existingFilterIndex];
@@ -138,6 +141,14 @@ export const getFilterHubRequestParams = <
             list: serverFilterValue,
             operator: getFilterLogicOperator(filterCategory, "OR"),
           },
+        });
+      }
+      if (filterCategory.type === "date") {
+        const date = parseAmericanDate(serverFilterValue[0]);
+        pushOrMergeFilter(filters, {
+          field: serverFilterField,
+          operator: filterCategory.operator ?? "=",
+          value: date.toISOString(),
         });
       }
       if (filterCategory.type === "dateRange") {

--- a/client/src/app/pages/advisory-list/advisory-context.tsx
+++ b/client/src/app/pages/advisory-list/advisory-context.tsx
@@ -27,7 +27,7 @@ interface IAdvisorySearchContext {
     AdvisorySummary,
     "identifier" | "title" | "type" | "labels" | "modified" | "vulnerabilities",
     "identifier" | "modified",
-    "" | "average_severity" | "modified" | "labels",
+    "" | "average_severity" | "modifiedBefore" | "modifiedAfter" | "labels",
     string
   >;
 
@@ -88,9 +88,18 @@ export const AdvisorySearchProvider: React.FunctionComponent<
         type: FilterType.search,
       },
       {
-        categoryKey: "modified",
-        title: "Revision",
-        type: FilterType.dateRange,
+        categoryKey: "modifiedBefore",
+        serverFilterField: "modified",
+        title: "Revised before",
+        type: FilterType.date,
+        operator: "<",
+      },
+      {
+        categoryKey: "modifiedAfter",
+        serverFilterField: "modified",
+        title: "Revised after",
+        type: FilterType.date,
+        operator: ">",
       },
       {
         categoryKey: "labels",

--- a/client/src/app/pages/sbom-list/sbom-context.tsx
+++ b/client/src/app/pages/sbom-list/sbom-context.tsx
@@ -31,7 +31,7 @@ interface ISbomSearchContext {
     | "labels"
     | "vulnerabilities",
     "name" | "published",
-    "" | "published" | "labels",
+    "" | "publishedBefore" | "publishedAfter" | "labels",
     string
   >;
 
@@ -89,9 +89,18 @@ export const SbomSearchProvider: React.FunctionComponent<ISbomProvider> = ({
         type: FilterType.search,
       },
       {
-        categoryKey: "published",
-        title: "Created on",
-        type: FilterType.dateRange,
+        categoryKey: "publishedBefore",
+        serverFilterField: "published",
+        title: "Created before",
+        type: FilterType.date,
+        operator: "<",
+      },
+      {
+        categoryKey: "publishedAfter",
+        serverFilterField: "published",
+        title: "Created after",
+        type: FilterType.date,
+        operator: ">",
       },
       {
         categoryKey: "labels",

--- a/client/src/app/pages/search/components/SearchTabs.tsx
+++ b/client/src/app/pages/search/components/SearchTabs.tsx
@@ -39,7 +39,7 @@ export interface SearchTabsProps {
   filterPanelProps: {
     advisoryFilterPanelProps: IFilterPanelProps<
       AdvisorySummary,
-      "" | "modified" | "average_severity" | "labels"
+      "" | "modifiedBefore" | "modifiedAfter" | "average_severity" | "labels"
     >;
     packageFilterPanelProps: IFilterPanelProps<
       PackageTableData,
@@ -47,11 +47,11 @@ export interface SearchTabsProps {
     >;
     sbomFilterPanelProps: IFilterPanelProps<
       SbomSummary,
-      "" | "published" | "labels"
+      "" | "publishedBefore" | "publishedAfter" | "labels"
     >;
     vulnerabilityFilterPanelProps: IFilterPanelProps<
       VulnerabilitySummary,
-      "" | "base_severity" | "published"
+      "" | "base_severity" | "publishedBefore" | "publishedAfter"
     >;
   };
 

--- a/client/src/app/pages/vulnerability-list/vulnerability-context.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-context.tsx
@@ -21,7 +21,7 @@ export interface IVulnerabilitySearchContext {
     VulnerabilitySummary,
     "identifier" | "title" | "severity" | "published" | "sboms",
     "identifier" | "published" | "severity",
-    "" | "base_severity" | "published",
+    "" | "base_severity" | "publishedBefore" | "publishedAfter",
     string
   >;
 
@@ -83,9 +83,18 @@ export const VulnerabilitySearchProvider: React.FunctionComponent<
         ],
       },
       {
-        categoryKey: "published",
-        title: "Created on",
-        type: FilterType.dateRange,
+        categoryKey: "publishedBefore",
+        serverFilterField: "published",
+        title: "Created before",
+        type: FilterType.date,
+        operator: "<",
+      },
+      {
+        categoryKey: "publishedAfter",
+        serverFilterField: "published",
+        title: "Created after",
+        type: FilterType.date,
+        operator: ">",
       },
     ],
     isExpansionEnabled: true,


### PR DESCRIPTION
Fixes: https://github.com/trustification/trustify-ui/issues/393, https://github.com/trustification/trustify-ui/issues/394, https://issues.redhat.com/browse/TC-2393, and https://issues.redhat.com/browse/TC-2402

- This PR creates a new FilterType `date`.
- All current filters using "dateRange" are being replaced by "date". This way we avoid all issues described in the JIRAs and Github issues linked above.
