### PR TITLE
ci: use e2e code coverage for codecov

### DIFF
--- a/.github/workflows/ci-coverage.yaml
+++ b/.github/workflows/ci-coverage.yaml
@@ -58,3 +58,8 @@ jobs:
         with:
           name: coverage-report
           path: coverage
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: trustification/trustify-ui

--- a/.github/workflows/ci-repo.yaml
+++ b/.github/workflows/ci-repo.yaml
@@ -35,11 +35,6 @@ jobs:
         run: npm run test -- --coverage --watchAll=false
       - name: Check
         run: npm run check
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: trustification/trustify-ui
       - name: Crate Format
         working-directory: ./crate
         run: cargo fmt --check


### PR DESCRIPTION
## Summary by Sourcery

Consolidate Codecov uploads by integrating the Codecov action into the ci-coverage workflow and removing the redundant upload step from the ci-repo workflow

CI:
- Add Codecov upload step in ci-coverage workflow
- Remove Codecov upload from ci-repo workflow