### PR TITLE
ci: setup codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This PR should make Codevov not to fail showing the Red Fail Icon, even if the code coverage is impacted by the PR.

- While having code coverage is important, it should not block PRs. The Red Failure Icon of Gitghub gives that impression