### PR TITLE
ci: remove npm 9 dependency from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,12 @@ FROM registry.access.redhat.com/ubi9/nodejs-22:latest AS builder
 
 USER 1001
 COPY --chown=1001 . .
-RUN npm clean-install --ignore-scripts && npm run build && npm run dist
+RUN \
+  npm version && \
+  npm config ls && \
+  npm clean-install --verbose --ignore-scripts --no-audit && \
+  npm run build && \
+  npm run dist
 
 # Runner image
 FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:latest

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -4,7 +4,12 @@
 FROM registry.access.redhat.com/ubi9/nodejs-22:latest AS ui-source
 USER 1001
 COPY --chown=1001 . .
-RUN npm clean-install --ignore-scripts && npm run build && npm run dist
+RUN \
+  npm version && \
+  npm config ls && \
+  npm clean-install --verbose --ignore-scripts --no-audit && \
+  npm run build && \
+  npm run dist
 
 ######################################################################
 # Prepare server


### PR DESCRIPTION
npm v9 was needed when we were using Nodejs 18 to avoid network issues while downloading npm dependencies.
I believe we don't have that issue anymore as we use nodejs 22 as a minimun version of Nodejs

## Summary by Sourcery

Remove the npm v9 dependency from the Dockerfiles and streamline the npm installation steps now that Node.js 22 is the minimum version.

Enhancements:
- Eliminate the global npm@9 installation by relying on the npm version bundled with Node.js 22

Build:
- Insert npm version and config checks before installation
- Replace npm clean-install command with a verbose, ignore-scripts, no-audit invocation
- Retain build and dist steps unchanged