### PR TITLE
ci: fix image tag for e2e testing when merge_group

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -42,8 +42,10 @@ jobs:
       - name: Extract vars for Pull Request
         shell: bash
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+        env:
+          base_ref: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
         run: |
-          branch=${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          branch=$base_ref
           branch=$(echo ${branch#refs/heads/})
           image_tag="latest"
           if [[ "$branch" != "main" ]]; then


### PR DESCRIPTION
For e2e tests we rely on the backend container image.
The container image tag for the backend is defined by the target branch in which PRs of trustify-ui are created.

In cases where the e2e tests were running in the merge_queue, the container image tag was not created correctly. This PR should fix it

## Summary by Sourcery

Fix e2e CI workflow to derive backend image tags correctly for merge_group events and ensure consistent behavior across pull_request and push triggers.

Bug Fixes:
- Correct image_tag assignment for merge_group e2e test runs.

CI:
- Include merge_group trigger in pull_request branch extraction logic.
- Unify and simplify image_tag computation for pull_request, merge_group, and push events.