### PR TITLE
ci: add npm params to ci to avoid req deny

### DIFF
--- a/.github/workflows/ci-coverage.yaml
+++ b/.github/workflows/ci-coverage.yaml
@@ -24,7 +24,7 @@ jobs:
           node-version: 22
           cache: npm
       - name: install dependencies
-        run: npm ci
+        run: npm ci --verbose --ignore-scripts --no-audit
 
       - name: install trustify
         id: install-trustify

--- a/.github/workflows/ci-e2e-template.yaml
+++ b/.github/workflows/ci-e2e-template.yaml
@@ -141,7 +141,7 @@ jobs:
           node-version: 22
           cache: "npm"
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --verbose --ignore-scripts --no-audit
 
       - name: Start trustify
         uses: ./.github/actions/start-trustify

--- a/.github/workflows/ci-repo.yaml
+++ b/.github/workflows/ci-repo.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Verify package-lock.json
         run: ./scripts/verify_lock.mjs
       - name: Install dependencies
-        run: npm clean-install --ignore-scripts
+        run: npm ci --verbose --ignore-scripts --no-audit
       # - name: Lint sources
       #   run: npm run lint
       - name: Build

--- a/.github/workflows/tag-dist.yaml
+++ b/.github/workflows/tag-dist.yaml
@@ -25,7 +25,7 @@ jobs:
           node-version: 22
       - name: Install
         working-directory: build
-        run: npm clean-install --ignore-scripts
+        run: npm ci --verbose --ignore-scripts --no-audit
       - name: Build
         working-directory: build
         run: npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY --chown=1001 . .
 RUN \
   npm version && \
   npm config ls && \
-  npm clean-install --verbose --ignore-scripts --no-audit && \
+  npm ci --verbose --ignore-scripts --no-audit && \
   npm run build && \
   npm run dist
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -7,7 +7,7 @@ COPY --chown=1001 . .
 RUN \
   npm version && \
   npm config ls && \
-  npm clean-install --verbose --ignore-scripts --no-audit && \
+  npm ci --verbose --ignore-scripts --no-audit && \
   npm run build && \
   npm run dist
 


### PR DESCRIPTION
Adding "--verbose --ignore-scripts --no-audit" to our workflows. This should slightly help to reduce the number of requests of our workflows.

We experienced in the past errors like:
```
#10 78.20 npm verbose stack HttpErrorGeneral: 429 Too Many Requests - GET https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz
#10 78.20 npm verbose stack     at /usr/lib/node_modules/npm/node_modules/npm-registry-fetch/lib/check-response.js:103:15
#10 78.20 npm verbose stack     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
#10 78.20 npm verbose statusCode 429
```

## Summary by Sourcery

Add npm install flags to CI workflows and Dockerfiles to reduce registry requests and prevent HTTP 429 rate limit errors

Bug Fixes:
- Prevent npm registry HTTP 429 Too Many Requests errors by adjusting install command parameters

CI:
- Include --verbose, --ignore-scripts, and --no-audit flags in npm ci commands across GitHub workflows and Dockerfiles