### PR TITLE
tests: sbom-explorer-details reuse SbomDetailsPage utils

### DIFF
--- a/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.feature
+++ b/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.feature
@@ -59,7 +59,6 @@ Feature: SBOM Explorer - View SBOM details
             | quarkus-bom | jdom        |
 
     Scenario Outline: View SBOM Vulnerabilities
-        Given An ingested SBOM "<sbomName>" is available
         When User visits SBOM details Page of "<sbomName>"
         When User selects the Tab "Vulnerabilities"
         When User Clicks on Vulnerabilities Tab Action
@@ -77,7 +76,6 @@ Feature: SBOM Explorer - View SBOM details
 
     @slow
     Scenario Outline: Pagination of SBOM Vulnerabilities table
-        Given An ingested SBOM "<sbomName>" is available
         When User visits SBOM details Page of "<sbomName>"
         When User selects the Tab "Vulnerabilities"
         Then Pagination of Vulnerabilities list works
@@ -95,7 +93,6 @@ Feature: SBOM Explorer - View SBOM details
         | ubi9-minimal-container |
 
     Scenario Outline: Check Column Headers of SBOM Explorer Vulnerabilities table
-        Given An ingested SBOM "<sbomName>" is available
         When User visits SBOM details Page of "<sbomName>"
         When User selects the Tab "Vulnerabilities"
         Then List of Vulnerabilities has column "Id"
@@ -110,7 +107,6 @@ Feature: SBOM Explorer - View SBOM details
 
     @slow
     Scenario Outline: Sorting SBOM Vulnerabilities
-        Given An ingested SBOM "<sbomName>" is available
         When User visits SBOM details Page of "<sbomName>"
         When User selects the Tab "Vulnerabilities"
         Then Table column "Description" is not sortable

--- a/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
+++ b/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
@@ -10,17 +10,6 @@ export const { Given, When, Then } = createBdd(test);
 const PACKAGE_TABLE_NAME = "Package table";
 const VULN_TABLE_NAME = "Vulnerability table";
 
-Given("An ingested SBOM {string} is available", async ({ page }, sbomName) => {
-  const sbomListPage = await SbomListPage.build(page);
-
-  const toolbar = await sbomListPage.getToolbar();
-  const table = await sbomListPage.getTable();
-
-  await toolbar.applyTextFilter("Filter text", sbomName);
-  await table.waitUntilDataIsLoaded();
-  await table.verifyColumnContainsText("Name", sbomName);
-});
-
 When(
   "User visits SBOM details Page of {string}",
   async ({ page }, sbomName) => {


### PR DESCRIPTION
Depends on https://github.com/guacsec/trustify-ui/pull/723

This PR includes all changes from https://github.com/guacsec/trustify-ui/pull/723 so that PR needs to be merged first.

- This PR Removes all the steps `Given An ingested SBOM "<sbomName>" is available` and let the step `User visits SBOM details Page of "<sbomName>"` do all the navigation.
- Doing the changes in the PR, we are reusing already existing helpers for navigating to the SBOM Details page

Reasoning:
All tests within the @sbom-explorer directory should assume we successfully arrived to SBOM Details Page; therefore we can safely use our utility classes for navigating to the SBOM Details Page.

## Summary by Sourcery

Refactor sbom-explorer end-to-end tests to reuse SbomDetailsPage utilities for navigation and remove redundant Given steps; extract shared SBOM list page steps into a new sbom-search test suite for vulnerability checks and label management.

New Features:
- Add SBOM Search Page tests to verify vulnerabilities and label additions from the SBOM list

Enhancements:
- Simplify sbom-explorer tests by delegating navigation to SbomDetailsPage.build and removing manual list-page steps

Tests:
- Extract common 'ingested SBOM' and 'label addition' steps into a new sbom-search suite
- Introduce sbom-search.step.ts and sbom-search.feature for shared list-page scenarios