### PR TITLE
tests (fix): codecov use repository owner as namespace

### DIFF
--- a/.github/workflows/ci-coverage.yaml
+++ b/.github/workflows/ci-coverage.yaml
@@ -62,4 +62,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: trustification/trustify-ui
+          slug: ${{ github.repository_owner }}/trustify-ui


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use GitHub repository owner as namespace for Codecov slug instead of hard-coded value