### PR TITLE
tests (fix): replace /upload by /importers as default landing page

### DIFF
--- a/e2e/tests/ui/helpers/Auth.ts
+++ b/e2e/tests/ui/helpers/Auth.ts
@@ -10,12 +10,14 @@ export const login = async (page: Page) => {
     const userName = AUTH_USER;
     const userPassword = AUTH_PASSWORD;
 
-    await page.goto("/upload");
+    await page.goto("/importers");
 
     await page.fill('input[name="username"]:visible', userName);
     await page.fill('input[name="password"]:visible', userPassword);
     await page.keyboard.press("Enter");
 
-    await expect(page.getByRole("heading", { name: "Upload" })).toHaveCount(1); // Ensure login was successful
+    await expect(page.getByRole("heading", { name: "Importers" })).toHaveCount(
+      1,
+    ); // Ensure login was successful
   }
 };

--- a/e2e/tests/ui/pages/Navigation.ts
+++ b/e2e/tests/ui/pages/Navigation.ts
@@ -27,7 +27,7 @@ export class Navigation {
   ) {
     // By default, we do not initialize navigation at "/"" where the Dashboard is located
     // This should help us to save some time loading pages as the Dashboard fetches too much data
-    await this._page.goto("/upload");
+    await this._page.goto("/importers");
     await this._page.getByRole("link", { name: menu }).click();
   }
 }


### PR DESCRIPTION
The Upload page does not exist any longer, now the Upload is done in the SBOM and Advisory List Page

This PR should make the default landing page of the e2e tests the `/importers` page

## Summary by Sourcery

Tests:
- Replace references to /upload with /importers and update heading expectation to 'Importers' in Auth and Navigation test helpers