### PR TITLE
fix: remove license type from Sbom Details Page (Package Tab)

### DIFF
--- a/client/src/app/pages/sbom-details/packages-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/packages-by-sbom.tsx
@@ -2,7 +2,6 @@ import type React from "react";
 import { generatePath, Link } from "react-router-dom";
 
 import {
-  Label,
   List,
   ListItem,
   Toolbar,
@@ -267,8 +266,7 @@ export const PackagesBySbom: React.FC<PackagesProps> = ({ sbomId }) => {
                                   {renderLicenseWithMappings(
                                     e.license_name,
                                     item.licenses_ref_mapping,
-                                  )}{" "}
-                                  <Label isCompact>{e.license_type}</Label>
+                                  )}
                                 </ListItem>
                               ))}
                             </List>


### PR DESCRIPTION
Fixes: https://github.com/guacsec/trustify-ui/issues/742

## Summary by Sourcery

Bug Fixes:
- Remove license type label from SBOM details package tab