### PR TITLE
fix: use original filename for the csv downloadable file

### DIFF
--- a/client/src/app/pages/sbom-scan/sbom-scan.tsx
+++ b/client/src/app/pages/sbom-scan/sbom-scan.tsx
@@ -58,6 +58,12 @@ export const SbomScan: React.FC = () => {
       setUploadResponseData(extractedData);
     });
 
+  const joinedFileName = React.useMemo(() => {
+    return Array.from(uploads.keys())
+      .map((e) => e.name)
+      .join("_");
+  }, [uploads]);
+
   // Navigation blockers
   const shouldBlock = React.useCallback<BlockerFunction>(
     ({ currentLocation, nextLocation }) => {
@@ -91,7 +97,7 @@ export const SbomScan: React.FC = () => {
   const handleDownloadCSV = async () => {
     const csv = convertToCSV(vulnerabilities);
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
-    saveAs(blob, "data.csv");
+    saveAs(blob, `${joinedFileName}.csv`);
   };
 
   const scanAnotherFile = () => {
@@ -234,8 +240,8 @@ export const SbomScan: React.FC = () => {
             variant={EmptyStateVariant.sm}
           >
             <EmptyStateBody>
-              The {Array.from(uploads.keys()).map((e) => e.name)} was
-              successfully analyzed and found no vulnerabilities to report.
+              The {joinedFileName} was successfully analyzed and found no
+              vulnerabilities to report.
             </EmptyStateBody>
             <EmptyStateFooter>
               <EmptyStateActions>


### PR DESCRIPTION
Feedback was given after a short internal demo.
The filename used for downloading the CSV file should reuse the original name of the file selected for the analysis (SBOM filename)

## Summary by Sourcery

Reuse the original uploaded SBOM filename(s) for the downloadable CSV file and related UI messages.

Enhancements:
- Compute a joined filename from the uploaded file(s) via React.useMemo
- Use the computed filename for the CSV download instead of a static name
- Update the EmptyState message to reference the computed filename