### PR TITLE
Queries : Use !!id for stronger string test

### DIFF
--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -92,7 +92,7 @@ export const useFetchAdvisoryById = (id: string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [AdvisoriesQueryKey, id],
     queryFn: () => getAdvisory({ client, path: { key: id } }),
-    enabled: id !== undefined,
+    enabled: !!id,
   });
 
   return {
@@ -127,7 +127,7 @@ export const useFetchAdvisorySourceById = (id: string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [AdvisoriesQueryKey, id, "source"],
     queryFn: () => downloadAdvisory({ client, path: { key: id } }),
-    enabled: id !== undefined,
+    enabled: !!id,
   });
 
   return {

--- a/client/src/app/queries/importers.ts
+++ b/client/src/app/queries/importers.ts
@@ -65,7 +65,7 @@ export const useFetchImporterById = (id: string) => {
   const { data, isLoading, error } = useQuery({
     queryKey: [ImportersQueryKey, id],
     queryFn: () => getImporter({ client, path: { name: id } }),
-    enabled: id !== undefined,
+    enabled: !!id,
   });
 
   return {

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -97,7 +97,7 @@ export const useFetchSBOMById = (
         ? Promise.resolve(undefined)
         : getSbom({ client, path: { id: id } });
     },
-    enabled: id !== undefined,
+    enabled: !!id,
     refetchInterval,
     retry,
   });


### PR DESCRIPTION
Replaces several `enabled: id !== undefined` with `enabled: !!id`.

The former version doesn't check for all cases.

## Summary by Sourcery

Enhancements:
- Use truthy check (!!id) instead of id !== undefined for query activation to prevent running with null, empty or zero values