### PR TITLE
fix: add sorting to License Filters

### DIFF
--- a/client/src/app/pages/package-list/package-context.tsx
+++ b/client/src/app/pages/package-list/package-context.tsx
@@ -69,6 +69,7 @@ export const PackageSearchProvider: React.FunctionComponent<
         value: debouncedInputValueLicense,
       },
     ],
+    sort: { field: "license", direction: "asc" },
     page: { pageNumber: 1, itemsPerPage: 10 },
   });
 

--- a/client/src/app/pages/sbom-list/sbom-context.tsx
+++ b/client/src/app/pages/sbom-list/sbom-context.tsx
@@ -70,6 +70,7 @@ export const SbomSearchProvider: React.FunctionComponent<ISbomProvider> = ({
         value: debouncedInputValueLicense,
       },
     ],
+    sort: { field: "license", direction: "asc" },
     page: { pageNumber: 1, itemsPerPage: 10 },
   });
 


### PR DESCRIPTION
A title enhancement to the License Filters so they are rendered in Alphabetical order when rendered in the Dropdown.

Currently, without this PR, the licenses would be rendered in random order as per image below.

<img width="1130" height="1012" alt="image (4)" src="https://github.com/user-attachments/assets/73788a79-1c20-41d5-9db1-dd4905725570" />

## Summary by Sourcery

Ensure license filters in package and SBOM lists are rendered in alphabetical order by adding ascending sort on the license field.

Bug Fixes:
- Add ascending sort on the license field in PackageSearchProvider
- Add ascending sort on the license field in SbomSearchProvider