### PR TITLE
fix: render only affected vulnerability in scan-sbom

### DIFF
--- a/client/src/app/pages/sbom-scan/components/VulnerabilityTable.tsx
+++ b/client/src/app/pages/sbom-scan/components/VulnerabilityTable.tsx
@@ -56,19 +56,19 @@ export const VulnerabilityTable: React.FC<IVulnerabilityTableProps> = ({
   isFetching,
   fetchError,
 }) => {
+  const affectedVulnerabilities = React.useMemo(() => {
+    return vulnerabilities.filter((item) => item.status === "affected");
+  }, [vulnerabilities]);
+
   const allImporterNames = React.useMemo(() => {
-    return vulnerabilities
+    return affectedVulnerabilities
       .flatMap((e) => Array.from(e.advisories.values()))
       .reduce((prev, current) => {
         const importerName = extractImporterNameFromAdvisory(current.advisory);
         prev.add(importerName);
         return prev;
       }, new Set<string>());
-  }, [vulnerabilities]);
-
-  const affectedVulnerabilities = React.useMemo(() => {
-    return vulnerabilities.filter((item) => item.status === "affected");
-  }, [vulnerabilities]);
+  }, [affectedVulnerabilities]);
 
   const tableDataWithUiId = useWithUiId(
     affectedVulnerabilities,


### PR DESCRIPTION
In response to https://issues.redhat.com/browse/TC-2980

- Removes the "Status" filter from the Vulnerability report
- The table will only render "affected" vulnerabilities

## Summary by Sourcery

Display only vulnerabilities with status 'affected' in the SBOM vulnerability report and remove the status filter.

Enhancements:
- Filter the vulnerability table data to only include items with status 'affected'.
- Remove the status filter option and its initial filter values from the table configuration.