### PR TITLE
fix: print filename in the scan sbom error empty state

### DIFF
--- a/client/src/app/pages/sbom-scan/components/UploadFileForAnalysis.tsx
+++ b/client/src/app/pages/sbom-scan/components/UploadFileForAnalysis.tsx
@@ -116,8 +116,8 @@ export const UploadFileForAnalysis: React.FC<IUploadFileForAnalysisProps> = ({
                 variant={EmptyStateVariant.sm}
               >
                 <EmptyStateBody>
-                  The file could not be analyzed. The file might be corrupted or
-                  an unsupported format.
+                  The {file.name} file could not be analyzed. The file might be
+                  corrupted or an unsupported format.
                   {upload.error.response?.data.message && (
                     <ExpandableSection toggleText="Show details">
                       {upload.error.response?.data.message}

--- a/client/src/app/pages/sbom-scan/sbom-scan.tsx
+++ b/client/src/app/pages/sbom-scan/sbom-scan.tsx
@@ -220,8 +220,8 @@ export const SbomScan: React.FC = () => {
             variant={EmptyStateVariant.sm}
           >
             <EmptyStateBody>
-              The file could not be analyzed. The file might be corrupted or an
-              unsupported format.
+              The {joinedFileName} file could not be analyzed. The file might be
+              corrupted or an unsupported format.
             </EmptyStateBody>
             <EmptyStateFooter>
               <EmptyStateActions>


### PR DESCRIPTION
An enhancement to render the filename in the empty error messages.
Addresses comment here https://issues.redhat.com/browse/TC-2985?focusedId=28205600&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-28205600

## Summary by Sourcery

Show the actual file name in SBOM scan error empty states

Enhancements:
- Include the file name in empty-state error messages in UploadFileForAnalysis component
- Include the file name in empty-state error messages in SbomScan component