### PR TITLE
fix(tests): toolbar multiselect should use exact match

### DIFF
--- a/e2e/tests/ui/pages/Toolbar.ts
+++ b/e2e/tests/ui/pages/Toolbar.ts
@@ -83,7 +83,10 @@ export class Toolbar {
       await inputText.clear();
       await inputText.fill(option);
 
-      const dropdownOption = this._page.getByRole("menuitem", { name: option });
+      const dropdownOption = this._page.getByRole("menuitem", {
+        name: option,
+        exact: true,
+      });
       await expect(dropdownOption).toBeVisible();
       await dropdownOption.click();
     }


### PR DESCRIPTION
Currently the main branch is failing its nightly e2e execution tests as you can see here https://github.com/guacsec/trustify-ui/actions/workflows/nightly-ci-e2e.yaml

At some point there was a change in the container backend `GET http://localhost:3000/api/v2/sbom/{id}/all-license-ids` that lists not only the licenses that belong to the current SBOM but also some default licenses. 

Why the tests is failing:
- The test is trying to apply a filter per license `Apache-2.0` but there are more than 1 license with the same prefix.

How this PR fixes the error:
- To select an element in the dropdown there should be an exact match and ignore the ones that do not match exactly the wanted filter

## Summary by Sourcery

Tests:
- Require exact matching when selecting toolbar multiselect dropdown options in e2e tests to avoid partial matches