### PR TITLE
fix: Scan SBOM - filter by Unknown Severity

### DIFF
--- a/client/src/app/pages/sbom-scan/components/VulnerabilityTable.tsx
+++ b/client/src/app/pages/sbom-scan/components/VulnerabilityTable.tsx
@@ -142,7 +142,7 @@ export const VulnerabilityTable: React.FC<IVulnerabilityTableProps> = ({
         placeholderText: "Severity",
         type: FilterType.multiselect,
         selectOptions: [
-          { value: "null", label: "Unknown" },
+          { value: "unknown", label: "Unknown" },
           { value: "none", label: "None" },
           { value: "low", label: "Low" },
           { value: "medium", label: "Medium" },


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/TC-3039

## Summary by Sourcery

Bug Fixes:
- Change the severity filter option value from "null" to "unknown" for the Unknown label