### PR TITLE
fix: ScanSBOM sort cell severity

### DIFF
--- a/client/src/app/pages/sbom-scan/components/VulnerabilityTable.tsx
+++ b/client/src/app/pages/sbom-scan/components/VulnerabilityTable.tsx
@@ -295,6 +295,18 @@ export const VulnerabilityTable: React.FC<IVulnerabilityTableProps> = ({
                               ) !== -1
                             );
                           })
+                          .sort(
+                            (
+                              [_advisoryKeyA, advisoryValueA],
+                              [_advisoryKeyB, advisoryValueB],
+                            ) => {
+                              const scoreA =
+                                advisoryValueA.opinionatedScore?.value ?? 0;
+                              const scoreB =
+                                advisoryValueB.opinionatedScore?.value ?? 0;
+                              return scoreB - scoreA;
+                            },
+                          )
                           .map(([advisoryKey, advisoryValue]) => (
                             <Flex key={advisoryKey}>
                               <FlexItem spacer={{ default: "spacerNone" }}>


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/TC-3038

Applies Sort to the cell Severity in the SCAN SBOM Report

## Summary by Sourcery

Bug Fixes:
- Sort vulnerabilities by descending opinionated severity score in the SBOM scan table