### PR TITLE
fix: ScanSBOM use spinner instead of icon

### DIFF
--- a/client/src/app/pages/sbom-scan/components/UploadFileForAnalysis.tsx
+++ b/client/src/app/pages/sbom-scan/components/UploadFileForAnalysis.tsx
@@ -15,10 +15,10 @@ import {
   ModalHeader,
   MultipleFileUpload,
   MultipleFileUploadMain,
+  Spinner,
 } from "@patternfly/react-core";
 
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
-import InProgressIcon from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
 import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
 import UploadIcon from "@patternfly/react-icons/dist/esm/icons/upload-icon";
 
@@ -143,7 +143,7 @@ export const UploadFileForAnalysis: React.FC<IUploadFileForAnalysisProps> = ({
               key={`${file.name}-${index}-progress`}
               headingLevel="h4"
               titleText={"Analyzing SBOM"}
-              icon={InProgressIcon}
+              icon={Spinner}
               variant={EmptyStateVariant.sm}
             >
               <EmptyStateBody>

--- a/client/src/app/pages/sbom-scan/sbom-scan.tsx
+++ b/client/src/app/pages/sbom-scan/sbom-scan.tsx
@@ -22,6 +22,7 @@ import {
   ModalFooter,
   ModalHeader,
   PageSection,
+  Spinner,
   Split,
   SplitItem,
   type MenuToggleElement,
@@ -30,7 +31,6 @@ import {
 import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
 import DownloadIcon from "@patternfly/react-icons/dist/esm/icons/download-icon";
 import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
-import InProgressIcon from "@patternfly/react-icons/dist/esm/icons/in-progress-icon";
 import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
 
 import type { ExtractResult } from "@app/client";
@@ -198,7 +198,7 @@ export const SbomScan: React.FC = () => {
           <EmptyState
             titleText="Generating vulnerability report"
             headingLevel="h4"
-            icon={InProgressIcon}
+            icon={Spinner}
           >
             <EmptyStateBody>
               Analyzing your SBOM for security vulnerabilities and package


### PR DESCRIPTION
Addresses: https://issues.redhat.com/browse/TC-3007

This PR replaces the Icon from 2 empty states and make them use the spinner as requested in the JIRA above

## Summary by Sourcery

Replace static InProgressIcon with dynamic Spinner component for SBOM scan empty states

Enhancements:
- Use Spinner as icon for "Generating vulnerability report" empty state in SbomScan
- Use Spinner as icon for "Analyzing SBOM" empty state in UploadFileForAnalysis