### PR TITLE
fix: add validations to rangeDate filter

### DIFF
--- a/client/src/app/components/FilterPanel/DateRangeFilter.tsx
+++ b/client/src/app/components/FilterPanel/DateRangeFilter.tsx
@@ -5,7 +5,6 @@ import {
   Form,
   FormGroup,
   isValidDate,
-  isValidDate as isValidJSDate,
 } from "@patternfly/react-core";
 
 import {
@@ -98,7 +97,7 @@ export const DateRangeFilter = <TItem,>({
         <DatePicker
           value={to ? americanDateFormat(to) : ""}
           onChange={onToDateChange}
-          isDisabled={isDisabled || !isValidJSDate(from)}
+          isDisabled={isDisabled || !isValidDate(from)}
           dateFormat={americanDateFormat}
           dateParse={parseAmericanDate}
           invalidFormatText={"Invalid date"}

--- a/client/src/app/components/FilterToolbar/DateRangeFilter.tsx
+++ b/client/src/app/components/FilterToolbar/DateRangeFilter.tsx
@@ -8,7 +8,6 @@ import {
   type ToolbarLabelGroup,
   Tooltip,
   isValidDate,
-  isValidDate as isValidJSDate,
 } from "@patternfly/react-core";
 
 import type { IFilterControlProps } from "./FilterControl";
@@ -146,7 +145,7 @@ export const DateRangeFilter = <TItem,>({
         <DatePicker
           value={to ? americanDateFormat(to) : ""}
           onChange={onToDateChange}
-          isDisabled={isDisabled || !isValidJSDate(from)}
+          isDisabled={isDisabled || !isValidDate(from)}
           dateFormat={americanDateFormat}
           dateParse={parseAmericanDate}
           invalidFormatText={"Invalid date"}


### PR DESCRIPTION
## Fixes
Fixes: https://github.com/trustification/trustify-ui/issues/393, https://github.com/trustification/trustify-ui/issues/394, and:

JIRA fixes:

- https://issues.redhat.com/browse/TC-2402
- https://issues.redhat.com/browse/TC-2422
- https://issues.redhat.com/browse/TC-2393

## What changes

- This PR is adding `validators` to each of the date picker components. That should avoid the user to select dates that wrong.
  - the Validators tell the date component to disable the dates that we know the user should not select. See the video below
- Setting  the "invalidFormatText" error in case the user types anything but dates
- For the filters to be applied both FROM and TO should be selected


https://github.com/user-attachments/assets/f6c8326b-ab45-46e2-94df-d8e8a04e5e8e

## Summary by Sourcery

Add date format validation and range enforcement to the DateRangeFilter components in both the filter panel and toolbar.

Enhancements:
- Show "Invalid date" error text when the user enters a malformed date in the date pickers
- Disable and validate the end-date picker to ensure the "to" date is not earlier than the "from" date