### PR TITLE
test: test old version of backend to double-check regresion

### DIFF
--- a/.github/workflows/ci-coverage.yaml
+++ b/.github/workflows/ci-coverage.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/start-trustify
         with:
           ui_image: ${{ inputs.ui_image }}
-          server_image: ${{ inputs.server_image }}
+          server_image: ghcr.io/guacsec/trustd:0.4.0
           server_db_image: ${{ inputs.server_db_image }}
 
       - name: trustify-ui - start in dev mode

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -76,4 +76,4 @@ jobs:
     with:
       artifact: trustify-ui
       ui_image: ghcr.io/guacsec/trustify-ui:pr-test
-      server_image: ghcr.io/guacsec/trustd:${{ needs.discover-envs-for-e2e-ci.outputs.image_tag }}
+      server_image: ghcr.io/guacsec/trustd:0.4.0


### PR DESCRIPTION
## Summary by Sourcery

Pin backend server image tag to v0.4.1 in CI workflows for regression testing

CI:
- Pin server_image to version 0.4.1 in ci-coverage workflow
- Pin server_image to version 0.4.1 in ci-e2e workflow