### PR TITLE
test: fix vulnerability count

### DIFF
--- a/e2e/tests/ui/pages/sbom-details/vulnerabilities/donutchart.spec.ts
+++ b/e2e/tests/ui/pages/sbom-details/vulnerabilities/donutchart.spec.ts
@@ -16,8 +16,8 @@ test.describe("DonutChart validations", { tag: "@tier1" }, () => {
 
     await expect(page.locator("#legend-labels-0")).toContainText("Critical: 0");
     await expect(page.locator("#legend-labels-1")).toContainText("High: 2");
-    await expect(page.locator("#legend-labels-2")).toContainText("Medium: 14");
-    await expect(page.locator("#legend-labels-3")).toContainText("Low: 0");
+    await expect(page.locator("#legend-labels-2")).toContainText("Medium: 13");
+    await expect(page.locator("#legend-labels-3")).toContainText("Low: 1");
     await expect(page.locator("#legend-labels-4")).toContainText("None: 0");
     await expect(page.locator("#legend-labels-5")).toContainText("Unknown: 0");
   });

--- a/e2e/tests/ui/pages/sbom-list/columns.spec.ts
+++ b/e2e/tests/ui/pages/sbom-list/columns.spec.ts
@@ -37,7 +37,11 @@ test.describe("Columns validations", { tag: "@tier1" }, () => {
       },
       {
         severity: "medium",
-        count: 14,
+        count: 13,
+      },
+      {
+        severity: "low",
+        count: 1,
       },
     ];
 


### PR DESCRIPTION
## Summary by Sourcery

Correct vulnerability count expectations in e2e SBOM list and donut chart UI tests.

Tests:
- Update medium severity count from 14 to 13 in columns and donut chart specs
- Add low severity count of 1 to the SBOM list and donut chart tests