### PR TITLE
fix: sbom vulnerability should take highest advisory score

### DIFF
--- a/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
+++ b/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
@@ -89,8 +89,14 @@ const advisoryToModels = (advisories: SbomAdvisory[]) => {
           (item) => !areVulnerabilityOfSbomEqual(item, existingElement),
         );
 
+        const vulnerabilityWithHighestScore =
+          existingElement.vulnerability.average_score >
+          current.vulnerability.average_score
+            ? existingElement
+            : current;
+
         const updatedItemInArray: VulnerabilityOfSbom = {
-          ...existingElement,
+          ...vulnerabilityWithHighestScore,
           relatedPackages: [
             ...existingElement.relatedPackages,
             {


### PR DESCRIPTION
SBOM's vulnerabilities can contain multiple advisories, each advisory with its own average_score. Since the current UI does not render all advisories but only one, we should render/select the one with the highest score

Fixes https://issues.redhat.com/browse/TC-3143

## Summary by Sourcery

Bug Fixes:
- Pick the advisory with the highest average_score instead of arbitrarily choosing one when multiple advisories exist for an SBOM vulnerability