### PR TITLE
fix: SBOM Details - Packages Tab - Long licenses occupy too much space

### DIFF
--- a/client/src/app/pages/sbom-details/packages-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/packages-by-sbom.tsx
@@ -217,20 +217,15 @@ export const PackagesBySbom: React.FC<PackagesProps> = ({ sbomId }) => {
                     </Td>
                     <Td
                       width={20}
-                      modifier="truncate"
+                      modifier="breakWord"
                       {...getTdProps({
                         columnKey: "licenses",
-                        isCompoundExpandToggle: item.licenses.length > 1,
+                        isCompoundExpandToggle: item.licenses.length > 0,
                         item: item,
                         rowIndex,
                       })}
                     >
-                      {item.licenses.length === 1
-                        ? renderLicenseWithMappings(
-                            item.licenses[0].license_name,
-                            item.licenses_ref_mapping,
-                          )
-                        : `${item.licenses.length} Licenses`}
+                      {item.licenses.length} Licenses
                     </Td>
                     <Td
                       width={20}


### PR DESCRIPTION
… for versions column

## Summary by Sourcery

Enhancements:
- Change the licenses table column to use truncation for long content instead of breaking words, matching the versions column behavior.