### PR TITLE
chore: remove deprecated function validatePagination

### DIFF
--- a/e2e/tests/ui/pages/Pagination.ts
+++ b/e2e/tests/ui/pages/Pagination.ts
@@ -47,53 +47,6 @@ export class Pagination {
     await expect(this._pagination.locator("input")).toHaveValue("1");
   }
 
-  /**
-   * @deprecated use fixtures/PaginationMatchers instead
-   */
-  async validatePagination() {
-    // Verify next buttons are enabled as there are more than 11 rows present
-    const nextPageButton = this._pagination.locator(
-      "button[data-action='next']",
-    );
-    await expect(nextPageButton).toBeVisible();
-    await expect(nextPageButton).not.toBeDisabled();
-
-    // Verify that previous buttons are disabled being on the first page
-    const prevPageButton = this._pagination.locator(
-      "button[data-action='previous']",
-    );
-    await expect(prevPageButton).toBeVisible();
-    await expect(prevPageButton).toBeDisabled();
-
-    // Verify that navigation button to last page is enabled
-    const lastPageButton = this._pagination.locator(
-      "button[data-action='last']",
-    );
-    await expect(lastPageButton).toBeVisible();
-    await expect(lastPageButton).not.toBeDisabled();
-
-    // Verify that navigation button to first page is disabled being on the first page
-    const firstPageButton = this._pagination.locator(
-      "button[data-action='first']",
-    );
-    await expect(firstPageButton).toBeVisible();
-    await expect(firstPageButton).toBeDisabled();
-
-    // Navigate to next page
-    await nextPageButton.click();
-
-    // Verify that previous buttons are enabled after moving to next page
-    await expect(prevPageButton).toBeVisible();
-    await expect(prevPageButton).not.toBeDisabled();
-
-    // Verify that navigation button to first page is enabled after moving to next page
-    await expect(firstPageButton).toBeVisible();
-    await expect(firstPageButton).not.toBeDisabled();
-
-    // Moving back to the first page
-    await firstPageButton.click();
-  }
-
   // TODO: This seems not belonging here. This matches two entities: Pagination and Table so cannot moved to fixtures/PaginationMatchers.ts. Needs refactoring.
   async validateItemsPerPage(columnName: string, table: Table) {
     // Verify that only 10 items are displayed

--- a/e2e/tests/ui/pages/advisory-details/vulnerabilities/pagination.spec.ts
+++ b/e2e/tests/ui/pages/advisory-details/vulnerabilities/pagination.spec.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { expect } from "../../../assertions";
 import { test } from "../../../fixtures";
 import { login } from "../../../helpers/Auth";
 import { VulnerabilitiesTab } from "./VulnerabilitiesTab";
@@ -17,7 +18,15 @@ test.describe.skip("Pagination validations", { tag: "@tier1" }, () => {
     );
     const pagination = await vulnerabilitiesTab.getPagination();
 
-    await pagination.validatePagination();
+    // Verify first page
+    await expect(pagination).toBeFirstPage();
+    await expect(pagination).toHaveNextPage();
+
+    // Navigate to next page
+    await pagination.getNextPageButton().click();
+
+    // Verify that previous buttons are enabled after moving to next page
+    await expect(pagination).toHavePreviousPage();
   });
 
   test("Items per page validations", async ({ page }) => {

--- a/e2e/tests/ui/pages/advisory-list/pagination.spec.ts
+++ b/e2e/tests/ui/pages/advisory-list/pagination.spec.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { expect } from "../../assertions";
 import { test } from "../../fixtures";
 import { login } from "../../helpers/Auth";
 import { AdvisoryListPage } from "./AdvisoryListPage";
@@ -13,7 +14,16 @@ test.describe("Pagination validations", { tag: "@tier1" }, () => {
     const listPage = await AdvisoryListPage.build(page);
 
     const pagination = await listPage.getPagination();
-    await pagination.validatePagination();
+
+    // Verify first page
+    await expect(pagination).toBeFirstPage();
+    await expect(pagination).toHaveNextPage();
+
+    // Navigate to next page
+    await pagination.getNextPageButton().click();
+
+    // Verify that previous buttons are enabled after moving to next page
+    await expect(pagination).toHavePreviousPage();
   });
 
   test("Items per page validations", async ({ page }) => {

--- a/e2e/tests/ui/pages/package-details/sboms/pagination.spec.ts
+++ b/e2e/tests/ui/pages/package-details/sboms/pagination.spec.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { expect } from "../../../assertions";
 import { test } from "../../../fixtures";
 import { login } from "../../../helpers/Auth";
 import { SbomsTab } from "./SbomsTab";
@@ -16,7 +17,15 @@ test.describe.skip("Pagination validations", { tag: "@tier1" }, () => {
     });
     const pagination = await sbomTab.getPagination();
 
-    await pagination.validatePagination();
+    // Verify first page
+    await expect(pagination).toBeFirstPage();
+    await expect(pagination).toHaveNextPage();
+
+    // Navigate to next page
+    await pagination.getNextPageButton().click();
+
+    // Verify that previous buttons are enabled after moving to next page
+    await expect(pagination).toHavePreviousPage();
   });
 
   test("Items per page validations", async ({ page }) => {

--- a/e2e/tests/ui/pages/package-details/vulnerabilities/pagination.spec.ts
+++ b/e2e/tests/ui/pages/package-details/vulnerabilities/pagination.spec.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { expect } from "../../../assertions";
 import { test } from "../../../fixtures";
 import { login } from "../../../helpers/Auth";
 import { VulnerabilitiesTab } from "./VulnerabilitiesTab";
@@ -16,7 +17,15 @@ test.describe.skip("Pagination validations", { tag: "@tier1" }, () => {
     });
     const pagination = await vulnerabilitiesTab.getPagination();
 
-    await pagination.validatePagination();
+    // Verify first page
+    await expect(pagination).toBeFirstPage();
+    await expect(pagination).toHaveNextPage();
+
+    // Navigate to next page
+    await pagination.getNextPageButton().click();
+
+    // Verify that previous buttons are enabled after moving to next page
+    await expect(pagination).toHavePreviousPage();
   });
 
   test("Items per page validations", async ({ page }) => {

--- a/e2e/tests/ui/pages/package-list/pagination.spec.ts
+++ b/e2e/tests/ui/pages/package-list/pagination.spec.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { expect } from "../../assertions";
 import { test } from "../../fixtures";
 import { login } from "../../helpers/Auth";
 import { PackageListPage } from "./PackageListPage";
@@ -13,7 +14,15 @@ test.describe("Pagination validations", { tag: "@tier1" }, () => {
     const listPage = await PackageListPage.build(page);
     const pagination = await listPage.getPagination();
 
-    await pagination.validatePagination();
+    // Verify first page
+    await expect(pagination).toBeFirstPage();
+    await expect(pagination).toHaveNextPage();
+
+    // Navigate to next page
+    await pagination.getNextPageButton().click();
+
+    // Verify that previous buttons are enabled after moving to next page
+    await expect(pagination).toHavePreviousPage();
   });
 
   test("Items per page validations", async ({ page }) => {

--- a/e2e/tests/ui/pages/sbom-details/packages/pagination.spec.ts
+++ b/e2e/tests/ui/pages/sbom-details/packages/pagination.spec.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { expect } from "../../../assertions";
 import { test } from "../../../fixtures";
 import { login } from "../../../helpers/Auth";
 import { PackagesTab } from "./PackagesTab";
@@ -13,7 +14,15 @@ test.describe("Pagination validations", { tag: "@tier1" }, () => {
     const packageTab = await PackagesTab.build(page, "quarkus-bom");
     const pagination = await packageTab.getPagination();
 
-    await pagination.validatePagination();
+    // Verify first page
+    await expect(pagination).toBeFirstPage();
+    await expect(pagination).toHaveNextPage();
+
+    // Navigate to next page
+    await pagination.getNextPageButton().click();
+
+    // Verify that previous buttons are enabled after moving to next page
+    await expect(pagination).toHavePreviousPage();
   });
 
   test("Items per page validations", async ({ page }) => {

--- a/e2e/tests/ui/pages/sbom-details/vulnerabilities/pagination.spec.ts
+++ b/e2e/tests/ui/pages/sbom-details/vulnerabilities/pagination.spec.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { expect } from "../../../assertions";
 import { test } from "../../../fixtures";
 import { login } from "../../../helpers/Auth";
 import { VulnerabilitiesTab } from "./VulnerabilitiesTab";
@@ -16,7 +17,15 @@ test.describe("Pagination validations", { tag: "@tier1" }, () => {
     );
     const pagination = await vulnerabilityTab.getPagination();
 
-    await pagination.validatePagination();
+    // Verify first page
+    await expect(pagination).toBeFirstPage();
+    await expect(pagination).toHaveNextPage();
+
+    // Navigate to next page
+    await pagination.getNextPageButton().click();
+
+    // Verify that previous buttons are enabled after moving to next page
+    await expect(pagination).toHavePreviousPage();
   });
 
   test("Items per page validations", async ({ page }) => {

--- a/e2e/tests/ui/pages/sbom-list/pagination.spec.ts
+++ b/e2e/tests/ui/pages/sbom-list/pagination.spec.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { expect } from "../../assertions";
 import { test } from "../../fixtures";
 import { login } from "../../helpers/Auth";
 import { SbomListPage } from "./SbomListPage";
@@ -13,7 +14,15 @@ test.describe("Pagination validations", { tag: "@tier1" }, () => {
     const listPage = await SbomListPage.build(page);
     const pagination = await listPage.getPagination();
 
-    await pagination.validatePagination();
+    // Verify first page
+    await expect(pagination).toBeFirstPage();
+    await expect(pagination).toHaveNextPage();
+
+    // Navigate to next page
+    await pagination.getNextPageButton().click();
+
+    // Verify that previous buttons are enabled after moving to next page
+    await expect(pagination).toHavePreviousPage();
   });
 
   test("Items per page validations", async ({ page }) => {

--- a/e2e/tests/ui/pages/vulnerability-details/advisories/pagination.spec.ts
+++ b/e2e/tests/ui/pages/vulnerability-details/advisories/pagination.spec.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { expect } from "../../../assertions";
 import { test } from "../../../fixtures";
 import { login } from "../../../helpers/Auth";
 import { AdvisoriesTab } from "./AdvisoriesTab";
@@ -14,7 +15,15 @@ test.describe.skip("Pagination validations", { tag: "@tier1" }, () => {
     const advisoriesTab = await AdvisoriesTab.build(page, "CVE-2023-2976");
     const pagination = await advisoriesTab.getPagination();
 
-    await pagination.validatePagination();
+    // Verify first page
+    await expect(pagination).toBeFirstPage();
+    await expect(pagination).toHaveNextPage();
+
+    // Navigate to next page
+    await pagination.getNextPageButton().click();
+
+    // Verify that previous buttons are enabled after moving to next page
+    await expect(pagination).toHavePreviousPage();
   });
 
   test("Items per page validations", async ({ page }) => {

--- a/e2e/tests/ui/pages/vulnerability-details/sboms/pagination.spec.ts
+++ b/e2e/tests/ui/pages/vulnerability-details/sboms/pagination.spec.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { expect } from "../../../assertions";
 import { test } from "../../../fixtures";
 import { login } from "../../../helpers/Auth";
 import { SbomsTab } from "./SbomsTab";
@@ -14,7 +15,15 @@ test.describe.skip("Pagination validations", { tag: "@tier1" }, () => {
     const sbomTab = await SbomsTab.build(page, "CVE-2023-2976");
     const pagination = await sbomTab.getPagination();
 
-    await pagination.validatePagination();
+    // Verify first page
+    await expect(pagination).toBeFirstPage();
+    await expect(pagination).toHaveNextPage();
+
+    // Navigate to next page
+    await pagination.getNextPageButton().click();
+
+    // Verify that previous buttons are enabled after moving to next page
+    await expect(pagination).toHavePreviousPage();
   });
 
   test("Items per page validations", async ({ page }) => {


### PR DESCRIPTION
This PR is just doing some cleanup removing the function `validatePagination` from `e2e/tests/ui/pages/Pagination.ts` because that function was previously deprecated

## Summary by Sourcery

Enhancements:
- Replace direct validatePagination helper usage in pagination E2E specs with explicit matcher-based assertions for first, next, and previous page behavior.