### PR TITLE
fix: enable tsc checks on e2e code

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,7 +14,7 @@
     "test:ui:host": "npx bddgen && npx playwright test --ui-host 127.0.0.1",
     "test:bdd": "npx bddgen && npx playwright test --project='bdd'",
     "test:bdd:trace": "npx bddgen && npx playwright test --project='bdd' --trace on",
-    "check": "biome check --error-on-warnings .",
+    "check": "biome check --error-on-warnings . && npx tsc --noEmit",
     "check:write": "biome check --write .",
     "format": "biome format .",
     "format:fix": "biome format --write ."

--- a/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
+++ b/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
@@ -16,7 +16,7 @@ Given("An ingested SBOM {string} is available", async ({ page }, sbomName) => {
   const toolbar = await sbomListPage.getToolbar();
   const table = await sbomListPage.getTable();
 
-  await toolbar.applyTextFilter("Filter text", sbomName);
+  await toolbar.applyFilter({ "Filter text": sbomName });
   await table.waitUntilDataIsLoaded();
   await table.verifyColumnContainsText("Name", sbomName);
 });

--- a/e2e/tests/ui/features/@sbom-search/sbom-search.step.ts
+++ b/e2e/tests/ui/features/@sbom-search/sbom-search.step.ts
@@ -16,7 +16,7 @@ Given("An ingested SBOM {string} is available", async ({ page }, sbomName) => {
   const toolbar = await sbomListPage.getToolbar();
   const table = await sbomListPage.getTable();
 
-  await toolbar.applyTextFilter("Filter text", sbomName);
+  await toolbar.applyFilter({ "Filter text": sbomName });
   await table.waitUntilDataIsLoaded();
   await table.verifyColumnContainsText("Name", sbomName);
 });

--- a/e2e/tests/ui/helpers/DetailsPage.ts
+++ b/e2e/tests/ui/helpers/DetailsPage.ts
@@ -129,10 +129,12 @@ export class DetailsPage {
     for (const element of elements) {
       const innerText = await element.textContent();
       const labelArr = await innerText?.split(delimiter);
-      vulnLabelCount[labelArr[0].trim().toString()] = parseInt(
-        labelArr[1].trim(),
-        10,
-      );
+      if (labelArr) {
+        vulnLabelCount[labelArr[0].trim().toString()] = parseInt(
+          labelArr[1].trim(),
+          10,
+        );
+      }
     }
     return vulnLabelCount;
   }


### PR DESCRIPTION
- Enable Typescript Checks for the e2e sub module
- As a result of enabling typescript check, also some code needed to be fixed

## Summary by Sourcery

Enable TypeScript compilation checks for the e2e submodule and update e2e test code to satisfy stricter type checking.

Bug Fixes:
- Guard against undefined split results when parsing vulnerability labels in the e2e details page helper to avoid runtime errors.
- Align SBOM-related UI step definitions with the updated toolbar filter API by switching to the generic applyFilter call.

Build:
- Update the e2e check script to run TypeScript (tsc) with noEmit alongside Biome checks.