### PR TITLE
Hide Upload advisory button on Search page

### DIFF
--- a/client/src/app/pages/advisory-list/advisory-list.tsx
+++ b/client/src/app/pages/advisory-list/advisory-list.tsx
@@ -17,7 +17,7 @@ export const AdvisoryList: React.FC = () => {
       <PageSection hasBodyWrapper={false}>
         <div>
           <AdvisorySearchProvider>
-            <AdvisoryToolbar showFilters />
+            <AdvisoryToolbar showFilters showActions />
             <AdvisoryTable />
           </AdvisorySearchProvider>
         </div>

--- a/client/src/app/pages/advisory-list/advisory-toolbar.tsx
+++ b/client/src/app/pages/advisory-list/advisory-toolbar.tsx
@@ -17,10 +17,12 @@ import { AdvisorySearchContext } from "./advisory-context";
 
 interface AdvisoryToolbarProps {
   showFilters?: boolean;
+  showActions?: boolean;
 }
 
 export const AdvisoryToolbar: React.FC<AdvisoryToolbarProps> = ({
   showFilters,
+  showActions,
 }) => {
   const navigate = useNavigate();
 
@@ -39,14 +41,16 @@ export const AdvisoryToolbar: React.FC<AdvisoryToolbarProps> = ({
     <Toolbar {...toolbarProps} aria-label="advisory-toolbar">
       <ToolbarContent>
         {showFilters && <FilterToolbar {...filterToolbarProps} />}
-        <ToolbarItem>
-          <Button
-            variant="primary"
-            onClick={() => navigate(Paths.advisoryUpload)}
-          >
-            Upload Advisory
-          </Button>
-        </ToolbarItem>
+        {showActions && (
+          <ToolbarItem>
+            <Button
+              variant="primary"
+              onClick={() => navigate(Paths.advisoryUpload)}
+            >
+              Upload Advisory
+            </Button>
+          </ToolbarItem>
+        )}
         <ToolbarItem {...paginationToolbarItemProps}>
           <SimplePagination
             idPrefix="advisory-table"


### PR DESCRIPTION
This PR is trying to resolve this issue:

https://issues.redhat.com/browse/TC-3248

I used the same principle that we used on the same problem with SBOM tab

## Summary by Sourcery

New Features:
- Add a configurable option on the advisory toolbar to control visibility of action buttons like "Upload Advisory".