### PR TITLE
feat: migrate to v3 analysis response

### DIFF
--- a/client/openapi/trustd.yaml
+++ b/client/openapi/trustd.yaml
@@ -4694,6 +4694,7 @@ components:
       required:
       - vulnerability
       - advisory
+      - scores
       - average_severity
       - average_score
       - status
@@ -4710,6 +4711,11 @@ components:
           oneOf:
           - type: 'null'
           - $ref: '#/components/schemas/StatusContext'
+        scores:
+          type: array
+          items:
+            $ref: '#/components/schemas/Score'
+          description: All CVSS scores associated with the vulnerability
         status:
           type: string
         version_range:

--- a/client/src/app/pages/sbom-scan/hooks/useVulnerabilitiesOfSbom.ts
+++ b/client/src/app/pages/sbom-scan/hooks/useVulnerabilitiesOfSbom.ts
@@ -52,22 +52,18 @@ export const useVulnerabilitiesOfSbomByPurls = (purls: string[]) => {
     }
 
     const vulnerabilities = Object.entries(analysisResponse)
-      .flatMap(([purl, analysisDetails]) => {
-        return analysisDetails.details.flatMap((vulnerability) => {
-          return Object.entries(vulnerability.status).flatMap(
-            ([status, advisories]) => {
-              return advisories.map((advisory) => {
-                return {
-                  purl,
-                  vulnerability,
-                  status: status as VulnerabilityStatus,
-                  advisory,
-                  scores: advisory.scores,
-                };
-              });
-            },
-          );
-        });
+      .flatMap(([purl, analysis]) => {
+        return analysis.details
+          .flatMap((detail) => detail.purl_statuses)
+          .map((e) => {
+            return {
+              purl,
+              vulnerability: e.vulnerability,
+              status: e.status as VulnerabilityStatus,
+              advisory: e.advisory,
+              scores: e.scores,
+            };
+          });
       })
       //group
       .reduce((prev, current) => {

--- a/client/src/app/queries/vulnerabilities.ts
+++ b/client/src/app/queries/vulnerabilities.ts
@@ -4,8 +4,8 @@ import type { AxiosError } from "axios";
 import type { HubRequestParams } from "@app/api/models";
 import { client } from "@app/axios-config/apiInit";
 import {
-  type AnalysisResponseV2,
-  analyze,
+  type AnalysisResponse,
+  analyzeV3,
   getVulnerability,
   listVulnerabilities,
 } from "@app/client";
@@ -50,7 +50,7 @@ export const useFetchVulnerabilitiesByPackageIds = (ids: string[]) => {
       return chunks;
     }, []),
     dataResolver: async (ids: string[]) => {
-      const response = await analyze({
+      const response = await analyzeV3({
         client,
         body: { purls: ids },
       });
@@ -71,7 +71,7 @@ export const useFetchVulnerabilitiesByPackageIds = (ids: string[]) => {
   const isFetching = userQueries.some(({ isFetching }) => isFetching);
   const fetchError = userQueries.find(({ error }) => !!error);
 
-  const analysisResponse: AnalysisResponseV2 = {};
+  const analysisResponse: AnalysisResponse = {};
 
   if (!isFetching) {
     for (const data of userQueries.map((item) => item?.data ?? {})) {


### PR DESCRIPTION
Migrates to v3 analysis endpoint. In draft status until the backend merges the latest changes to v3 endpoint

## Summary by Sourcery

Migrate vulnerability analysis queries and data handling to use the v3 analysis response format.

New Features:
- Expose all CVSS scores for each vulnerability advisory in the OpenAPI schema and client models.

Enhancements:
- Adapt SBOM vulnerability aggregation logic to the new v3 analysis response structure with per-PURL vulnerability statuses.
- Update client queries to call the v3 analyze endpoint and use the corresponding response type.