### PR TITLE
fix: advisory-list sorting use document_id

### DIFF
--- a/client/src/app/pages/advisory-list/advisory-context.tsx
+++ b/client/src/app/pages/advisory-list/advisory-context.tsx
@@ -118,7 +118,7 @@ export const AdvisorySearchProvider: React.FunctionComponent<
     getHubRequestParams({
       ...tableControlState,
       hubSortFieldKeys: {
-        identifier: "identifier",
+        identifier: "document_id",
         modified: "modified",
       },
     }),


### PR DESCRIPTION
- Advisory List Page: use `document_id` for sorting instead of the current `identifier` as it was suggested at https://github.com/guacsec/trustify/issues/1810#issuecomment-3049997703

## Summary by Sourcery

Bug Fixes:
- Correct advisory list sorting by switching the sort key from identifier to document_id.