### PR TITLE
tests: add Toolbar and Table utility functions

### DIFF
--- a/e2e/tests/ui/pages/Table.ts
+++ b/e2e/tests/ui/pages/Table.ts
@@ -87,6 +87,25 @@ export class Table<
     return expandedCell;
   }
 
+  async expandRow(rowIndex: number) {
+    const rows = await this.getRows();
+    const row = rows.nth(rowIndex);
+
+    const toggleButton = row.getByRole("button", { name: "Details" });
+    await expect(toggleButton).toBeVisible();
+    await toggleButton.click();
+
+    const expandedArea = row.locator(".pf-m-expanded");
+    await expect(expandedArea).toBeVisible();
+    return expandedArea;
+  }
+
+  async getRows() {
+    const rows = this._table.locator("tbody");
+    await expect(rows).toBeVisible();
+    return rows;
+  }
+
   async getColumn(columnName: TColumnName) {
     const column = this._table.locator(`td[data-label="${columnName}"]`);
     await expect(column.first()).toBeVisible();

--- a/e2e/tests/ui/pages/Toolbar.ts
+++ b/e2e/tests/ui/pages/Toolbar.ts
@@ -127,4 +127,62 @@ export class Toolbar<
       .click();
     await this._page.getByRole("menuitem", { name: filterName }).click();
   }
+
+  /**
+   * Clears all applied filters by clicking the "Clear all filters" button
+   */
+  async clearAllFilters() {
+    const clearButton = this._toolbar.getByRole("button", {
+      name: "Clear all filters",
+    });
+    await expect(clearButton).toBeVisible();
+    await clearButton.click();
+
+    // Verify all filter chips are removed
+    await expect(this._toolbar.locator(".pf-m-label-group")).toHaveCount(0);
+  }
+
+  /**
+   * Removes a specific filter chip by clicking its close button
+   * @param filterName the name of the filter category (e.g., "Filter text", "Revision", "Label")
+   * @param chipValue the specific value of the chip to remove
+   */
+  async removeFilterChip(filterName: TFilterName, chipValue: string) {
+    const chipGroup = this._toolbar.locator(".pf-m-label-group", {
+      hasText: filterName,
+    });
+    await expect(chipGroup).toBeVisible();
+
+    const chip = chipGroup.locator(".pf-v6-c-label", {
+      hasText: chipValue,
+    });
+    await expect(chip).toBeVisible();
+
+    const closeButton = chip.getByRole("button", { name: /close/i });
+    await closeButton.click();
+
+    // Verify chip is removed
+    await expect(chip).not.toBeVisible();
+  }
+
+  /**
+   * Removes all filters from a specific category/group by clicking the group's close button
+   * @param filterName the name of the filter category to remove (e.g., "Filter text", "Revision", "Label")
+   */
+  async removeFilterGroup(filterName: TFilterName) {
+    const chipGroup = this._toolbar.locator(".pf-m-label-group", {
+      hasText: filterName,
+    });
+    await expect(chipGroup).toBeVisible();
+
+    // // Find the close button for the entire group (usually in the chip group header)
+    const groupCloseButton = chipGroup
+      .locator(".pf-v6-c-label-group__close")
+      .getByRole("button");
+    await expect(groupCloseButton).toBeVisible();
+    await groupCloseButton.click();
+
+    // Verify the entire group is removed
+    await expect(chipGroup).not.toBeVisible();
+  }
 }


### PR DESCRIPTION
Add e2e utilities:
- Table: 
  - `expandRow`: to expand a row just like what we need for tables like the Importers List where each row can be expanded
  - `getRows`: returns all rows from a current table
- Toolbar:
  - `clearAllFilters`: to click on the clear all filters link
  - `removeFilterChip`: to remove an individual filter
  - `removeFilterGroup`: to remove all filters that belong to the same category. E.g. Labels

## Summary by Sourcery

Add new end-to-end testing utilities for interacting with toolbar filters and expandable table rows.

New Features:
- Provide toolbar helpers to clear all filters, remove individual filter chips, and remove entire filter groups in UI tests.
- Add table helpers to expand a specific row and to retrieve table rows for use in UI tests.

Tests:
- Extend the Toolbar and Table page objects with new methods to support filter manipulation and row expansion in e2e scenarios.