### PR TITLE
test: Add tests for SBOM correlation with package and vulnerability

### DIFF
--- a/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.feature
+++ b/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.feature
@@ -154,3 +154,32 @@ Feature: SBOM Explorer - View SBOM details
         Examples:
         |         sbomName       |
         |      rhn_satellite     |
+
+    Scenario Outline: SBOM Explorer Vulnerability Correlation with Affected Advisory
+        Given User is on the Vulnerabilities tab with "100" rows per page for SBOM "<sbomName>"
+        When User clicks on the vulnerability row with ID "<vulnerabilityID>"
+        Then The Application navigates to the Vulnerability details Page of "<vulnerabilityID>"
+        And The Related SBOMs tab loaded with SBOM "<sbomName>" with status "<status>"
+        Examples:
+        |         sbomName       | vulnerabilityID | status |
+        |        quarkus-bom     | CVE-2023-0044   | Affected |
+
+    Scenario Outline: SBOM Explorer Vulnerability Correlation with Fixed Advisory
+        Given User is on the Vulnerabilities tab with "100" rows per page for SBOM "<sbomName>"
+        Then The vulnerability "<vulnerabilityID>" does not show in the Vulnerabilities table
+        When User visits Vulnerability details Page of "<vulnerabilityID>"
+        Then The Related SBOMs tab loaded with SBOM "<sbomName>" with status "<status>"
+        Examples:
+        |         sbomName       | vulnerabilityID | status |
+        |        quarkus-bom     | CVE-2023-1584   | Fixed |
+
+    Scenario Outline: SBOM Explorer Package Correlation with SBOM
+        Given User is on the Vulnerabilities tab with "100" rows per page for SBOM "<sbomName>"
+        When User clicks on Affected dependencies count button of the "<vulnerabilityID>"
+        And User clicks on the package name "<packageName>" link on the expanded table
+        Then The Application navigates to the Package details Page of "<packageName>"
+        And Vulnerability "<vulnerabilityID>" visible under Vulnerabilities tab
+        And The SBOMs using package tab loaded with SBOM "<sbomName>"
+        Examples:
+        |         sbomName       | vulnerabilityID | packageName |
+        |        quarkus-bom     | CVE-2023-0044   | quarkus-vertx-http |

--- a/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
+++ b/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
@@ -2,6 +2,12 @@ import { createBdd } from "playwright-bdd";
 
 import { DetailsPage } from "../../helpers/DetailsPage";
 import { ToolbarTable } from "../../helpers/ToolbarTable";
+import { VulnerabilitiesTab } from "../../pages/sbom-details/vulnerabilities/VulnerabilitiesTab";
+import { VulnerabilityDetailsPage } from "../../pages/vulnerability-details/VulnerabilityDetailsPage";
+import { SbomsTab } from "../../pages/vulnerability-details/sboms/SbomsTab";
+import { PackageDetailsPage } from "../../pages/package-details/PackageDetailsPage";
+import { VulnerabilitiesTab as PackageVulnerabilitiesTab } from "../../pages/package-details/vulnerabilities/VulnerabilitiesTab";
+import { SbomsTab as PackageSbomsTab } from "../../pages/package-details/sboms/SbomsTab";
 import { DeletionConfirmDialog } from "../../pages/ConfirmDialog";
 import { SbomListPage } from "../../pages/sbom-list/SbomListPage";
 import { test } from "../../fixtures";
@@ -224,3 +230,120 @@ Then("The SBOM deleted message is displayed", async ({ page }) => {
   });
   await expect(alertHeading).toBeVisible({ timeout: 10000 });
 });
+
+Given(
+  "User is on the Vulnerabilities tab with {string} rows per page for SBOM {string}",
+  async ({ page }, rowsPerPage: string, sbomName: string) => {
+    const vulnerabilitiesTab = await VulnerabilitiesTab.build(page, sbomName);
+    const pagination = await vulnerabilitiesTab.getPagination(true);
+    await pagination.selectItemsPerPage(
+      Number(rowsPerPage) as 10 | 20 | 50 | 100,
+    );
+  },
+);
+
+When(
+  "User clicks on the vulnerability row with ID {string}",
+  async ({ page }, vulnerabilityID: string) => {
+    await page
+      .getByRole("link", { name: vulnerabilityID, exact: true })
+      .click();
+  },
+);
+
+Then(
+  "The Application navigates to the Vulnerability details Page of {string}",
+  async ({ page }, vulnerabilityID: string) => {
+    const vulnDetailsPage = await VulnerabilityDetailsPage.fromCurrentPage(
+      page,
+      vulnerabilityID,
+    );
+    await vulnDetailsPage._layout.verifyPageHeader(vulnerabilityID);
+  },
+);
+
+Then(
+  "The Related SBOMs tab loaded with SBOM {string} with status {string}",
+  async ({ page }, sbomName: string, status: string) => {
+    const sbomsTab = await SbomsTab.fromCurrentPage(page);
+    const table = await sbomsTab.getTable();
+    await expect(table).toHaveColumnWithValue("Name", sbomName, 0);
+    await expect(table).toHaveColumnWithValue("Status", status, 0);
+  },
+);
+
+Then(
+  "The vulnerability {string} does not show in the Vulnerabilities table",
+  async ({ page }, vulnerabilityID: string) => {
+    const toolbarTable = new ToolbarTable(page, VULN_TABLE_NAME);
+    await toolbarTable.waitForTableContent();
+    const vulnerabilityLink = page.getByRole("link", {
+      name: vulnerabilityID,
+      exact: true,
+    });
+    await expect(vulnerabilityLink).not.toBeVisible();
+  },
+);
+
+When(
+  "User visits Vulnerability details Page of {string}",
+  async ({ page }, vulnerabilityID: string) => {
+    await VulnerabilityDetailsPage.build(page, vulnerabilityID);
+  },
+);
+
+When(
+  "User clicks on Affected dependencies count button of the {string}",
+  async ({ page }, vulnerabilityID: string) => {
+    const vulnerabilityRow = page.locator(
+      `table[aria-label="Vulnerability table"] tbody:has(a:text-is("${vulnerabilityID}"))`,
+    );
+    const affectedDepsButton = vulnerabilityRow
+      .first()
+      .locator('td[data-label="Affected dependencies"] button');
+    await affectedDepsButton.click();
+  },
+);
+
+When(
+  "User clicks on the package name {string} link on the expanded table",
+  async ({ page }, packageName: string) => {
+    const innerTable = page.locator(
+      'table[aria-label="Vulnerability table"] td[data-label="Affected dependencies"] table',
+    );
+    const packageLink = innerTable.getByRole("link", {
+      name: packageName,
+      exact: true,
+    });
+    await packageLink.click();
+  },
+);
+
+Then(
+  "The Application navigates to the Package details Page of {string}",
+  async ({ page }, packageName: string) => {
+    const packageDetailsPage = await PackageDetailsPage.fromCurrentPage(
+      page,
+      packageName,
+    );
+    await packageDetailsPage._layout.verifyPageHeader(packageName);
+  },
+);
+
+Then(
+  "Vulnerability {string} visible under Vulnerabilities tab",
+  async ({ page }, vulnerabilityID: string) => {
+    const vulnTab = await PackageVulnerabilitiesTab.fromCurrentPage(page);
+    const table = await vulnTab.getTable();
+    await expect(table).toHaveColumnWithValue("ID", vulnerabilityID);
+  },
+);
+
+Then(
+  "The SBOMs using package tab loaded with SBOM {string}",
+  async ({ page }, sbomName: string) => {
+    const sbomsTab = await PackageSbomsTab.fromCurrentPage(page);
+    const table = await sbomsTab.getTable();
+    await expect(table).toHaveColumnWithValue("Name", sbomName, 0);
+  },
+);

--- a/e2e/tests/ui/pages/advisory-details/AdvisoryDetailsPage.ts
+++ b/e2e/tests/ui/pages/advisory-details/AdvisoryDetailsPage.ts
@@ -11,6 +11,10 @@ export class AdvisoryDetailsPage {
     this._layout = layout;
   }
 
+  /**
+   * Build the page object by navigating from the sidebar to the advisory list,
+   * filtering, and clicking on the advisory link.
+   */
   static async build(page: Page, advisoryID: string) {
     const navigation = await Navigation.build(page);
     await navigation.goToSidebar("Advisories");
@@ -26,6 +30,21 @@ export class AdvisoryDetailsPage {
 
     const layout = await DetailsPageLayout.build(page);
     await layout.verifyPageHeader(advisoryID);
+
+    return new AdvisoryDetailsPage(page, layout);
+  }
+
+  /**
+   * Build the page object from the current page state WITHOUT navigating.
+   * @param page - The Playwright page object
+   * @param advisoryID - Optional advisory ID to verify the page header
+   */
+  static async fromCurrentPage(page: Page, advisoryID?: string) {
+    const layout = await DetailsPageLayout.build(page);
+
+    if (advisoryID) {
+      await layout.verifyPageHeader(advisoryID);
+    }
 
     return new AdvisoryDetailsPage(page, layout);
   }

--- a/e2e/tests/ui/pages/advisory-details/vulnerabilities/VulnerabilitiesTab.ts
+++ b/e2e/tests/ui/pages/advisory-details/vulnerabilities/VulnerabilitiesTab.ts
@@ -13,8 +13,26 @@ export class VulnerabilitiesTab {
     this._detailsPage = layout;
   }
 
-  static async build(page: Page, packageName: string) {
-    const detailsPage = await AdvisoryDetailsPage.build(page, packageName);
+  /**
+   * Build the tab by navigating to the advisory details page and selecting the tab.
+   */
+  static async build(page: Page, advisoryID: string) {
+    const detailsPage = await AdvisoryDetailsPage.build(page, advisoryID);
+    await detailsPage._layout.selectTab("Vulnerabilities");
+
+    return new VulnerabilitiesTab(page, detailsPage);
+  }
+
+  /**
+   * Build the tab from the current page state WITHOUT navigating.
+   * @param page - The Playwright page object
+   * @param advisoryID - Optional advisory ID to verify the page header
+   */
+  static async fromCurrentPage(page: Page, advisoryID?: string) {
+    const detailsPage = await AdvisoryDetailsPage.fromCurrentPage(
+      page,
+      advisoryID,
+    );
     await detailsPage._layout.selectTab("Vulnerabilities");
 
     return new VulnerabilitiesTab(page, detailsPage);

--- a/e2e/tests/ui/pages/package-details/PackageDetailsPage.ts
+++ b/e2e/tests/ui/pages/package-details/PackageDetailsPage.ts
@@ -10,6 +10,11 @@ export class PackageDetailsPage {
     this._layout = layout;
   }
 
+  /**
+   * Build the page object by navigating from the sidebar to the package list,
+   * filtering, and clicking on the package link.
+   * Use this for unit tests or when starting from scratch.
+   */
   static async build(
     page: Page,
     packageDetail: { Name: string; Version?: string },
@@ -30,6 +35,24 @@ export class PackageDetailsPage {
       .click();
     const layout = await DetailsPageLayout.build(page);
     await layout.verifyPageHeader(packageDetail.Name);
+
+    return new PackageDetailsPage(page, layout);
+  }
+
+  /**
+   * Build the page object from the current page state WITHOUT navigating.
+   * Use this in E2E flows when the application has already navigated to this page
+   * (e.g., after clicking a package link from another page).
+   *
+   * @param page - The Playwright page object
+   * @param packageName - Optional package name to verify the page header
+   */
+  static async fromCurrentPage(page: Page, packageName?: string) {
+    const layout = await DetailsPageLayout.build(page);
+
+    if (packageName) {
+      await layout.verifyPageHeader(packageName);
+    }
 
     return new PackageDetailsPage(page, layout);
   }

--- a/e2e/tests/ui/pages/package-details/sboms/SbomsTab.ts
+++ b/e2e/tests/ui/pages/package-details/sboms/SbomsTab.ts
@@ -13,11 +13,29 @@ export class SbomsTab {
     this._detailsPage = layout;
   }
 
+  /**
+   * Build the tab by navigating to the package details page and selecting the tab.
+   */
   static async build(page: Page, packageDetail: Record<string, string>) {
     const detailsPage = await PackageDetailsPage.build(page, {
       Name: packageDetail.Name,
       Version: packageDetail.Version,
     });
+    await detailsPage._layout.selectTab("SBOMs using package");
+
+    return new SbomsTab(page, detailsPage);
+  }
+
+  /**
+   * Build the tab from the current page state WITHOUT navigating.
+   * @param page - The Playwright page object
+   * @param packageName - Optional package name to verify the page header
+   */
+  static async fromCurrentPage(page: Page, packageName?: string) {
+    const detailsPage = await PackageDetailsPage.fromCurrentPage(
+      page,
+      packageName,
+    );
     await detailsPage._layout.selectTab("SBOMs using package");
 
     return new SbomsTab(page, detailsPage);

--- a/e2e/tests/ui/pages/package-details/vulnerabilities/VulnerabilitiesTab.ts
+++ b/e2e/tests/ui/pages/package-details/vulnerabilities/VulnerabilitiesTab.ts
@@ -13,11 +13,29 @@ export class VulnerabilitiesTab {
     this._detailsPage = layout;
   }
 
+  /**
+   * Build the tab by navigating to the package details page and selecting the tab.
+   */
   static async build(page: Page, packageDetail: Record<string, string>) {
     const detailsPage = await PackageDetailsPage.build(page, {
       Name: packageDetail.Name,
       Version: packageDetail.Version,
     });
+    await detailsPage._layout.selectTab("Vulnerabilities");
+
+    return new VulnerabilitiesTab(page, detailsPage);
+  }
+
+  /**
+   * Build the tab from the current page state WITHOUT navigating.
+   * @param page - The Playwright page object
+   * @param packageName - Optional package name to verify the page header
+   */
+  static async fromCurrentPage(page: Page, packageName?: string) {
+    const detailsPage = await PackageDetailsPage.fromCurrentPage(
+      page,
+      packageName,
+    );
     await detailsPage._layout.selectTab("Vulnerabilities");
 
     return new VulnerabilitiesTab(page, detailsPage);

--- a/e2e/tests/ui/pages/sbom-details/SbomDetailsPage.ts
+++ b/e2e/tests/ui/pages/sbom-details/SbomDetailsPage.ts
@@ -11,6 +11,10 @@ export class SbomDetailsPage {
     this._layout = layout;
   }
 
+  /**
+   * Build the page object by navigating from the sidebar to the SBOM list,
+   * filtering, and clicking on the SBOM link.
+   */
   static async build(page: Page, sbomName: string) {
     const navigation = await Navigation.build(page);
     await navigation.goToSidebar("SBOMs");
@@ -26,6 +30,21 @@ export class SbomDetailsPage {
 
     const layout = await DetailsPageLayout.build(page);
     await layout.verifyPageHeader(sbomName);
+
+    return new SbomDetailsPage(page, layout);
+  }
+
+  /**
+   * Build the page object from the current page state WITHOUT navigating.
+   * @param page - The Playwright page object
+   * @param sbomName - Optional SBOM name to verify the page header
+   */
+  static async fromCurrentPage(page: Page, sbomName?: string) {
+    const layout = await DetailsPageLayout.build(page);
+
+    if (sbomName) {
+      await layout.verifyPageHeader(sbomName);
+    }
 
     return new SbomDetailsPage(page, layout);
   }

--- a/e2e/tests/ui/pages/sbom-details/vulnerabilities/VulnerabilitiesTab.ts
+++ b/e2e/tests/ui/pages/sbom-details/vulnerabilities/VulnerabilitiesTab.ts
@@ -13,10 +13,23 @@ export class VulnerabilitiesTab {
     this._detailsPage = layout;
   }
 
+  /**
+   * Build the tab by navigating to the SBOM details page and selecting the tab.
+   */
   static async build(page: Page, sbomName: string) {
     const detailsPage = await SbomDetailsPage.build(page, sbomName);
     await detailsPage._layout.selectTab("Vulnerabilities");
 
+    return new VulnerabilitiesTab(page, detailsPage);
+  }
+
+  /**
+   * Build the tab from the current page state WITHOUT navigating.
+   * @param page - The Playwright page object
+   * @param sbomName - Optional SBOM name to verify the page header
+   */
+  static async fromCurrentPage(page: Page, sbomName?: string) {
+    const detailsPage = await SbomDetailsPage.fromCurrentPage(page, sbomName);
     return new VulnerabilitiesTab(page, detailsPage);
   }
 

--- a/e2e/tests/ui/pages/vulnerability-details/VulnerabilityDetailsPage.ts
+++ b/e2e/tests/ui/pages/vulnerability-details/VulnerabilityDetailsPage.ts
@@ -11,6 +11,10 @@ export class VulnerabilityDetailsPage {
     this._layout = layout;
   }
 
+  /**
+   * Build the page object by navigating from the sidebar to the vulnerability list,
+   * filtering, and clicking on the vulnerability link.
+   */
   static async build(page: Page, vulnerabilityID: string) {
     const navigation = await Navigation.build(page);
     await navigation.goToSidebar("Vulnerabilities");
@@ -28,6 +32,21 @@ export class VulnerabilityDetailsPage {
 
     const layout = await DetailsPageLayout.build(page);
     await layout.verifyPageHeader(vulnerabilityID);
+
+    return new VulnerabilityDetailsPage(page, layout);
+  }
+
+  /**
+   * Build the page object from the current page state WITHOUT navigating.
+   * @param page - The Playwright page object
+   * @param vulnerabilityID - Optional vulnerability ID to verify the page header
+   */
+  static async fromCurrentPage(page: Page, vulnerabilityID?: string) {
+    const layout = await DetailsPageLayout.build(page);
+
+    if (vulnerabilityID) {
+      await layout.verifyPageHeader(vulnerabilityID);
+    }
 
     return new VulnerabilityDetailsPage(page, layout);
   }

--- a/e2e/tests/ui/pages/vulnerability-details/advisories/AdvisoriesTab.ts
+++ b/e2e/tests/ui/pages/vulnerability-details/advisories/AdvisoriesTab.ts
@@ -13,8 +13,26 @@ export class AdvisoriesTab {
     this._detailsPage = layout;
   }
 
+  /**
+   * Build the tab by navigating to the vulnerability details page and selecting the tab.
+   */
   static async build(page: Page, vulnerabilityID: string) {
     const detailsPage = await VulnerabilityDetailsPage.build(
+      page,
+      vulnerabilityID,
+    );
+    await detailsPage._layout.selectTab("Related Advisories");
+
+    return new AdvisoriesTab(page, detailsPage);
+  }
+
+  /**
+   * Build the tab from the current page state WITHOUT navigating.
+   * @param page - The Playwright page object
+   * @param vulnerabilityID - Optional vulnerability ID to verify the page header
+   */
+  static async fromCurrentPage(page: Page, vulnerabilityID?: string) {
+    const detailsPage = await VulnerabilityDetailsPage.fromCurrentPage(
       page,
       vulnerabilityID,
     );

--- a/e2e/tests/ui/pages/vulnerability-details/sboms/SbomsTab.ts
+++ b/e2e/tests/ui/pages/vulnerability-details/sboms/SbomsTab.ts
@@ -13,8 +13,26 @@ export class SbomsTab {
     this._detailsPage = layout;
   }
 
+  /**
+   * Build the tab by navigating to the vulnerability details page and selecting the tab.
+   */
   static async build(page: Page, vulnerabilityID: string) {
     const detailsPage = await VulnerabilityDetailsPage.build(
+      page,
+      vulnerabilityID,
+    );
+    await detailsPage._layout.selectTab("Related SBOMs");
+
+    return new SbomsTab(page, detailsPage);
+  }
+
+  /**
+   * Build the tab from the current page state WITHOUT navigating.
+   * @param page - The Playwright page object
+   * @param vulnerabilityID - Optional vulnerability ID to verify the page header
+   */
+  static async fromCurrentPage(page: Page, vulnerabilityID?: string) {
+    const detailsPage = await VulnerabilityDetailsPage.fromCurrentPage(
       page,
       vulnerabilityID,
     );


### PR DESCRIPTION
Add tests:
 - SBOM correlation with Vulnerability
 - SBOM correlation with Package
Update utilities:
 - Add `fromCurrentPage` to create page objects from current page without navigation

## Summary by Sourcery

Add end-to-end coverage for SBOM explorer correlations between SBOMs, vulnerabilities, advisories, and packages, and enhance page objects to be constructible from the current navigation state.

New Features:
- Introduce E2E scenarios validating SBOM-to-vulnerability correlations for affected and fixed advisories.
- Add E2E scenario verifying navigation and correlation between SBOMs, vulnerabilities, and package details from affected dependencies.

Enhancements:
- Extend SBOM, vulnerability, advisory, and package details page objects and tabs with fromCurrentPage constructors to support flows that reuse the existing page state without sidebar navigation.