### PR TITLE
tests: add filter tests to package-list and vulnerability-list pages

### DIFF
--- a/e2e/tests/ui/pages/package-list/PackageListPage.ts
+++ b/e2e/tests/ui/pages/package-list/PackageListPage.ts
@@ -23,7 +23,7 @@ export class PackageListPage {
       "Filter text": "string",
       Type: "multiSelect",
       Architecture: "multiSelect",
-      License: "multiSelect",
+      License: "typeahead",
     });
   }
 

--- a/e2e/tests/ui/pages/package-list/filter.spec.ts
+++ b/e2e/tests/ui/pages/package-list/filter.spec.ts
@@ -3,9 +3,17 @@
 import { expect } from "../../assertions";
 import { test } from "../../fixtures";
 import { login } from "../../helpers/Auth";
+import {
+  testBrowserNavigationBackAndForward,
+  testClearAllFilters,
+  testFilterMatches,
+  testFilterShowsEmptyState,
+  testRemovalOfFiltersFromToolbar,
+  testUrlPersistence,
+} from "../common/filter-test-helpers";
 import { PackageListPage } from "./PackageListPage";
 
-test.describe("Filter validations", { tag: "@tier1" }, () => {
+test.describe("Filter validations", { tag: ["@filtering"] }, () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
   });
@@ -35,5 +43,172 @@ test.describe("Filter validations", { tag: "@tier1" }, () => {
     // Architecture
     await toolbar.applyFilter({ Architecture: ["S390", "No Arch"] });
     await expect(table).toHaveEmptyState();
+  });
+
+  testFilterMatches("Filter partial text match", {
+    filters: { "Filter text": "keycloak" },
+    assertions: { columnName: "Name", value: "keycloak-adapter-core" },
+    getConfig: async ({ page }) => {
+      const listPage = await PackageListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testFilterShowsEmptyState("Filter with non existent package", {
+    filters: { "Filter text": "nonexistent-package-12345" },
+    getConfig: async ({ page }) => {
+      const listPage = await PackageListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testClearAllFilters({
+    filters: {
+      "Filter text": "keycloak",
+      Type: ["Maven", "RPM"],
+      Architecture: ["No Arch"],
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await PackageListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testRemovalOfFiltersFromToolbar({
+    filters: {
+      "Filter text": "keycloak",
+      Type: ["Maven", "RPM"],
+      Architecture: ["No Arch"],
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await PackageListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+});
+
+test.describe("Filter edge cases", { tag: ["@filtering"] }, () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  testFilterShowsEmptyState("Filter with special characters in text", {
+    filters: {
+      "Filter text": "keycloak*",
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await PackageListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testFilterShowsEmptyState("Filter with very long text string", {
+    filters: {
+      "Filter text": "keycloak-".repeat(100),
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await PackageListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testFilterMatches("Whitespace variations", {
+    filters: { "Filter text": "  keycloak-core  " },
+    assertions: { columnName: "Name", value: "keycloak-core" },
+    getConfig: async ({ page }) => {
+      const listPage = await PackageListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testFilterMatches("Empty filter input is handled", {
+    filters: { "Filter text": "" },
+    assertions: { columnName: "Name", value: "accordion" },
+    getConfig: async ({ page }) => {
+      const listPage = await PackageListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+});
+
+test.describe("Filter state persistence", { tag: ["@filtering"] }, () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  testUrlPersistence({
+    filters: {
+      "Filter text": "keycloak-core",
+      Type: ["Maven", "RPM"],
+      Architecture: ["No Arch"],
+      License: ["Apache-2.0", "Apache License 1.0"],
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await PackageListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testBrowserNavigationBackAndForward({
+    filters: {
+      "Filter text": "keycloak-core",
+      Type: ["Maven", "RPM"],
+      Architecture: ["No Arch"],
+      License: ["Apache-2.0", "Apache License 1.0"],
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await PackageListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
   });
 });

--- a/e2e/tests/ui/pages/vulnerability-list/filter.spec.ts
+++ b/e2e/tests/ui/pages/vulnerability-list/filter.spec.ts
@@ -3,9 +3,17 @@
 import { expect } from "../../assertions";
 import { test } from "../../fixtures";
 import { login } from "../../helpers/Auth";
+import {
+  testBrowserNavigationBackAndForward,
+  testClearAllFilters,
+  testFilterMatches,
+  testFilterShowsEmptyState,
+  testRemovalOfFiltersFromToolbar,
+  testUrlPersistence,
+} from "../common/filter-test-helpers";
 import { VulnerabilityListPage } from "./VulnerabilityListPage";
 
-test.describe("Filter validations", { tag: "@tier1" }, () => {
+test.describe("Filter validations", { tag: ["@filtering"] }, () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
   });
@@ -29,5 +37,200 @@ test.describe("Filter validations", { tag: "@tier1" }, () => {
       Published: { from: "02/18/2024", to: "02/20/2024" },
     });
     await expect(table).toHaveColumnWithValue("ID", "CVE-2024-26308");
+  });
+
+  testFilterMatches("Filter partial text match", {
+    filters: { "Filter text": "CVE-2024" },
+    assertions: { columnName: "ID", value: "CVE-2024-26308" },
+    getConfig: async ({ page }) => {
+      const listPage = await VulnerabilityListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testFilterShowsEmptyState("Filter with non existent CVE", {
+    filters: { "Filter text": "CVE-9999-99999" },
+    getConfig: async ({ page }) => {
+      const listPage = await VulnerabilityListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testClearAllFilters({
+    filters: {
+      "Filter text": "CVE-2024",
+      CVSS: ["Medium", "High"],
+      Published: { from: "01/01/2024", to: "12/31/2024" },
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await VulnerabilityListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testRemovalOfFiltersFromToolbar({
+    filters: {
+      "Filter text": "CVE-2024",
+      CVSS: ["Medium", "High"],
+      Published: { from: "01/01/2024", to: "12/31/2024" },
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await VulnerabilityListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+});
+
+test.describe("Filter edge cases", { tag: ["@filtering"] }, () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  testFilterShowsEmptyState("Filter with invalid CVE format", {
+    filters: {
+      "Filter text": "INVALID-CVE-FORMAT",
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await VulnerabilityListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testFilterShowsEmptyState("Filter with special characters in text", {
+    filters: {
+      "Filter text": "CVE-2024*",
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await VulnerabilityListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testFilterShowsEmptyState("Filter with very long text string", {
+    filters: {
+      "Filter text": "CVE-2024-".repeat(100),
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await VulnerabilityListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testFilterMatches("Whitespace variations", {
+    filters: { "Filter text": "  CVE-2024-26308  " },
+    assertions: { columnName: "ID", value: "CVE-2024-26308" },
+    getConfig: async ({ page }) => {
+      const listPage = await VulnerabilityListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testFilterMatches("Empty filter input is handled", {
+    filters: { "Filter text": "" },
+    assertions: { columnName: "ID", value: "CVE-2023-1906" },
+    getConfig: async ({ page }) => {
+      const listPage = await VulnerabilityListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testFilterShowsEmptyState("Filter with future date range", {
+    filters: {
+      Published: { from: "01/01/2099", to: "12/31/2099" },
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await VulnerabilityListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+});
+
+test.describe("Filter state persistence", { tag: ["@filtering"] }, () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  testUrlPersistence({
+    filters: {
+      "Filter text": "CVE-2024-26308",
+      CVSS: ["Medium", "High"],
+      Published: { from: "02/18/2024", to: "02/20/2024" },
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await VulnerabilityListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
+  });
+
+  testBrowserNavigationBackAndForward({
+    filters: {
+      "Filter text": "CVE-2024-26308",
+      CVSS: ["Medium", "High"],
+      Published: { from: "02/18/2024", to: "02/20/2024" },
+    },
+    getConfig: async ({ page }) => {
+      const listPage = await VulnerabilityListPage.build(page);
+      const toolbar = await listPage.getToolbar();
+      const table = await listPage.getTable();
+      return {
+        toolbar,
+        table,
+      };
+    },
   });
 });


### PR DESCRIPTION
Add tests to package-list and vulnerability-list pages reusing the reusable tests created by `e2e/tests/ui/pages/common/filter-test-helpers`

## Summary by Sourcery

Expand end-to-end filter coverage for vulnerability and package list pages using shared filter test helpers.

Enhancements:
- Adjust package list toolbar configuration to treat the License filter as a typeahead input instead of a multi-select.

Tests:
- Add filter behavior tests for vulnerability list covering partial matches, empty states, edge cases, and state persistence across navigation and URL reloads.
- Add filter behavior tests for package list covering partial matches, empty states, edge cases, and state persistence across navigation and URL reloads.