### PR TITLE
feat: add all sbom pages

### DIFF
--- a/client/src/app/layout/sidebar.tsx
+++ b/client/src/app/layout/sidebar.tsx
@@ -3,6 +3,7 @@ import { NavLink } from "react-router-dom";
 import {
   Icon,
   Nav,
+  NavExpandable,
   NavItem,
   NavList,
   PageSidebar,
@@ -42,16 +43,18 @@ export const SidebarApp: React.FC = () => {
               Search
             </NavLink>
           </li>
-          <li className={nav.navItem}>
-            <NavLink
-              to={Paths.sboms}
-              className={({ isActive }) => {
-                return css(LINK_CLASS, isActive ? ACTIVE_LINK_CLASS : "");
-              }}
-            >
-              SBOMs
-            </NavLink>
-          </li>
+          <NavExpandable title="SBOMs" isExpanded>
+            <li className={nav.navItem}>
+              <NavLink
+                to={Paths.sboms}
+                className={({ isActive }) => {
+                  return css(LINK_CLASS, isActive ? ACTIVE_LINK_CLASS : "");
+                }}
+              >
+                All SBOMs
+              </NavLink>
+            </li>
+          </NavExpandable>
           <li className={nav.navItem}>
             <NavLink
               to={Paths.vulnerabilities}

--- a/client/src/app/pages/sbom-list/sbom-list.tsx
+++ b/client/src/app/pages/sbom-list/sbom-list.tsx
@@ -2,10 +2,11 @@ import type React from "react";
 
 import { Content, PageSection } from "@patternfly/react-core";
 
+import { DocumentMetadata } from "@app/components/DocumentMetadata";
+
 import { SbomSearchProvider } from "./sbom-context";
 import { SbomTable } from "./sbom-table";
 import { SbomToolbar } from "./sbom-toolbar";
-import { DocumentMetadata } from "@app/components/DocumentMetadata";
 
 export const SbomList: React.FC = () => {
   return (
@@ -18,7 +19,7 @@ export const SbomList: React.FC = () => {
       </PageSection>
       <PageSection hasBodyWrapper={false}>
         <div>
-          <SbomSearchProvider>
+          <SbomSearchProvider isBulkSelectionEnabled>
             <SbomToolbar showFilters showActions />
             <SbomTable />
           </SbomSearchProvider>

--- a/client/src/app/pages/sbom-list/sbom-table.tsx
+++ b/client/src/app/pages/sbom-list/sbom-table.tsx
@@ -43,8 +43,16 @@ import { SbomSearchContext } from "./sbom-context";
 export const SbomTable: React.FC = () => {
   const { pushNotification } = React.useContext(NotificationsContext);
 
-  const { isFetching, fetchError, totalItemCount, tableControls } =
-    React.useContext(SbomSearchContext);
+  const {
+    isFetching,
+    fetchError,
+    totalItemCount,
+    tableControls,
+    bulkSelection: {
+      isEnabled: showBulkSelector,
+      controls: bulkSelectionControls,
+    },
+  } = React.useContext(SbomSearchContext);
 
   const [editLabelsModalState, setEditLabelsModalState] =
     React.useState<SbomSummary | null>(null);
@@ -64,6 +72,11 @@ export const SbomTable: React.FC = () => {
     expansionDerivedState: { isCellExpanded },
     filterState: { filterValues, setFilterValues },
   } = tableControls;
+
+  const {
+    selectedItems: _selectedItems,
+    propHelpers: { getSelectCheckboxTdProps },
+  } = bulkSelectionControls;
 
   const { downloadSBOM, downloadSBOMLicenses } = useDownload();
 
@@ -123,6 +136,9 @@ export const SbomTable: React.FC = () => {
                 <Tr {...getTrProps({ item })}>
                   <TableRowContentWithControls
                     {...tableControls}
+                    getSelectCheckboxTdProps={
+                      showBulkSelector ? getSelectCheckboxTdProps : undefined
+                    }
                     item={item}
                     rowIndex={rowIndex}
                   >

--- a/client/src/app/pages/sbom-list/sbom-toolbar.tsx
+++ b/client/src/app/pages/sbom-list/sbom-toolbar.tsx
@@ -10,6 +10,7 @@ import {
 
 import { FilterToolbar } from "@app/components/FilterToolbar";
 import { SimplePagination } from "@app/components/SimplePagination";
+import { ToolbarBulkSelector } from "@app/components/ToolbarBulkSelector";
 import { Paths } from "@app/Routes";
 
 import { SbomSearchContext } from "./sbom-context";
@@ -25,7 +26,13 @@ export const SbomToolbar: React.FC<SbomToolbarProps> = ({
 }) => {
   const navigate = useNavigate();
 
-  const { tableControls } = React.useContext(SbomSearchContext);
+  const {
+    tableControls,
+    bulkSelection: {
+      isEnabled: showBulkSelector,
+      controls: bulkSelectionControls,
+    },
+  } = React.useContext(SbomSearchContext);
 
   const {
     propHelpers: {
@@ -36,9 +43,16 @@ export const SbomToolbar: React.FC<SbomToolbarProps> = ({
     },
   } = tableControls;
 
+  const {
+    propHelpers: { toolbarBulkSelectorProps },
+  } = bulkSelectionControls;
+
   return (
     <Toolbar {...toolbarProps} aria-label="sbom-toolbar">
       <ToolbarContent>
+        {showBulkSelector && (
+          <ToolbarBulkSelector {...toolbarBulkSelectorProps} />
+        )}
         {showFilters && <FilterToolbar {...filterToolbarProps} />}
         {showActions && (
           <>

--- a/e2e/tests/ui/pages/Navigation.ts
+++ b/e2e/tests/ui/pages/Navigation.ts
@@ -18,7 +18,7 @@ export class Navigation {
     menu:
       | "Dashboard"
       | "Search"
-      | "SBOMs"
+      | "All SBOMs"
       | "Vulnerabilities"
       | "Packages"
       | "Advisories"

--- a/e2e/tests/ui/pages/sbom-details/SbomDetailsPage.ts
+++ b/e2e/tests/ui/pages/sbom-details/SbomDetailsPage.ts
@@ -17,7 +17,7 @@ export class SbomDetailsPage {
    */
   static async build(page: Page, sbomName: string) {
     const navigation = await Navigation.build(page);
-    await navigation.goToSidebar("SBOMs");
+    await navigation.goToSidebar("All SBOMs");
 
     const listPage = await SbomListPage.build(page);
     const toolbar = await listPage.getToolbar();

--- a/e2e/tests/ui/pages/sbom-list/SbomListPage.ts
+++ b/e2e/tests/ui/pages/sbom-list/SbomListPage.ts
@@ -13,7 +13,7 @@ export class SbomListPage {
 
   static async build(page: Page) {
     const navigation = await Navigation.build(page);
-    await navigation.goToSidebar("SBOMs");
+    await navigation.goToSidebar("All SBOMs");
 
     return new SbomListPage(page);
   }


### PR DESCRIPTION
Covers https://issues.redhat.com/browse/TC-3450

This should unblock @stanislavsemeniuk to start working on the "Create" Group Modal

- Adds "All SBOMs" sub  menu
- Adds a Bulk Selector to the "All SBOMs" page
  - On a separate PR the Creation of Groups can reuse the file `client/src/app/pages/sbom-list/sbom-table.tsx` to determine which rows were selected. E.g.

```ts
const {
    selectedItems,
  } = bulkSelectionControls;
```
<img width="2540" height="1125" alt="image" src="https://github.com/user-attachments/assets/1b34ef01-30c7-4fd8-bb66-044ffd76ac19" />

- The "Bulk selector" is not added to the Search page (Sbom Tab)

## Summary by Sourcery

Enable bulk selection for the SBOM list and update navigation to present SBOMs under an expandable menu entry labeled "All SBOMs".

New Features:
- Add bulk selection capabilities to the SBOM list via shared context, toolbar controls, and row checkboxes.

Enhancements:
- Wrap the SBOM list route under a "SBOMs" expandable sidebar section with an "All SBOMs" entry.
- Pass configuration into the SBOM search provider to toggle selection support.

Tests:
- Update end-to-end navigation and SBOM page tests to use the new "All SBOMs" sidebar label.