### PR TITLE
tests(fix): remove sortable field from Table

### DIFF
--- a/e2e/tests/ui/assertions/TableMatchers.ts
+++ b/e2e/tests/ui/assertions/TableMatchers.ts
@@ -1,18 +1,17 @@
 import { expect as baseExpect } from "@playwright/test";
-import type { Table, TColumnValue } from "../pages/Table";
+import type { Table } from "../pages/Table";
 import type { MatcherResult } from "./types";
 
 export interface TableMatchers<
-  TColumn extends Record<string, TColumnValue>,
+  TColumns extends readonly string[],
   _TActions extends readonly string[],
-  TColumnName extends Extract<keyof TColumn, string>,
 > {
   toBeSortedBy(
-    columnName: TColumnName,
+    columnName: TColumns[number],
     order: "ascending" | "descending",
   ): Promise<MatcherResult>;
   toHaveColumnWithValue(
-    columnName: TColumnName,
+    columnName: TColumns[number],
     value: string,
     rowIndex?: number,
   ): Promise<MatcherResult>;
@@ -25,28 +24,22 @@ export interface TableMatchers<
 }
 
 type TableMatcherDefinitions = {
-  readonly [K in keyof TableMatchers<
-    Record<string, TColumnValue>,
-    [],
-    string
-  >]: <
-    TColumn extends Record<string, TColumnValue>,
+  readonly [K in keyof TableMatchers<readonly string[], readonly string[]>]: <
+    const TColumns extends readonly string[],
     const TActions extends readonly string[],
-    TColumnName extends Extract<keyof TColumn, string>,
   >(
-    receiver: Table<TColumn, TActions, TColumnName>,
-    ...args: Parameters<TableMatchers<TColumn, TActions, TColumnName>[K]>
+    receiver: Table<TColumns, TActions>,
+    ...args: Parameters<TableMatchers<TColumns, TActions>[K]>
   ) => Promise<MatcherResult>;
 };
 
 export const tableAssertions = baseExpect.extend<TableMatcherDefinitions>({
   toBeSortedBy: async <
-    TColumn extends Record<string, TColumnValue>,
+    const TColumns extends readonly string[],
     const TActions extends readonly string[],
-    TColumnName extends Extract<keyof TColumn, string>,
   >(
-    table: Table<TColumn, TActions, TColumnName>,
-    columnName: TColumnName,
+    table: Table<TColumns, TActions>,
+    columnName: TColumns[number],
     order: "ascending" | "descending",
   ) => {
     try {
@@ -65,12 +58,11 @@ export const tableAssertions = baseExpect.extend<TableMatcherDefinitions>({
     }
   },
   toHaveColumnWithValue: async <
-    TColumn extends Record<string, TColumnValue>,
+    const TColumns extends readonly string[],
     const TActions extends readonly string[],
-    TColumnName extends Extract<keyof TColumn, string>,
   >(
-    table: Table<TColumn, TActions, TColumnName>,
-    columnName: TColumnName,
+    table: Table<TColumns, TActions>,
+    columnName: TColumns[number],
     value: string,
     rowIndex?: number,
   ) => {
@@ -101,16 +93,15 @@ export const tableAssertions = baseExpect.extend<TableMatcherDefinitions>({
     }
   },
   toHaveNumberOfRows: async <
-    TColumn extends Record<string, TColumnValue>,
+    const TColumns extends readonly string[],
     const TActions extends readonly string[],
-    TColumnName extends Extract<keyof TColumn, string>,
   >(
-    table: Table<TColumn, TActions, TColumnName>,
+    table: Table<TColumns, TActions>,
     expectedRows: { equal?: number; greaterThan?: number; lessThan?: number },
   ) => {
     try {
       const rows = table._table.locator(
-        `td[data-label="${Object.keys(table._columns)[0]}"]`,
+        `td[data-label="${table._columns[0]}"]`,
       );
 
       if (expectedRows.equal) {
@@ -139,11 +130,10 @@ export const tableAssertions = baseExpect.extend<TableMatcherDefinitions>({
     }
   },
   toHaveEmptyState: async <
-    TColumn extends Record<string, TColumnValue>,
+    const TColumns extends readonly string[],
     const TActions extends readonly string[],
-    TColumnName extends Extract<keyof TColumn, string>,
   >(
-    table: Table<TColumn, TActions, TColumnName>,
+    table: Table<TColumns, TActions>,
   ): Promise<MatcherResult> => {
     try {
       await baseExpect(

--- a/e2e/tests/ui/assertions/index.ts
+++ b/e2e/tests/ui/assertions/index.ts
@@ -1,6 +1,6 @@
 import { mergeExpects } from "@playwright/test";
 
-import type { Table, TColumnValue } from "../pages/Table";
+import type { Table } from "../pages/Table";
 import { tableAssertions, type TableMatchers } from "./TableMatchers";
 
 import type { Pagination } from "../pages/Pagination";
@@ -30,16 +30,15 @@ const merged = mergeExpects(
  * Overload from TableMatchers.ts
  */
 function typedExpect<
-  TColumn extends Record<string, TColumnValue>,
+  const TColumns extends readonly string[],
   const TActions extends readonly string[],
-  TColumnName extends Extract<keyof TColumn, string>,
 >(
-  value: Table<TColumn, TActions, TColumnName>,
+  value: Table<TColumns, TActions>,
 ): Omit<
-  ReturnType<typeof merged<Table<TColumn, TActions, TColumnName>>>,
-  keyof TableMatchers<TColumn, TActions, TColumnName>
+  ReturnType<typeof merged<Table<TColumns, TActions>>>,
+  keyof TableMatchers<TColumns, TActions>
 > &
-  TableMatchers<TColumn, TActions, TColumnName>;
+  TableMatchers<TColumns, TActions>;
 
 /**
  * Overload from PaginationMatchers.ts

--- a/e2e/tests/ui/features/@sbom-scan/scan-sbom.step.ts
+++ b/e2e/tests/ui/features/@sbom-scan/scan-sbom.step.ts
@@ -105,15 +105,15 @@ Then(
     const table = await Table.build(
       page,
       "Vulnerability table",
-      {
-        "Vulnerability ID": { isSortable: true },
-        Description: { isSortable: false },
-        Severity: { isSortable: true },
-        Status: { isSortable: false },
-        "Affected packages": { isSortable: true },
-        Published: { isSortable: true },
-        Updated: { isSortable: true },
-      },
+      [
+        "Vulnerability ID",
+        "Description",
+        "Severity",
+        "Status",
+        "Affected packages",
+        "Published",
+        "Updated",
+      ],
       [],
     );
     const tooltipButton = table.getColumnTooltipButton(column, tooltipMessage);

--- a/e2e/tests/ui/pages/advisory-details/vulnerabilities/VulnerabilitiesTab.ts
+++ b/e2e/tests/ui/pages/advisory-details/vulnerabilities/VulnerabilitiesTab.ts
@@ -46,14 +46,7 @@ export class VulnerabilitiesTab {
     return await Table.build(
       this._page,
       "vulnerability table",
-      {
-        ID: { isSortable: true },
-        Title: { isSortable: false },
-        Discovery: { isSortable: false },
-        Release: { isSortable: false },
-        Score: { isSortable: false },
-        CWE: { isSortable: false },
-      },
+      ["ID", "Title", "Discovery", "Release", "Score", "CWE"],
       [],
     );
   }

--- a/e2e/tests/ui/pages/advisory-list/AdvisoryListPage.ts
+++ b/e2e/tests/ui/pages/advisory-list/AdvisoryListPage.ts
@@ -30,14 +30,7 @@ export class AdvisoryListPage {
     return await Table.build(
       this._page,
       "advisory-table",
-      {
-        ID: { isSortable: true },
-        Title: { isSortable: false },
-        Type: { isSortable: false },
-        Labels: { isSortable: false },
-        Revision: { isSortable: true },
-        Vulnerabilities: { isSortable: false },
-      },
+      ["ID", "Title", "Type", "Labels", "Revision", "Vulnerabilities"],
       ["Edit labels", "Download", "Delete"],
     );
   }

--- a/e2e/tests/ui/pages/common/filter-test-helpers.ts
+++ b/e2e/tests/ui/pages/common/filter-test-helpers.ts
@@ -4,7 +4,7 @@ import type { Page } from "@playwright/test";
 
 import { expect } from "../../assertions";
 import { test } from "../../fixtures";
-import type { Table, TColumnValue } from "../../pages/Table";
+import type { Table } from "../../pages/Table";
 import type { Toolbar } from "../../pages/Toolbar";
 import {
   isDateRangeFilter,
@@ -28,12 +28,11 @@ export interface FilterTestConfig<
   /**
    * Table
    */
-  TColumn extends Record<string, TColumnValue>,
+  TColumns extends readonly string[],
   TActions extends readonly string[],
-  TColumnName extends Extract<keyof TColumn, string>,
 > {
   toolbar: Toolbar<TFilter, TFilterName, TKebabActions>;
-  table: Table<TColumn, TActions, TColumnName>;
+  table: Table<TColumns, TActions>;
 }
 
 export const testFilterMatches = <
@@ -46,9 +45,8 @@ export const testFilterMatches = <
   /**
    * Table
    */
-  TColumn extends Record<string, TColumnValue>,
+  TColumns extends readonly string[],
   TActions extends readonly string[],
-  TColumnName extends Extract<keyof TColumn, string>,
 >(
   testName: string,
   {
@@ -57,20 +55,17 @@ export const testFilterMatches = <
     getConfig,
   }: {
     filters: Partial<FilterValueType<TFilter>>;
-    assertions: { columnName: TColumnName; value: string; rowIndex?: number };
+    assertions: {
+      columnName: TColumns[number];
+      value: string;
+      rowIndex?: number;
+    };
     getConfig: ({
       page,
     }: {
       page: Page;
     }) => Promise<
-      FilterTestConfig<
-        TFilter,
-        TFilterName,
-        TKebabActions,
-        TColumn,
-        TActions,
-        TColumnName
-      >
+      FilterTestConfig<TFilter, TFilterName, TKebabActions, TColumns, TActions>
     >;
   },
 ) =>
@@ -101,9 +96,8 @@ export const testFilterShowsEmptyState = <
   /**
    * Table
    */
-  TColumn extends Record<string, TColumnValue>,
+  TColumns extends readonly string[],
   TActions extends readonly string[],
-  TColumnName extends Extract<keyof TColumn, string>,
 >(
   testName: string,
   {
@@ -116,14 +110,7 @@ export const testFilterShowsEmptyState = <
     }: {
       page: Page;
     }) => Promise<
-      FilterTestConfig<
-        TFilter,
-        TFilterName,
-        TKebabActions,
-        TColumn,
-        TActions,
-        TColumnName
-      >
+      FilterTestConfig<TFilter, TFilterName, TKebabActions, TColumns, TActions>
     >;
   },
 ) =>
@@ -148,9 +135,8 @@ export const testClearAllFilters = <
   /**
    * Table
    */
-  TColumn extends Record<string, TColumnValue>,
+  TColumns extends readonly string[],
   TActions extends readonly string[],
-  TColumnName extends Extract<keyof TColumn, string>,
 >({
   filters,
   getConfig,
@@ -161,14 +147,7 @@ export const testClearAllFilters = <
   }: {
     page: Page;
   }) => Promise<
-    FilterTestConfig<
-      TFilter,
-      TFilterName,
-      TKebabActions,
-      TColumn,
-      TActions,
-      TColumnName
-    >
+    FilterTestConfig<TFilter, TFilterName, TKebabActions, TColumns, TActions>
   >;
 }) =>
   test("Clear all filters button removes all applied filters", async ({
@@ -197,9 +176,8 @@ export const testRemovalOfFiltersFromToolbar = <
   /**
    * Table
    */
-  TColumn extends Record<string, TColumnValue>,
+  TColumns extends readonly string[],
   TActions extends readonly string[],
-  TColumnName extends Extract<keyof TColumn, string>,
 >({
   filters,
   getConfig,
@@ -210,14 +188,7 @@ export const testRemovalOfFiltersFromToolbar = <
   }: {
     page: Page;
   }) => Promise<
-    FilterTestConfig<
-      TFilter,
-      TFilterName,
-      TKebabActions,
-      TColumn,
-      TActions,
-      TColumnName
-    >
+    FilterTestConfig<TFilter, TFilterName, TKebabActions, TColumns, TActions>
   >;
 }) =>
   test("Remove filters by clicking Toolbar should be possible", async ({
@@ -280,9 +251,8 @@ export const testUrlPersistence = <
   /**
    * Table
    */
-  TColumn extends Record<string, TColumnValue>,
+  TColumns extends readonly string[],
   TActions extends readonly string[],
-  TColumnName extends Extract<keyof TColumn, string>,
 >({
   filters,
   getConfig,
@@ -293,14 +263,7 @@ export const testUrlPersistence = <
   }: {
     page: Page;
   }) => Promise<
-    FilterTestConfig<
-      TFilter,
-      TFilterName,
-      TKebabActions,
-      TColumn,
-      TActions,
-      TColumnName
-    >
+    FilterTestConfig<TFilter, TFilterName, TKebabActions, TColumns, TActions>
   >;
 }) =>
   test("Filters persist in URL and survive page reload", async ({ page }) => {
@@ -328,9 +291,8 @@ export const testBrowserNavigationBackAndForward = <
   /**
    * Table
    */
-  TColumn extends Record<string, TColumnValue>,
+  TColumns extends readonly string[],
   TActions extends readonly string[],
-  TColumnName extends Extract<keyof TColumn, string>,
 >({
   filters,
   getConfig,
@@ -341,14 +303,7 @@ export const testBrowserNavigationBackAndForward = <
   }: {
     page: Page;
   }) => Promise<
-    FilterTestConfig<
-      TFilter,
-      TFilterName,
-      TKebabActions,
-      TColumn,
-      TActions,
-      TColumnName
-    >
+    FilterTestConfig<TFilter, TFilterName, TKebabActions, TColumns, TActions>
   >;
 }) =>
   test("Browser navigation (back/forward/goto) maintains filter state", async ({

--- a/e2e/tests/ui/pages/package-details/sboms/SbomsTab.ts
+++ b/e2e/tests/ui/pages/package-details/sboms/SbomsTab.ts
@@ -49,11 +49,7 @@ export class SbomsTab {
     return await Table.build(
       this._page,
       "SBOM table",
-      {
-        Name: { isSortable: true },
-        Version: { isSortable: false },
-        Supplier: { isSortable: false },
-      },
+      ["Name", "Version", "Supplier"],
       [],
     );
   }

--- a/e2e/tests/ui/pages/package-details/vulnerabilities/VulnerabilitiesTab.ts
+++ b/e2e/tests/ui/pages/package-details/vulnerabilities/VulnerabilitiesTab.ts
@@ -49,12 +49,7 @@ export class VulnerabilitiesTab {
     return await Table.build(
       this._page,
       "vulnerability table",
-      {
-        ID: { isSortable: true },
-        Description: { isSortable: false },
-        CVSS: { isSortable: true },
-        "Date published": { isSortable: true },
-      },
+      ["ID", "Description", "CVSS", "Date published"],
       [],
     );
   }

--- a/e2e/tests/ui/pages/package-list/PackageListPage.ts
+++ b/e2e/tests/ui/pages/package-list/PackageListPage.ts
@@ -31,16 +31,16 @@ export class PackageListPage {
     return await Table.build(
       this._page,
       "Package table",
-      {
-        Name: { isSortable: true },
-        Namespace: { isSortable: true },
-        Version: { isSortable: true },
-        Type: { isSortable: false },
-        Licenses: { isSortable: false },
-        Path: { isSortable: false },
-        Qualifiers: { isSortable: false },
-        Vulnerabilities: { isSortable: false },
-      },
+      [
+        "Name",
+        "Namespace",
+        "Version",
+        "Type",
+        "Licenses",
+        "Path",
+        "Qualifiers",
+        "Vulnerabilities",
+      ],
       [],
     );
   }

--- a/e2e/tests/ui/pages/sbom-details/packages/PackagesTab.ts
+++ b/e2e/tests/ui/pages/sbom-details/packages/PackagesTab.ts
@@ -31,14 +31,7 @@ export class PackagesTab {
     return await Table.build(
       this._page,
       "Package table",
-      {
-        Name: { isSortable: true },
-        Version: { isSortable: false },
-        Vulnerabilities: { isSortable: false },
-        Licenses: { isSortable: false },
-        PURLs: { isSortable: false },
-        CPEs: { isSortable: false },
-      },
+      ["Name", "Version", "Vulnerabilities", "Licenses", "PURLs", "CPEs"],
       [],
     );
   }

--- a/e2e/tests/ui/pages/sbom-details/vulnerabilities/VulnerabilitiesTab.ts
+++ b/e2e/tests/ui/pages/sbom-details/vulnerabilities/VulnerabilitiesTab.ts
@@ -41,14 +41,14 @@ export class VulnerabilitiesTab {
     return await Table.build(
       this._page,
       "Vulnerability table",
-      {
-        Id: { isSortable: true },
-        Description: { isSortable: false },
-        CVSS: { isSortable: true },
-        "Affected dependencies": { isSortable: true },
-        Published: { isSortable: true },
-        Updated: { isSortable: true },
-      },
+      [
+        "Id",
+        "Description",
+        "CVSS",
+        "Affected dependencies",
+        "Published",
+        "Updated",
+      ],
       [],
     );
   }

--- a/e2e/tests/ui/pages/sbom-list/SbomListPage.ts
+++ b/e2e/tests/ui/pages/sbom-list/SbomListPage.ts
@@ -39,15 +39,15 @@ export class SbomListPage {
     return await Table.build(
       this._page,
       "sbom-table",
-      {
-        Name: { isSortable: true },
-        Version: { isSortable: false },
-        Supplier: { isSortable: false },
-        Labels: { isSortable: false },
-        "Created on": { isSortable: true },
-        Dependencies: { isSortable: false },
-        Vulnerabilities: { isSortable: false },
-      },
+      [
+        "Name",
+        "Version",
+        "Supplier",
+        "Labels",
+        "Created on",
+        "Dependencies",
+        "Vulnerabilities",
+      ],
       ["Edit labels", "Download SBOM", "Download License Report", "Delete"],
     );
   }

--- a/e2e/tests/ui/pages/vulnerability-details/advisories/AdvisoriesTab.ts
+++ b/e2e/tests/ui/pages/vulnerability-details/advisories/AdvisoriesTab.ts
@@ -51,13 +51,7 @@ export class AdvisoriesTab {
     return await Table.build(
       this._page,
       "Advisory table",
-      {
-        ID: { isSortable: true },
-        Title: { isSortable: false },
-        Type: { isSortable: false },
-        Revision: { isSortable: false },
-        Vulnerabilities: { isSortable: false },
-      },
+      ["ID", "Title", "Type", "Revision", "Vulnerabilities"],
       [],
     );
   }

--- a/e2e/tests/ui/pages/vulnerability-details/sboms/SbomsTab.ts
+++ b/e2e/tests/ui/pages/vulnerability-details/sboms/SbomsTab.ts
@@ -49,14 +49,7 @@ export class SbomsTab {
     return await Table.build(
       this._page,
       "Sbom table",
-      {
-        Name: { isSortable: true },
-        Version: { isSortable: false },
-        Status: { isSortable: false },
-        Dependencies: { isSortable: true },
-        Supplier: { isSortable: false },
-        "Created on": { isSortable: true },
-      },
+      ["Name", "Version", "Status", "Dependencies", "Supplier", "Created on"],
       [],
     );
   }

--- a/e2e/tests/ui/pages/vulnerability-list/VulnerabilityListPage.ts
+++ b/e2e/tests/ui/pages/vulnerability-list/VulnerabilityListPage.ts
@@ -30,13 +30,7 @@ export class VulnerabilityListPage {
     return await Table.build(
       this._page,
       "Vulnerability table",
-      {
-        ID: { isSortable: true },
-        Description: { isSortable: false },
-        CVSS: { isSortable: true },
-        "Date published": { isSortable: true },
-        "Impacted SBOMs": { isSortable: false },
-      },
+      ["ID", "Description", "CVSS", "Date published", "Impacted SBOMs"],
       [],
     );
   }


### PR DESCRIPTION
Before a Table could be defined as:

```ts
const table = await Table.build(
      page,
      "Vulnerability table",
      {
        "Vulnerability ID": { isSortable: true },
        Description: { isSortable: false },
        Severity: { isSortable: true },
        Status: { isSortable: false },
        "Affected packages": { isSortable: true },
        Published: { isSortable: true },
        Updated: { isSortable: true },
      },
      [],
    );
```

Notice that the columns are defined as "isSortable=true|false". Although the original intention was to use Typescript to limit operations on columns based on `isSortable=true|false`, the reality was that it added less value compared to the effort of setting those validations using Typescript

After:
```ts
const table = await Table.build(
      page,
      "Vulnerability table",
      [
        "Vulnerability ID",
        "Description",
        "Severity",
        "Status",
        "Affected packages",
        "Published",
        "Updated",
      ],
      [],
    );
```

Notice that for defining a table we only require the column name and no longer require "isSortable"

## Summary by Sourcery

Simplify the e2e testing Table helper to accept an ordered list of column names instead of a typed column definition with sortable metadata, and update related matchers, filter helpers, and page objects accordingly.

Enhancements:
- Refine the Table test utility and its TypeScript generics to operate on readonly string column name arrays rather than column metadata objects.
- Streamline table-related matchers and shared filter test helpers to use column name string unions derived from column arrays.
- Update all page objects and step definitions constructing tables to pass column name arrays instead of isSortable-annotated column maps.