### PR TITLE
tests(fix): rename playwright-test-generator

### DIFF
--- a/.claude/agents/bdd-test-generator.md
+++ b/.claude/agents/bdd-test-generator.md
@@ -1,5 +1,5 @@
 ---
-name: e2e-test-generator
+name: bdd-test-generator
 description: |
   Use this agent to generate Playwright BDD test step definitions for Trustify UI scenarios.
 

--- a/.claude/agents/e2e-test-orchestrator.md
+++ b/.claude/agents/e2e-test-orchestrator.md
@@ -3,7 +3,7 @@ name: e2e-test-orchestrator
 description: |
   Use this agent to orchestrate automated E2E test generation and review with iterative feedback.
 
-  This orchestrator manages the e2e-test-generator and bdd-test-reviewer agents through an
+  This orchestrator manages the e2e-bdd-generator and bdd-test-reviewer agents through an
   automated workflow with up to 3 iterations to ensure quality test code.
 
   <example>
@@ -18,7 +18,7 @@ description: |
 model: sonnet
 ---
 
-You are the E2E Test Orchestrator for Trustify UI. You coordinate the e2e-test-generator and bdd-test-reviewer agents to produce high-quality, standards-compliant test code through an automated feedback loop.
+You are the E2E Test Orchestrator for Trustify UI. You coordinate the e2e-bdd-generator and bdd-test-reviewer agents to produce high-quality, standards-compliant test code through an automated feedback loop.
 
 ## Your Mission
 
@@ -108,11 +108,11 @@ For each iteration (1 to 3):
 
 ### Step 2.1: Launch Generator
 
-**Use Task tool to spawn e2e-test-generator agent**:
+**Use Task tool to spawn bdd-test-generator agent**:
 
 ```typescript
 Task tool:
-  subagent_type: "e2e-test-generator"
+  subagent_type: "bdd-test-generator"
   prompt: "Generate step definitions for scenario: [scenario name]"
   [If iteration > 1, include feedback from previous review]
 ```

--- a/.claude/shared/README.md
+++ b/.claude/shared/README.md
@@ -37,7 +37,7 @@ BDD-specific validation rules for playwright-bdd tests (`.step.ts`) and Gherkin 
 
 **Used by:**
 - `.claude/agents/bdd-test-reviewer.md` - BDD test and feature file reviewer
-- `.claude/agents/e2e-test-generator.md` - BDD test generator
+- `.claude/agents/bdd-test-generator.md` - BDD test generator
 - `.github/chatmodes/playwright-tester.chatmode.md` - Test generator chatmode
 
 **Contents:**
@@ -172,7 +172,7 @@ When updating standards:
 1. Edit `bdd-standards.md` directly
 2. Changes automatically apply to:
    - `bdd-test-reviewer`
-   - `e2e-test-generator`
+   - `bdd-test-generator`
 3. Commit changes with clear description
 4. Update version number at bottom of file
 

--- a/.claude/shared/bdd-standards.md
+++ b/.claude/shared/bdd-standards.md
@@ -4,7 +4,7 @@ This document contains BDD-specific validation rules and code quality standards 
 
 **Used by:**
 - `.claude/agents/bdd-test-reviewer.md`
-- `.claude/agents/e2e-test-generator.md`
+- `.claude/agents/bdd-test-generator.md`
 - `.github/chatmodes/playwright-tester.chatmode.md`
 
 **For core Playwright standards** (page objects, assertions, waits, test structure), see [playwright-standards.md](./playwright-standards.md).

--- a/.claude/shared/e2e-test-standards.md
+++ b/.claude/shared/e2e-test-standards.md
@@ -4,7 +4,7 @@ This document contains shared validation rules and code quality standards used a
 
 **Used by:**
 - `.claude/agents/e2e-test-reviewer.md`
-- `.claude/agents/e2e-test-generator.md`
+- `.claude/agents/bdd-test-generator.md`
 - `.github/chatmodes/playwright-reviewer.chatmode.md`
 - `.github/chatmodes/playwright-tester.chatmode.md`
 


### PR DESCRIPTION
- rename `.claude/agents/playwright-test-generator.md` by `.claude/agents/bdd-test-generator.md`
  - Its own description makes it clear that its main purpose is to focus on the BDD tests `Use this agent to generate Playwright BDD test step definitions for Trustify UI scenarios. This agent is designed to work with the e2e-test-orchestrator. It generates test files based on Gherkin scenarios and can accept feedback to improve generated code`
- Update any reference to `.claude/agents/bdd-test-generator.md`

## Summary by Sourcery

Rename the Playwright BDD test generator agent and update all orchestrator and shared documentation references to match.

Enhancements:
- Rename the e2e Playwright BDD test generator agent to bdd-test-generator to better reflect its purpose and align naming across agents and chatmodes.

Documentation:
- Update orchestrator, standards, and shared README documentation to reference the renamed bdd-test-generator agent consistently.