### PR TITLE
fix: rename toHaveTitle to toHaveDialogTitle to avoid Playwright collision

### DIFF
--- a/e2e/tests/ui/assertions/DialogMatchers.ts
+++ b/e2e/tests/ui/assertions/DialogMatchers.ts
@@ -3,7 +3,7 @@ import type { DeletionConfirmDialog } from "../pages/ConfirmDialog";
 import type { MatcherResult } from "./types";
 
 export interface DialogMatchers {
-  toHaveTitle(expectedTitle: string): Promise<MatcherResult>;
+  toHaveDialogTitle(expectedTitle: string): Promise<MatcherResult>;
 }
 
 type DialogMatcherDefinitions = {
@@ -14,7 +14,7 @@ type DialogMatcherDefinitions = {
 };
 
 export const dialogAssertions = baseExpect.extend<DialogMatcherDefinitions>({
-  toHaveTitle: async (
+  toHaveDialogTitle: async (
     dialog: DeletionConfirmDialog,
     expectedTitle: string,
   ): Promise<MatcherResult> => {

--- a/e2e/tests/ui/features/@advisory-explorer/advisory-explorer.step.ts
+++ b/e2e/tests/ui/features/@advisory-explorer/advisory-explorer.step.ts
@@ -179,7 +179,7 @@ When(
   "User select Delete button from the Permanently delete Advisory model window",
   async ({ page }) => {
     const dialog = await DeletionConfirmDialog.build(page, "Confirm dialog");
-    await expect(dialog).toHaveTitle(
+    await expect(dialog).toHaveDialogTitle(
       "Warning alert:Permanently delete Advisory?",
     );
     await dialog.clickConfirm();

--- a/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
+++ b/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
@@ -189,7 +189,9 @@ When(
   "User select Delete button from the Permanently delete SBOM model window",
   async ({ page }) => {
     const dialog = await DeletionConfirmDialog.build(page, "Confirm dialog");
-    await expect(dialog).toHaveTitle("Warning alert:Permanently delete SBOM?");
+    await expect(dialog).toHaveDialogTitle(
+      "Warning alert:Permanently delete SBOM?",
+    );
     await dialog.clickConfirm();
   },
 );


### PR DESCRIPTION
## Summary
Renamed the custom `toHaveTitle` matcher in `DialogMatchers.ts` to `toHaveDialogTitle` to prevent name collision with Playwright's built-in `toHaveTitle` matcher (which only works with Page objects).

## Changes
- Updated `DialogMatchers.ts` interface definition from `toHaveTitle` to `toHaveDialogTitle`
- Updated matcher implementation in `DialogMatchers.ts`
- Updated test usage in `advisory-explorer.step.ts`
- Updated test usage in `sbom-explorer.step.ts`

## Impact
- Eliminates merge order dependency in `e2e/tests/ui/assertions/index.ts`
- More explicit and maintainable API - `toHaveDialogTitle` clearly indicates it's for dialog assertions
- No more runtime errors: "toHaveTitle can be only used with Page object"

## Testing
- ✅ Type checking passes (`npm run check`)
- ✅ Formatting applied

Fixes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rename the custom dialog title assertion to avoid collision with Playwright's built-in matcher.

Enhancements:
- Rename the DialogMatchers interface and matcher from toHaveTitle to toHaveDialogTitle for clearer dialog-specific semantics and to prevent conflicts with Playwright.

Tests:
- Update e2e step definitions to use the new toHaveDialogTitle matcher when asserting deletion confirmation dialog titles.