### PR TITLE
fix: replace custom debounce with useDebounceValue in SBOMEditLabelsForm

### DIFF
--- a/client/src/app/pages/sbom-list/components/SBOMEditLabelsForm.tsx
+++ b/client/src/app/pages/sbom-list/components/SBOMEditLabelsForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import type { AxiosError } from "axios";
+import { useDebounceValue } from "usehooks-ts";
 
 import type { SbomSummary } from "@app/client";
 import { EditLabelsForm } from "@app/components/EditLabelsForm";
@@ -22,14 +23,7 @@ export const SBOMEditLabelsForm: React.FC<SBOMEditLabelsFormProps> = ({
   const { pushNotification } = React.useContext(NotificationsContext);
 
   const [inputValue, setInputValue] = React.useState("");
-  const [debouncedInputValue, setDebouncedInputValue] = React.useState("");
-
-  React.useEffect(() => {
-    const delayInputTimeoutId = setTimeout(() => {
-      setDebouncedInputValue(inputValue);
-    }, 400);
-    return () => clearTimeout(delayInputTimeoutId);
-  }, [inputValue]);
+  const [debouncedInputValue] = useDebounceValue(inputValue, 400);
 
   const { labels } = useFetchSBOMLabels(debouncedInputValue);
 


### PR DESCRIPTION
## Summary
Fixes #580 by replacing the custom debounce implementation in `SBOMEditLabelsForm` with the `useDebounceValue` hook from `usehooks-ts` for consistency with the rest of the codebase.

## Changes
- Added `useDebounceValue` import from `usehooks-ts`
- Replaced custom debounce logic (9 lines) with single hook call (1 line)
- Removed manual `setTimeout`/`clearTimeout` management
- Removed unnecessary state variable and `useEffect`

## Benefits
- ✅ **Consistency**: Aligns with patterns used in `sbom-context.tsx` and `package-context.tsx`
- ✅ **Simplicity**: Reduced from 9 lines to 1 line
- ✅ **Maintainability**: No manual timeout management
- ✅ **Less error-prone**: Uses tested library hook instead of manual implementation

## Testing
- ✅ All linter checks pass (`npm run check`)
- ✅ TypeScript type checking passes
- Functionality remains identical with 400ms debounce delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Simplify SBOMEditLabelsForm by using the shared useDebounceValue hook instead of a local debounce implementation.