### PR TITLE
fix: coverage counts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -70,7 +70,25 @@
       "last 1 safari version"
     ]
   },
-  "nyc": {},
+  "nyc": {
+    "include": [
+      "client/src/app/**/*.ts",
+      "client/src/app/**/*.tsx"
+    ],
+    "exclude": [
+      "**/*.test.ts",
+      "**/*.test.tsx",
+      "**/*.spec.ts",
+      "**/*.spec.tsx",
+      "**/__tests__/**",
+      "**/node_modules/**",
+      "**/dist/**",
+      "client/src/app/client/**",
+      "e2e/**"
+    ],
+    "all": false,
+    "exclude-after-remap": true
+  },
   "msw": {
     "workerDirectory": "public"
   }

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,21 @@ coverage:
     patch:
       default:
         informational: true
+
+ignore:
+  - "e2e/**/*"                    # E2E test workspace
+  - "**/node_modules/**"          # Dependencies
+  - "**/*.test.ts"                # Unit test files
+  - "**/*.test.tsx"               # Unit test React files
+  - "**/*.spec.ts"                # Spec test files
+  - "**/*.spec.tsx"               # Spec test React files
+  - "**/dist/**"                  # Build artifacts
+  - "**/coverage/**"              # Coverage reports
+  - "**/.nyc_output/**"           # NYC temp data
+  - "**/config/**"                # Configuration files
+  - "**/__tests__/**"             # Test directories
+  - "**/jest.config.ts"           # Jest config
+  - "**/playwright.config.ts"     # Playwright config
+  - "**/rsbuild.config.ts"        # Rsbuild config
+  - "**/openapi-ts.config.ts"     # OpenAPI generator config
+  - "crate/**"                    # Rust crate directory


### PR DESCRIPTION
## Summary by Sourcery

Configure coverage tooling to ignore test, build, and infrastructure files so reported coverage better reflects application source code.

Build:
- Add NYC configuration in client package.json to include only app TypeScript sources and exclude tests, build artifacts, and client-specific paths from coverage.

CI:
- Extend Codecov configuration to ignore tests, build artifacts, tooling configs, and non-application directories in coverage reports.