### PR TITLE
chore: Optimize and clean up existing tests and step definitions

### DIFF
--- a/.github/chatmodes/playwright-orchestrator.chatmode.md
+++ b/.github/chatmodes/playwright-orchestrator.chatmode.md
@@ -43,7 +43,7 @@ Input: Scenario Name
 
 ### Phase 1: Initialization
 
-1. **Validate Input**: Ensure scenario name is provided in format "Scenario Outline: scenario name"
+1. **Validate Input**: Ensure scenario name is provided in format "Scenario Outline: scenario name" or a feature file contanining scenarios with prefix "Scenario" or "Scenario Outline". In case of feature files, iterate over scenarios one by one.
 2. **Set Iteration Counter**: Initialize iteration = 1, max_iterations = 3
 3. **Prepare Context**: Set up working directory and environment
 

--- a/e2e/tests/ui/features/@advisory-explorer/advisory-explorer.feature
+++ b/e2e/tests/ui/features/@advisory-explorer/advisory-explorer.feature
@@ -2,21 +2,17 @@ Feature: Advisory Explorer
     Background: Authentication
         Given User is authenticated
 
-# Search for advisories
+    # Search for advisories
     Scenario: Search for an advisory using the general search bar
-        
         When User searches for an advisory named "<advisoryID>" in the general search bar
-        
         Then The advisory "<advisoryID>" shows in the results
 
         Examples:
             | advisoryID      |
             | CVE-2024-26308  |
-    
-    Scenario: Search for an advisory using the dedicated search bar
 
+    Scenario: Search for an advisory using the dedicated search bar
         When User searches for "<advisoryID>" in the dedicated search bar
-        
         Then The advisory "<advisoryID>" shows in the results
 
         Examples:
@@ -25,9 +21,7 @@ Feature: Advisory Explorer
 
     # Advisory Explorer
     Scenario: Display an overview of an advisory
-
         When User visits Advisory details Page of "<advisoryID>"
-
         Then The page title is "<advisoryID>"
         Then The "Download" action is available
 
@@ -36,9 +30,7 @@ Feature: Advisory Explorer
             | CVE-2024-26308  |
 
     Scenario: Download an advisory
-
         When User visits Advisory details Page of "<advisoryID>"
-
         Then "Download Advisory" action is invoked and downloaded filename is "<fileName>"
 
         Examples:
@@ -46,9 +38,7 @@ Feature: Advisory Explorer
             | CVE-2024-26308  | CVE-2024-26308.json |
 
     Scenario: Display the Info tab
-
         When User visits Advisory details Page of "<advisoryID>"
-
         Then The "Overview" panel is visible
         Then The "Publisher" panel is visible
         Then The "Tracking" panel is visible
@@ -57,37 +47,39 @@ Feature: Advisory Explorer
             | advisoryID      |
             | CVE-2024-26308  |
 
-# Advisory Vulnerabilities
-Scenario: Display vulnerabilities tied to a single advisory
-    Given User visits Advisory details Page of "<advisoryName>" with type "<advisoryType>"
-    Then User navigates to the Vulnerabilities tab on the Advisory Overview page
-    Then Pagination of "vulnerability" table works
-    Then A list of all active vulnerabilites tied to the advisory should display
-    And The "ID, Title, Discovery, Release, Score, CWE" information should be visible for each vulnerability
-    And The vulnerabilities should be sorted by ID by default
-    And User visits Vulnerability details Page of "<vulnerabilityID>" by clicking it
+    # Advisory Vulnerabilities
+    Scenario: Display vulnerabilities tied to a single advisory
+        Given User visits Advisory details Page of "<advisoryName>" with type "<advisoryType>"
+        Then User navigates to the Vulnerabilities tab on the Advisory Overview page
+        Then Pagination of "vulnerability" table works
+        Then A list of all active vulnerabilites tied to the advisory should display
+        And The "ID, Title, Discovery, Release, Score, CWE" information should be visible for each vulnerability
+        And The vulnerabilities should be sorted by ID by default
+        And User visits Vulnerability details Page of "<vulnerabilityID>" by clicking it
 
-    Examples:
-        | advisoryName    | vulnerabilityID | advisoryType |
-        | CVE-2023-3223   | CVE-2023-3223   |     csaf     |
+        Examples:
+            | advisoryName    | vulnerabilityID | advisoryType |
+            | CVE-2023-3223   | CVE-2023-3223   |     csaf     |
 
-Scenario: Delete an advisory from the Advisory Explorer page
-    Given User visits Advisory details Page of "<advisoryID>"
-    When User Clicks on Actions button and Selects Delete option from the drop down
-    When User select Delete button from the Permanently delete Advisory model window
-    Then The Advisory deleted message is displayed
-    And Application Navigates to Advisory list page
-    And The "<advisoryID>" should not be present on Advisory list page as it is deleted
-    Examples:
-    |         advisoryID       |
-    |         CVE-2025-22130   |
+    Scenario: Delete an advisory from the Advisory Explorer page
+        Given User visits Advisory details Page of "<advisoryID>"
+        When User Clicks on Actions button and Selects Delete option from the drop down
+        When User select Delete button from the Permanently delete Advisory model window
+        Then The Advisory deleted message is displayed
+        And Application Navigates to Advisory list page
+        And The "<advisoryID>" should not be present on Advisory list page as it is deleted
 
-Scenario: Delete an advisory from the Advisory List Page
-    When User Deletes "<advisoryID>" using the toggle option from Advisory List Page
-    When User select Delete button from the Permanently delete Advisory model window
-    Then The Advisory deleted message is displayed
-    And Application Navigates to Advisory list page
-    And The "<advisoryID>" should not be present on Advisory list page as it is deleted
-    Examples:
-    |         advisoryID       |
-    |         CVE-2023-1906    |
+        Examples:
+            | advisoryID       |
+            | CVE-2025-22130   |
+
+    Scenario: Delete an advisory from the Advisory List Page
+        When User Deletes "<advisoryID>" using the toggle option from Advisory List Page
+        When User select Delete button from the Permanently delete Advisory model window
+        Then The Advisory deleted message is displayed
+        And Application Navigates to Advisory list page
+        And The "<advisoryID>" should not be present on Advisory list page as it is deleted
+
+        Examples:
+            | advisoryID       |
+            | CVE-2023-1906    |

--- a/e2e/tests/ui/features/@advisory-explorer/advisory-explorer.step.ts
+++ b/e2e/tests/ui/features/@advisory-explorer/advisory-explorer.step.ts
@@ -1,11 +1,15 @@
 import { createBdd } from "playwright-bdd";
+
+import { test } from "../../fixtures";
+
 import { expect } from "../../assertions";
+
 import { ToolbarTable } from "../../helpers/ToolbarTable";
 import { SearchPage } from "../../helpers/SearchPage";
+
+import { AdvisoryDetailsPage } from "../../pages/advisory-details/AdvisoryDetailsPage";
 import { AdvisoryListPage } from "../../pages/advisory-list/AdvisoryListPage";
-import { test } from "../../fixtures";
 import { DeletionConfirmDialog } from "../../pages/ConfirmDialog";
-import { DetailsPage } from "../../helpers/DetailsPage";
 
 export const { Given, When, Then } = createBdd(test);
 
@@ -14,19 +18,23 @@ const VULN_TABLE_NAME = "vulnerability table";
 Given(
   "User visits Advisory details Page of {string}",
   async ({ page }, advisoryID) => {
-    const searchPage = new SearchPage(page, "Advisories");
-    await searchPage.dedicatedSearch(advisoryID);
-    await page.getByRole("link", { name: advisoryID, exact: true }).click();
+    await AdvisoryDetailsPage.build(page, advisoryID);
   },
 );
 
 Given(
   "User visits Advisory details Page of {string} with type {string}",
   async ({ page }, advisoryName, advisoryType) => {
-    const searchPage = new SearchPage(page, "Advisories");
-    await searchPage.dedicatedSearch(advisoryName);
-    const advisory = `xpath=//tr[contains(.,'${advisoryName}') and contains(.,'${advisoryType}')]/td/a`;
-    await page.locator(advisory).click();
+    const listPage = await AdvisoryListPage.build(page);
+    const toolbar = await listPage.getToolbar();
+    const table = await listPage.getTable();
+
+    await toolbar.applyFilter({ "Filter text": advisoryName });
+    const rows = await table.getRowsByCellValue({
+      ID: advisoryName,
+      Type: advisoryType,
+    });
+    await rows.getByRole("link", { name: advisoryName, exact: true }).click();
   },
 );
 
@@ -42,8 +50,9 @@ When(
 When(
   "User searches for {string} in the dedicated search bar",
   async ({ page }, advisoryID) => {
-    const searchPage = new SearchPage(page, "Advisories");
-    await searchPage.dedicatedSearch(advisoryID);
+    const listPage = await AdvisoryListPage.build(page);
+    const toolbar = await listPage.getToolbar();
+    await toolbar.applyFilter({ "Filter text": advisoryID });
   },
 );
 
@@ -86,7 +95,8 @@ Then(
 Then(
   "User navigates to the Vulnerabilities tab on the Advisory Overview page",
   async ({ page }) => {
-    await page.getByRole("tab", { name: "Vulnerabilities" }).click();
+    const detailsPage = await AdvisoryDetailsPage.fromCurrentPage(page);
+    await detailsPage._layout.selectTab("Vulnerabilities");
   },
 );
 
@@ -164,14 +174,6 @@ When(
     const table = await listPage.getTable();
     const rowToDelete = 0;
     await table.clickAction("Delete", rowToDelete);
-  },
-);
-
-When(
-  "User Clicks on Actions button and Selects Delete option from the drop down",
-  async ({ page }) => {
-    const details = new DetailsPage(page);
-    await details.clickOnPageAction("Delete");
   },
 );
 

--- a/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.feature
+++ b/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.feature
@@ -46,15 +46,12 @@ Feature: SBOM Explorer - View SBOM details
         # confirms its visible for all tabs
         Then The page title is "<sbomName>"
         Then The Package table is sorted by "Name"
-
         When Search by FilterText "<packageName>"
         Then The Package table is sorted by "Name"
         Then The Package table total results is 1
         Then The "Name" column of the Package table table contains "<packageName>"
-
         When Search by FilterText "nothing matches"
         Then The Package table total results is 0
-
         When User clear all filters
         Then The Package table total results is greather than 1
 
@@ -76,8 +73,8 @@ Feature: SBOM Explorer - View SBOM details
         Then List of related Vulnerabilities should be sorted by "Id" in ascending order
 
         Examples:
-        | sbomName    |
-        | quarkus-bom |
+            | sbomName    |
+            | quarkus-bom |
 
     @slow
     Scenario Outline: Pagination of SBOM Vulnerabilities table
@@ -85,9 +82,10 @@ Feature: SBOM Explorer - View SBOM details
         When User visits SBOM details Page of "<sbomName>"
         When User selects the Tab "Vulnerabilities"
         Then Pagination of "Vulnerability" table works
+
         Examples:
-        | sbomName    |
-        | quarkus-bom |
+            | sbomName    |
+            | quarkus-bom |
 
     @slow
     Scenario Outline: View paginated list of SBOM Packages
@@ -95,9 +93,10 @@ Feature: SBOM Explorer - View SBOM details
         When User visits SBOM details Page of "<sbomName>"
         When User selects the Tab "Packages"
         Then Pagination of "Package" table works
+
         Examples:
-        |        sbomName        |
-        | ubi9-minimal-container |
+            | sbomName               |
+            | ubi9-minimal-container |
 
     Scenario Outline: Check Column Headers of SBOM Explorer Vulnerabilities table
         Given An ingested SBOM "<sbomName>" is available
@@ -109,9 +108,10 @@ Feature: SBOM Explorer - View SBOM details
         Then List of Vulnerabilities has column "Affected dependencies"
         Then List of Vulnerabilities has column "Published"
         Then List of Vulnerabilities has column "Updated"
+
         Examples:
-        | sbomName    |
-        | quarkus-bom |
+            | sbomName    |
+            | quarkus-bom |
 
     @slow
     Scenario Outline: Sorting SBOM Vulnerabilities
@@ -119,19 +119,21 @@ Feature: SBOM Explorer - View SBOM details
         When User visits SBOM details Page of "<sbomName>"
         When User selects the Tab "Vulnerabilities"
         Then Table column "Description" is not sortable
-        Then Sorting of "Id, CVSS, Affected dependencies, Published, Updated" Columns Works
+        Then Sorting of "Vulnerability" table for "Id, CVSS, Affected dependencies, Published, Updated" columns works
+
         Examples:
-        | sbomName    |
-        | quarkus-bom |
+            | sbomName    |
+            | quarkus-bom |
 
     Scenario Outline: Add Labels to SBOM from SBOM Explorer Page
         Given An ingested SBOM "<sbomName>" is available
         When User visits SBOM details Page of "<sbomName>"
         When User Adds Labels "<Labels>" to "<sbomName>" SBOM from Explorer Page
         Then The Label list "<Labels>" added to the SBOM "<sbomName>" on Explorer Page
+
         Examples:
-        |         sbomName       |    Labels     |
-        | ubi9-minimal-container | RANDOM_LABELS |
+            | sbomName               | Labels        |
+            | ubi9-minimal-container | RANDOM_LABELS |
 
     Scenario Outline: Delete SBOM from SBOM Explorer Page
         Given An ingested SBOM "<sbomName>" is available
@@ -141,9 +143,10 @@ Feature: SBOM Explorer - View SBOM details
         Then The SBOM deleted message is displayed
         And Application Navigates to SBOM list page
         And The "<sbomName>" should not be present on SBOM list page as it is deleted
+
         Examples:
-        |         sbomName       |
-        |        MRG-M-3.0.0     |
+            | sbomName    |
+            | MRG-M-3.0.0 |
 
     Scenario Outline: Delete SBOM from SBOM List Page
         When User Deletes "<sbomName>" using the toggle option from SBOM List Page
@@ -151,27 +154,30 @@ Feature: SBOM Explorer - View SBOM details
         Then The SBOM deleted message is displayed
         And Application Navigates to SBOM list page
         And The "<sbomName>" should not be present on SBOM list page as it is deleted
+
         Examples:
-        |         sbomName       |
-        |      rhn_satellite     |
+            | sbomName      |
+            | rhn_satellite |
 
     Scenario Outline: SBOM Explorer Vulnerability Correlation with Affected Advisory
         Given User is on the Vulnerabilities tab with "100" rows per page for SBOM "<sbomName>"
         When User clicks on the vulnerability row with ID "<vulnerabilityID>"
         Then The Application navigates to the Vulnerability details Page of "<vulnerabilityID>"
         And The Related SBOMs tab loaded with SBOM "<sbomName>" with status "<status>"
+
         Examples:
-        |         sbomName       | vulnerabilityID | status |
-        |        quarkus-bom     | CVE-2023-0044   | Affected |
+            | sbomName    | vulnerabilityID | status   |
+            | quarkus-bom | CVE-2023-0044   | Affected |
 
     Scenario Outline: SBOM Explorer Vulnerability Correlation with Fixed Advisory
         Given User is on the Vulnerabilities tab with "100" rows per page for SBOM "<sbomName>"
         Then The vulnerability "<vulnerabilityID>" does not show in the Vulnerabilities table
-        When User visits Vulnerability details Page of "<vulnerabilityID>"
+        Given User visits Vulnerability details Page of "<vulnerabilityID>"
         Then The Related SBOMs tab loaded with SBOM "<sbomName>" with status "<status>"
+
         Examples:
-        |         sbomName       | vulnerabilityID | status |
-        |        quarkus-bom     | CVE-2023-1584   | Fixed |
+            | sbomName    | vulnerabilityID | status |
+            | quarkus-bom | CVE-2023-1584   | Fixed  |
 
     Scenario Outline: SBOM Explorer Package Correlation with SBOM
         Given User is on the Vulnerabilities tab with "100" rows per page for SBOM "<sbomName>"
@@ -180,6 +186,7 @@ Feature: SBOM Explorer - View SBOM details
         Then The Application navigates to the Package details Page of "<packageName>"
         And Vulnerability "<vulnerabilityID>" visible under Vulnerabilities tab
         And The SBOMs using package tab loaded with SBOM "<sbomName>"
+
         Examples:
-        |         sbomName       | vulnerabilityID | packageName |
-        |        quarkus-bom     | CVE-2023-0044   | quarkus-vertx-http |
+            | sbomName    | vulnerabilityID | packageName        |
+            | quarkus-bom | CVE-2023-0044   | quarkus-vertx-http |

--- a/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
+++ b/e2e/tests/ui/features/@sbom-explorer/sbom-explorer.step.ts
@@ -1,7 +1,12 @@
 import { createBdd } from "playwright-bdd";
 
+import { test } from "../../fixtures";
+
+import { expect } from "../../assertions";
+
 import { DetailsPage } from "../../helpers/DetailsPage";
 import { ToolbarTable } from "../../helpers/ToolbarTable";
+
 import { VulnerabilitiesTab } from "../../pages/sbom-details/vulnerabilities/VulnerabilitiesTab";
 import { VulnerabilityDetailsPage } from "../../pages/vulnerability-details/VulnerabilityDetailsPage";
 import { SbomsTab } from "../../pages/vulnerability-details/sboms/SbomsTab";
@@ -10,8 +15,7 @@ import { VulnerabilitiesTab as PackageVulnerabilitiesTab } from "../../pages/pac
 import { SbomsTab as PackageSbomsTab } from "../../pages/package-details/sboms/SbomsTab";
 import { DeletionConfirmDialog } from "../../pages/ConfirmDialog";
 import { SbomListPage } from "../../pages/sbom-list/SbomListPage";
-import { test } from "../../fixtures";
-import { expect } from "../../assertions";
+import { SbomDetailsPage } from "../../pages/sbom-details/SbomDetailsPage";
 
 export const { Given, When, Then } = createBdd(test);
 
@@ -20,31 +24,40 @@ const VULN_TABLE_NAME = "Vulnerability table";
 
 When(
   "User visits SBOM details Page of {string}",
-  async ({ page }, sbomName) => {
-    await page.getByRole("link", { name: sbomName, exact: true }).click();
+  async ({ page }, sbomName: string) => {
+    // Click the SBOM link from the list page
+    const link = page.getByRole("link", { name: sbomName, exact: true });
+    await link.click();
+    // Wait for details page to load and verify
+    const sbomDetailsPage = await SbomDetailsPage.fromCurrentPage(
+      page,
+      sbomName,
+    );
+    await sbomDetailsPage._layout.verifyPageHeader(sbomName);
   },
 );
 
-Then("{string} is visible", async ({ page }, fieldName) => {
-  await expect(page.locator(`[aria-label="${fieldName}"]`)).toBeVisible();
+Then("{string} is visible", async ({ page }, fieldName: string) => {
+  const field = page.locator(`[aria-label="${fieldName}"]`);
+  await expect(field).toBeVisible();
 });
 
 Then(
   "The Package table is sorted by {string}",
-  async ({ page }, columnName) => {
+  async ({ page }, columnName: string) => {
     const toolbarTable = new ToolbarTable(page, PACKAGE_TABLE_NAME);
     await toolbarTable.verifyTableIsSortedBy(columnName);
   },
 );
 
-Then("Search by FilterText {string}", async ({ page }, filterText) => {
+Then("Search by FilterText {string}", async ({ page }, filterText: string) => {
   const toolbarTable = new ToolbarTable(page, PACKAGE_TABLE_NAME);
   await toolbarTable.filterByText(filterText);
 });
 
 Then(
   "The Package table total results is {int}",
-  async ({ page }, totalResults) => {
+  async ({ page }, totalResults: number) => {
     const toolbarTable = new ToolbarTable(page, PACKAGE_TABLE_NAME);
     await toolbarTable.verifyPaginationHasTotalResults(totalResults);
   },
@@ -52,7 +65,7 @@ Then(
 
 Then(
   "The Package table total results is greather than {int}",
-  async ({ page }, totalResults) => {
+  async ({ page }, totalResults: number) => {
     const toolbarTable = new ToolbarTable(page, PACKAGE_TABLE_NAME);
     await toolbarTable.verifyPaginationHasTotalResultsGreatherThan(
       totalResults,
@@ -62,18 +75,20 @@ Then(
 
 Then(
   "The {string} column of the Package table table contains {string}",
-  async ({ page }, columnName, expectedValue) => {
+  async ({ page }, columnName: string, expectedValue: string) => {
     const toolbarTable = new ToolbarTable(page, PACKAGE_TABLE_NAME);
     await toolbarTable.verifyColumnContainsText(columnName, expectedValue);
   },
 );
 
 When("User Clicks on Vulnerabilities Tab Action", async ({ page }) => {
-  await page.getByLabel("Tab action").click();
+  const tabActionButton = page.getByLabel("Tab action");
+  await tabActionButton.click();
 });
 
 Then("Vulnerability Popup menu appears with message", async ({ page }) => {
-  await page.getByText("Any found vulnerabilities").isVisible();
+  const popupMessage = page.getByText("Any found vulnerabilities");
+  await expect(popupMessage).toBeVisible();
   await page.getByLabel("Close").click();
 });
 
@@ -113,16 +128,16 @@ Then("SBOM Version should be visible inside the tab", async ({ page }) => {
 Then(
   "SBOM Creation date should be visible inside the tab",
   async ({ page }) => {
-    const panelSBOMVersion = await page.locator(
+    const panelSBOMCreationDate = await page.locator(
       `xpath=//section[@id='vulnerabilities-tab-section']//dt[contains(.,'Creation date')]/following-sibling::dd`,
     );
-    await panelSBOMVersion.isVisible();
+    await panelSBOMCreationDate.isVisible();
   },
 );
 
 Then(
   "List of related Vulnerabilities should be sorted by {string} in ascending order",
-  async ({ page }, columnName) => {
+  async ({ page }, columnName: string) => {
     const toolbarTable = new ToolbarTable(page, VULN_TABLE_NAME);
     await toolbarTable.verifyTableIsSortedBy(columnName, true);
   },
@@ -130,7 +145,7 @@ Then(
 
 Then(
   "List of Vulnerabilities has column {string}",
-  async ({ page }, columnHeader) => {
+  async ({ page }, columnHeader: string) => {
     const toolbarTable = new ToolbarTable(page, VULN_TABLE_NAME);
     await toolbarTable.verifyTableHeaderContains(columnHeader);
   },
@@ -138,7 +153,7 @@ Then(
 
 Then(
   "Table column {string} is not sortable",
-  async ({ page }, columnHeader) => {
+  async ({ page }, columnHeader: string) => {
     const toolbarTable = new ToolbarTable(page, VULN_TABLE_NAME);
     await toolbarTable.verifyColumnIsNotSortable(columnHeader);
   },
@@ -146,7 +161,7 @@ Then(
 
 When(
   "User Adds Labels {string} to {string} SBOM from Explorer Page",
-  async ({ page }, labelList, _sbomName) => {
+  async ({ page }, labelList: string, _sbomName: string) => {
     const detailsPage = new DetailsPage(page);
     await detailsPage.editLabelsDetailsPage();
     const labelsToAdd =
@@ -163,9 +178,9 @@ When(
 
 Then(
   "The Label list {string} added to the SBOM {string} on Explorer Page",
-  async ({ page }, labelList, sbomName) => {
+  async ({ page }, labelList: string, sbomName: string) => {
     const detailsPage = new DetailsPage(page);
-    await detailsPage.selectTab(`Info`);
+    await detailsPage.selectTab("Info");
     const infoSection = page.locator("#info-tab-section");
     // Use stored generated labels if placeholder was used
     const labelsToVerify =
@@ -174,14 +189,6 @@ Then(
           (page as any).testContext?.generatedLabels || labelList
         : labelList;
     await detailsPage.verifyLabels(labelsToVerify, sbomName, infoSection);
-  },
-);
-
-When(
-  "User Clicks on Actions button and Selects Delete option from the drop down",
-  async ({ page }) => {
-    const details = new DetailsPage(page);
-    await details.clickOnPageAction("Delete");
   },
 );
 
@@ -198,7 +205,7 @@ When(
 
 When(
   "User Deletes {string} using the toggle option from SBOM List Page",
-  async ({ page }, sbomName) => {
+  async ({ page }, sbomName: string) => {
     const listPage = await SbomListPage.build(page);
     const toolbar = await listPage.getToolbar();
     await toolbar.applyFilter({ "Filter text": sbomName });
@@ -209,9 +216,8 @@ When(
 );
 
 Then("Application Navigates to SBOM list page", async ({ page }) => {
-  await expect(
-    page.getByRole("heading", { level: 1, name: "SBOMs" }),
-  ).toBeVisible();
+  const heading = page.getByRole("heading", { level: 1, name: "SBOMs" });
+  await expect(heading).toBeVisible();
 });
 
 Then(
@@ -247,9 +253,11 @@ Given(
 When(
   "User clicks on the vulnerability row with ID {string}",
   async ({ page }, vulnerabilityID: string) => {
-    await page
-      .getByRole("link", { name: vulnerabilityID, exact: true })
-      .click();
+    const vulnerabilityLink = page.getByRole("link", {
+      name: vulnerabilityID,
+      exact: true,
+    });
+    await vulnerabilityLink.click();
   },
 );
 
@@ -287,7 +295,9 @@ Then(
   },
 );
 
-When(
+// Shared step - navigates to vulnerability details page
+// Also defined in @vulnerability-explorer/vulnerability-explorer.step.ts
+Given(
   "User visits Vulnerability details Page of {string}",
   async ({ page }, vulnerabilityID: string) => {
     await VulnerabilityDetailsPage.build(page, vulnerabilityID);
@@ -297,9 +307,12 @@ When(
 When(
   "User clicks on Affected dependencies count button of the {string}",
   async ({ page }, vulnerabilityID: string) => {
-    const vulnerabilityRow = page.locator(
-      `table[aria-label="Vulnerability table"] tbody:has(a:text-is("${vulnerabilityID}"))`,
+    const vulnerabilityTable = page.locator(
+      `table[aria-label="Vulnerability table"]`,
     );
+    const vulnerabilityRow = vulnerabilityTable.locator("tbody").filter({
+      has: page.getByRole("link", { name: vulnerabilityID, exact: true }),
+    });
     const affectedDepsButton = vulnerabilityRow
       .first()
       .locator('td[data-label="Affected dependencies"] button');
@@ -310,8 +323,11 @@ When(
 When(
   "User clicks on the package name {string} link on the expanded table",
   async ({ page }, packageName: string) => {
-    const innerTable = page.locator(
-      'table[aria-label="Vulnerability table"] td[data-label="Affected dependencies"] table',
+    const vulnerabilityTable = page.locator(
+      'table[aria-label="Vulnerability table"]',
+    );
+    const innerTable = vulnerabilityTable.locator(
+      'td[data-label="Affected dependencies"] table',
     );
     const packageLink = innerTable.getByRole("link", {
       name: packageName,

--- a/e2e/tests/ui/features/@sbom-scan/scan-sbom.feature
+++ b/e2e/tests/ui/features/@sbom-scan/scan-sbom.feature
@@ -2,213 +2,227 @@ Feature: Scan SBOM - To Generate Vulnerability Report for SBOM
     As an RHTPA user
     I want to be able to scan an SBOM so that I can review the vulnerabilities within the SBOM without having to ingest
 
-Background: Authentication
-    Given User is authenticated
+    Background: Authentication
+        Given User is authenticated
 
-Scenario: Verify Generate Vulnerability Report option
-    When User Navigates to SBOMs List page
-    When User Clicks Generate Vulnerability Button
-    Then The Application should navigate to Generate Vulnerability Report screen
-    Then The Page should contain Browse files option and instruction to Drag and drop files
+    Scenario: Verify Generate Vulnerability Report option
+        When User Navigates to SBOMs List page
+        When User Clicks Generate Vulnerability Button
+        Then The Application should navigate to Generate Vulnerability Report screen
+        Then The Page should contain Browse files option and instruction to Drag and drop files
 
-Scenario: Generate Vulnerability Report For SBOM without any vulnerabilities
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    Then "No Vulnerabilities found" header should be displayed
-    #Bug: TC-2985
-    #Then "The "<fileName>" was analyzed and found no vulnerabilities report" message should be displayed
-    Then "Try another file" button should be displayed 
-    When User Clicks on "Try another file" button
-    Then Application navigates to Generate Vulnerability Report screen
-    Examples:
-        |               fileName            |              filePath           |
-        |  example_product_quarkus.json.bz2 |   /tests/common/assets/sbom/    |
-        |  ubi9-minimal-9.3-1361.json.bz2   |   /tests/common/assets/sbom/    |
+    Scenario: Generate Vulnerability Report For SBOM without any vulnerabilities
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        Then "No Vulnerabilities found" header should be displayed
+        #Bug: TC-2985
+        #Then "The "<fileName>" was analyzed and found no vulnerabilities report" message should be displayed
+        Then "Try another file" button should be displayed
+        When User Clicks on "Try another file" button
+        Then Application navigates to Generate Vulnerability Report screen
 
-Scenario: Cancel Generate vulnerability report
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    Then The Page should have a spinner with "<header>" message and "<cancelLabel>" option while processing the SBOM
-    When User Clicks on "<cancelLabel>" link 
-    Then Application navigates to Generate Vulnerability Report screen
-    Examples:
-        |               fileName                     |              filePath              |              header             |   cancelLabel   |
-        |  example_component_quarkus.json.bz2        |    /tests/common/assets/sbom/      | Generating vulnerability report |  Cancel Report  |
+        Examples:
+            | fileName                          | filePath                     |
+            | example_product_quarkus.json.bz2  | /tests/common/assets/sbom/   |
+            | ubi9-minimal-9.3-1361.json.bz2    | /tests/common/assets/sbom/   |
 
-Scenario: Generate Vulnerability Report for supported SBOM file extensions
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    Then On the successful report generation the Application should render Vulnerability Report for the SBOM
-    Examples:
-    |        fileName          |               filePath            |
-    |    examples_sbom.json    |    /tests/common/assets/sbom/     |
-    |   exhort_mvn.json.bz2    |    /tests/common/assets/sbom/     |
+    Scenario: Cancel Generate vulnerability report
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        Then The Page should have a spinner with "<header>" message and "<cancelLabel>" option while processing the SBOM
+        When User Clicks on "<cancelLabel>" link
+        Then Application navigates to Generate Vulnerability Report screen
 
-Scenario: Verify Generate Vulnerability Report Screen
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Clicks on Browse files Button
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    Then On the successful report generation the Application should render Vulnerability Report for the SBOM
-    Then The title should be Vulnerability report with text "This is a temporary vulnerability report"
-    Then Filtering drop down should be visible with drop down values "<filters>"
-    Then Tooltip on the "Published" column should display "The date when information about this vulnerability was first made available"
-    Then Tooltip on the "Updated" column should display "The date when information about this vulnerability was most recently revised"
-    Then "Actions" button should be visible with dropdown options "<ActionsOptions>"
-    Examples:
-        |                        fileName              |              filePath             |                         filters                    |              ActionsOptions         |
-        |     quarkus-bom-3.8.3.redhat-00003.json.bz2  |   /tests/common/assets/sbom/      |      Vulnerability ID, Importer, Severity  |   Generate new report, Download as CSV |
-        |               exhort_mvn.json.bz2            |   /tests/common/assets/sbom/      |      Vulnerability ID, Importer, Severity  |   Generate new report, Download as CSV |
+        Examples:
+            | fileName                        | filePath                   | header                          | cancelLabel    |
+            | example_component_quarkus.json.bz2 | /tests/common/assets/sbom/ | Generating vulnerability report | Cancel Report  |
 
-Scenario: Verify Vulnerabilities on Generate Vulnerability Report for an SBOM
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Clicks on Browse files Button
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    Then On the successful report generation the Application should render Vulnerability Report for the SBOM
-    Then The Vulnerabilities on the Vulnerability ID column should match with "<Vulnerabilities>"
-    Examples:
-        |                        fileName              |              filePath             |     Vulnerabilities |
-        |     quarkus-bom-3.8.3.redhat-00003.json.bz2  |   /tests/common/assets/sbom/      |    CVE-2024-2700,CVE-2024-29025,CVE-2025-48924,CVE-2025-49574,CVE-2025-55163     |
-        |               exhort_mvn.json.bz2            |   /tests/common/assets/sbom/      |    CVE-2022-45787,CVE-2023-0481,CVE-2023-1584,CVE-2023-4853,CVE-2024-2700,CVE-2024-29025,CVE-2025-48924,CVE-2025-48988,CVE-2025-48989,CVE-2025-49128,CVE-2025-49574,CVE-2025-52520,CVE-2025-53506,CVE-2025-55163,CVE-2025-55668 |
+    Scenario: Generate Vulnerability Report for supported SBOM file extensions
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        Then On the successful report generation the Application should render Vulnerability Report for the SBOM
 
-Scenario: Verify Vulnerability Details on Generate Vulnerability Report for an SBOM
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Clicks on Browse files Button
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    Then On the successful report generation the Application should render Vulnerability Report for the SBOM
-    When User Applies "Vulnerability ID" filter with "<Vulnerability>" on the Vulnerability Report
-    When User Enters "<Vulnerability>" in the Vulnerability ID Textbox
-    When User Clicks on More option if visible on Severity column of the "<Vulnerability>"
-    # Bug: TC-3002 Importer value to Unknown
-    Then The Severity column of the "<Vulnerability>" should match with "<severity:Importer>"
-    Then The "Description" column of the "<Vulnerability>" should match with "<Description>"
-    Then The "Status" column of the "<Vulnerability>" should match with "<status>"
-    Then The "Affected packages" column of the "<Vulnerability>" should match with "<affectedcount>"
-    Then The "Published" column of the "<Vulnerability>" should match with "<Published>"
-    Then The "Updated" column of the "<Vulnerability>" should match with "<Updated>"
-    Examples:
-        |                   fileName                   |             filePath              |   Vulnerability    |                                            Description                             |                                               severity:Importer                        |  status  |  affectedcount  |     Published   |      Updated      |
-        |     quarkus-bom-3.8.3.redhat-00003.json.bz2  |   /tests/common/assets/sbom/      |   CVE-2024-29025   |                       Netty HttpPostRequestDecoder can OOM                         |  Medium(5.3): Unknown,Medium(5.3): Unknown,Medium(5.3): Unknown,Medium(5.3): Unknown   | Affected |        1        |   Mar 25, 2024  |    Feb 13, 2025   |
-        |               exhort_mvn.json.bz2            |   /tests/common/assets/sbom/      |   CVE-2023-0481    |  In RestEasy Reactive implementation of Quarkus the insecure File.createTempFile() |                  Medium(5.3): Unknown,Low(3.3): Unknown,Medium(5.3): Unknown           | Affected |        1        |   Feb 24, 2023  |    Mar 12, 2025   |
+        Examples:
+            | fileName              | filePath                   |
+            | examples_sbom.json    | /tests/common/assets/sbom/ |
+            | exhort_mvn.json.bz2   | /tests/common/assets/sbom/ |
 
-Scenario: Verify Affected package list on Generate Vulnerability Report for an SBOM
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Clicks on Browse files Button
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    Then On the successful report generation the Application should render Vulnerability Report for the SBOM
-    When User Applies "Vulnerability ID" filter with "<Vulnerability>" on the Vulnerability Report
-    When User Enters "<Vulnerability>" in the Vulnerability ID Textbox
-    When User Clicks on Affected package count button of the "<Vulnerability>"
-    Then Affected Package table should expand
-    Then The "Type" column of the "<Vulnerability>" affected package should match with "<Type>"
-    Then The "Namespace" column of the "<Vulnerability>" affected package should match with "<Namespace>"
-    Then The "Name" column of the "<Vulnerability>" affected package should match with "<Name>"
-    Then The "Version" column of the "<Vulnerability>" affected package should match with "<Version>"
-    Then The "Path" column of the "<Vulnerability>" affected package should match with "<Path>"
-    Then The "Qualifiers" column of the "<Vulnerability>" affected package should match with "<Qualifiers>"
-    Examples:
-        |                   fileName                   |             filePath              |   Vulnerability    |  Type  |          Namespace           |               Name        |           Version         | Path |                                Qualifiers                      |
-        |     quarkus-bom-3.8.3.redhat-00003.json.bz2  |   /tests/common/assets/sbom/      |   CVE-2024-29025   |  maven |          io.netty            |       netty-codec-http    | 4.1.107.Final-redhat-00001|      |repository_url=https://maven.repository.redhat.com/ga/,type=jar |
-        |               exhort_mvn.json.bz2            |   /tests/common/assets/sbom/      |   CVE-2023-0481    |  maven | io.quarkus.resteasy.reactive | resteasy-reactive-common  |           2.13.7.Final    |      |                                                                |
+    Scenario: Verify Generate Vulnerability Report Screen
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Clicks on Browse files Button
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        Then On the successful report generation the Application should render Vulnerability Report for the SBOM
+        Then The title should be Vulnerability report with text "This is a temporary vulnerability report"
+        Then Filtering drop down should be visible with drop down values "<filters>"
+        Then Tooltip on the "Published" column should display "The date when information about this vulnerability was first made available"
+        Then Tooltip on the "Updated" column should display "The date when information about this vulnerability was most recently revised"
+        Then "Actions" button should be visible with dropdown options "<ActionsOptions>"
 
-Scenario: Verify Actions on Generate Vulnerability Report for an SBOM
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Clicks on Browse files Button
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    When User Clicks on "Actions" button
-    Then The Actions dropdown should have options "Generate new report" and "Download as CSV"
-    When User Clicks on "Generate new report" option from the Actions dropdown
-    Then Application navigates to Generate Vulnerability Report screen
-    Examples:
-        |                        fileName              |              filePath             |
-        |     quarkus-bom-3.8.3.redhat-00003.json.bz2  |   /tests/common/assets/sbom/      |
-        |               exhort_mvn.json.bz2            |   /tests/common/assets/sbom/      |
+        Examples:
+            | fileName                                | filePath                   | filters                               | ActionsOptions                         |
+            | quarkus-bom-3.8.3.redhat-00003.json.bz2 | /tests/common/assets/sbom/ | Vulnerability ID, Importer, Severity  | Generate new report, Download as CSV   |
+            | exhort_mvn.json.bz2                     | /tests/common/assets/sbom/ | Vulnerability ID, Importer, Severity  | Generate new report, Download as CSV   |
 
+    Scenario: Verify Vulnerabilities on Generate Vulnerability Report for an SBOM
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Clicks on Browse files Button
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        Then On the successful report generation the Application should render Vulnerability Report for the SBOM
+        Then The Vulnerabilities on the Vulnerability ID column should match with "<Vulnerabilities>"
 
-Scenario: Verify Download as CSV on Generate Vulnerability Report for an SBOM
-    Given User Navigated to Generate Vulnerability Report screen        
-    When User Clicks on Browse files Button
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    When User Clicks on "Actions" button
-    Then The Actions dropdown should have options "Generate new report" and "Download as CSV"
-    Then User Downloads CSV with default filename "<fileName>" by clicking on "Download as CSV" option
-    Examples:
-        |                        fileName              |              filePath             |
-        |     quarkus-bom-3.8.3.redhat-00003.json.bz2  |   /tests/common/assets/sbom/      |
-        |               exhort_mvn.json.bz2            |   /tests/common/assets/sbom/      |
+        Examples:
+            | fileName                                | filePath                   | Vulnerabilities                                                                                                                                                                                                                      |
+            | quarkus-bom-3.8.3.redhat-00003.json.bz2 | /tests/common/assets/sbom/ | CVE-2024-2700,CVE-2024-29025,CVE-2025-48924,CVE-2025-49574,CVE-2025-55163                                                                                                                                                           |
+            | exhort_mvn.json.bz2                     | /tests/common/assets/sbom/ | CVE-2022-45787,CVE-2023-0481,CVE-2023-1584,CVE-2023-4853,CVE-2024-2700,CVE-2024-29025,CVE-2025-48924,CVE-2025-48988,CVE-2025-48989,CVE-2025-49128,CVE-2025-49574,CVE-2025-52520,CVE-2025-53506,CVE-2025-55163,CVE-2025-55668 |
 
-Scenario: Verify Download and Leave on Generate Vulnerability Report for an SBOM
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Clicks on Browse files Button
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    When User Enters "<Vulnerability>" in the Vulnerability ID Textbox
-    When User Clicks on "<Vulnerability>" from the Vulnerability ID column
-    Then A modal window should open with "Leave Vulnerability Report?" message
-    When User Downloads CSV with default filename "<fileName>" and Leaves by clicking on "Download and Leave" button from the modal window
-    Then Application navigates to Vulnerability Explorer screen of "<Vulnerability>"
-    Examples:
-        |                        fileName              |              filePath             | Vulnerability  |
-        |     quarkus-bom-3.8.3.redhat-00003.json.bz2  |   /tests/common/assets/sbom/      | CVE-2025-48924 |
-        |               exhort_mvn.json.bz2            |   /tests/common/assets/sbom/      | CVE-2023-1584 |
+    Scenario: Verify Vulnerability Details on Generate Vulnerability Report for an SBOM
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Clicks on Browse files Button
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        Then On the successful report generation the Application should render Vulnerability Report for the SBOM
+        When User Applies "Vulnerability ID" filter with "<Vulnerability>" on the Vulnerability Report
+        When User Enters "<Vulnerability>" in the Vulnerability ID Textbox
+        When User Clicks on More option if visible on Severity column of the "<Vulnerability>"
+        # Bug: TC-3002 Importer value to Unknown
+        Then The Severity column of the "<Vulnerability>" should match with "<severity:Importer>"
+        Then The "Description" column of the "<Vulnerability>" should match with "<Description>"
+        Then The "Status" column of the "<Vulnerability>" should match with "<status>"
+        Then The "Affected packages" column of the "<Vulnerability>" should match with "<affectedcount>"
+        Then The "Published" column of the "<Vulnerability>" should match with "<Published>"
+        Then The "Updated" column of the "<Vulnerability>" should match with "<Updated>"
 
-Scenario: Verify Leave without Downloading on Generate Vulnerability Report for an SBOM
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Clicks on Browse files Button
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    When User Enters "<Vulnerability>" in the Vulnerability ID Textbox
-    When User Clicks on "<Vulnerability>" from the Vulnerability ID column
-    Then A modal window should open with "Leave Vulnerability Report?" message
-    When User Clicks on "Leave without Downloading" button from the modal window
-    Then Application navigates to Vulnerability Explorer screen of "<Vulnerability>"
-    Examples:
-        |                        fileName              |              filePath             | Vulnerability  |
-        |     quarkus-bom-3.8.3.redhat-00003.json.bz2  |   /tests/common/assets/sbom/      | CVE-2025-48924 |
-        |               exhort_mvn.json.bz2            |   /tests/common/assets/sbom/      | CVE-2023-1584 |
+        Examples:
+            | fileName                                | filePath                   | Vulnerability    | Description                                                                        | severity:Importer                                                                      | status   | affectedcount | Published      | Updated        |
+            | quarkus-bom-3.8.3.redhat-00003.json.bz2 | /tests/common/assets/sbom/ | CVE-2024-29025   | Netty HttpPostRequestDecoder can OOM                                               | Medium(5.3): Unknown,Medium(5.3): Unknown,Medium(5.3): Unknown,Medium(5.3): Unknown    | Affected | 1             | Mar 25, 2024   | Feb 13, 2025   |
+            | exhort_mvn.json.bz2                     | /tests/common/assets/sbom/ | CVE-2023-0481    | In RestEasy Reactive implementation of Quarkus the insecure File.createTempFile()  | Medium(5.3): Unknown,Low(3.3): Unknown,Medium(5.3): Unknown                            | Affected | 1             | Feb 24, 2023   | Mar 12, 2025   |
 
-Scenario: Verify Cancel on Leave Vulnerability Report modal window
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Clicks on Browse files Button
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    When User Enters "<Vulnerability>" in the Vulnerability ID Textbox
-    When User Clicks on "<Vulnerability>" from the Vulnerability ID column
-    Then A modal window should open with "Leave Vulnerability Report?" message
-    When User Clicks on "Cancel" button from the modal window
-    Then Application should remain on the Generate Vulnerability Report screen
-    Examples:
-        |                        fileName              |              filePath             | Vulnerability  |
-        |     quarkus-bom-3.8.3.redhat-00003.json.bz2  |   /tests/common/assets/sbom/      | CVE-2025-48924 |
-        |               exhort_mvn.json.bz2            |   /tests/common/assets/sbom/      | CVE-2023-1584  |
+    Scenario: Verify Affected package list on Generate Vulnerability Report for an SBOM
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Clicks on Browse files Button
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        Then On the successful report generation the Application should render Vulnerability Report for the SBOM
+        When User Applies "Vulnerability ID" filter with "<Vulnerability>" on the Vulnerability Report
+        When User Enters "<Vulnerability>" in the Vulnerability ID Textbox
+        When User Clicks on Affected package count button of the "<Vulnerability>"
+        Then Affected Package table should expand
+        Then The "Type" column of the "<Vulnerability>" affected package should match with "<Type>"
+        Then The "Namespace" column of the "<Vulnerability>" affected package should match with "<Namespace>"
+        Then The "Name" column of the "<Vulnerability>" affected package should match with "<Name>"
+        Then The "Version" column of the "<Vulnerability>" affected package should match with "<Version>"
+        Then The "Path" column of the "<Vulnerability>" affected package should match with "<Path>"
+        Then The "Qualifiers" column of the "<Vulnerability>" affected package should match with "<Qualifiers>"
 
-Scenario: Verify Filtering on Generate Vulnerability Report for an SBOM
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Clicks on Browse files Button
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    Then On the successful report generation the Application should render Vulnerability Report for the SBOM
-    When User Applies "<filter>" filter with "<value>" on the Vulnerability Report
-    Then Applied "<filter>" should be visible with "<value>" on the filter bar
-    Then The Vulnerabilities on the Vulnerability ID column should match with "<Vulnerabilities>"
-    When User Applies "Vulnerability ID" filter with "<Vulnerability>" on the Vulnerability Report
-    When User Enters "<Vulnerability>" in the Vulnerability ID Textbox
-    Then The "Severity" of the "<Vulnerability>" should match with "<severity:importer>"
-    Examples:
-        |                      fileName                |             filePath              |     filter         |      value     |                                                   Vulnerabilities                                       |  Vulnerability  |                        severity:importer                     |
-        |                examples_sbom.json            |   /tests/common/assets/sbom/      |    Severity        |      Medium    |                                          CVE-2025-48795,CVE-2025-48924                                  | CVE-2025-48924  |                     Medium(6.5): Unknown                     |
-        |               exhort_mvn.json.bz2            |   /tests/common/assets/sbom/      |    Severity        |      Medium    |CVE-2022-45787,CVE-2023-0481,CVE-2024-29025,CVE-2025-48924,CVE-2025-49128,CVE-2025-49574,CVE-2025-55668  |  CVE-2023-0481  |   Medium(5.3): Unknown,Low(3.3): Unknown,Medium(5.3): Unknown|
-        |     quarkus-bom-3.8.3.redhat-00003.json.bz2  |   /tests/common/assets/sbom/      |    Severity        |       High     |                                          CVE-2024-2700,CVE-2025-55163                                   |  CVE-2024-2700  |                         High(7): Unknown                     |
+        Examples:
+            | fileName                                | filePath                   | Vulnerability  | Type  | Namespace                        | Name                     | Version                    | Path | Qualifiers                                                     |
+            | quarkus-bom-3.8.3.redhat-00003.json.bz2 | /tests/common/assets/sbom/ | CVE-2024-29025 | maven | io.netty                         | netty-codec-http         | 4.1.107.Final-redhat-00001 |      | repository_url=https://maven.repository.redhat.com/ga/,type=jar|
+            | exhort_mvn.json.bz2                     | /tests/common/assets/sbom/ | CVE-2023-0481  | maven | io.quarkus.resteasy.reactive     | resteasy-reactive-common | 2.13.7.Final               |      |                                                                |
 
-Scenario: Verify Pagination on Generate Vulnerability Report for an SBOM
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Clicks on Browse files Button
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    Then Pagination of "Vulnerability" table works
-    Examples:
-        |                        fileName              |              filePath             |
-        |               exhort_mvn.json.bz2            |   /tests/common/assets/sbom/      |
+    Scenario: Verify Actions on Generate Vulnerability Report for an SBOM
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Clicks on Browse files Button
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        When User Clicks on "Actions" button
+        Then The Actions dropdown should have options "Generate new report" and "Download as CSV"
+        When User Clicks on "Generate new report" option from the Actions dropdown
+        Then Application navigates to Generate Vulnerability Report screen
 
-Scenario: Verify Sorting on Generate Vulnerability Report for an SBOM
-    Given User Navigated to Generate Vulnerability Report screen
-    When User Clicks on Browse files Button
-    When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
-    Then Sorting of "<sortableColumns>" Columns Works
-    Examples:
-    |                        fileName              |              filePath             |                        sortableColumns                    |
-    |                exhort_mvn.json.bz2           |   /tests/common/assets/sbom/      |    Vulnerability ID,Affected packages,Published,Updated   |
+        Examples:
+            | fileName                                | filePath                   |
+            | quarkus-bom-3.8.3.redhat-00003.json.bz2 | /tests/common/assets/sbom/ |
+            | exhort_mvn.json.bz2                     | /tests/common/assets/sbom/ |
+
+    Scenario: Verify Download as CSV on Generate Vulnerability Report for an SBOM
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Clicks on Browse files Button
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        When User Clicks on "Actions" button
+        Then The Actions dropdown should have options "Generate new report" and "Download as CSV"
+        Then User Downloads CSV with default filename "<fileName>" by clicking on "Download as CSV" option
+
+        Examples:
+            | fileName                                | filePath                   |
+            | quarkus-bom-3.8.3.redhat-00003.json.bz2 | /tests/common/assets/sbom/ |
+            | exhort_mvn.json.bz2                     | /tests/common/assets/sbom/ |
+
+    Scenario: Verify Download and Leave on Generate Vulnerability Report for an SBOM
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Clicks on Browse files Button
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        When User Enters "<Vulnerability>" in the Vulnerability ID Textbox
+        When User Clicks on "<Vulnerability>" from the Vulnerability ID column
+        Then A modal window should open with "Leave Vulnerability Report?" message
+        When User Downloads CSV with default filename "<fileName>" and Leaves by clicking on "Download and Leave" button from the modal window
+        Then Application navigates to Vulnerability Explorer screen of "<Vulnerability>"
+
+        Examples:
+            | fileName                                | filePath                   | Vulnerability  |
+            | quarkus-bom-3.8.3.redhat-00003.json.bz2 | /tests/common/assets/sbom/ | CVE-2025-48924 |
+            | exhort_mvn.json.bz2                     | /tests/common/assets/sbom/ | CVE-2023-1584  |
+
+    Scenario: Verify Leave without Downloading on Generate Vulnerability Report for an SBOM
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Clicks on Browse files Button
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        When User Enters "<Vulnerability>" in the Vulnerability ID Textbox
+        When User Clicks on "<Vulnerability>" from the Vulnerability ID column
+        Then A modal window should open with "Leave Vulnerability Report?" message
+        When User Clicks on "Leave without Downloading" button from the modal window
+        Then Application navigates to Vulnerability Explorer screen of "<Vulnerability>"
+
+        Examples:
+            | fileName                                | filePath                   | Vulnerability  |
+            | quarkus-bom-3.8.3.redhat-00003.json.bz2 | /tests/common/assets/sbom/ | CVE-2025-48924 |
+            | exhort_mvn.json.bz2                     | /tests/common/assets/sbom/ | CVE-2023-1584  |
+
+    Scenario: Verify Cancel on Leave Vulnerability Report modal window
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Clicks on Browse files Button
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        When User Enters "<Vulnerability>" in the Vulnerability ID Textbox
+        When User Clicks on "<Vulnerability>" from the Vulnerability ID column
+        Then A modal window should open with "Leave Vulnerability Report?" message
+        When User Clicks on "Cancel" button from the modal window
+        Then Application should remain on the Generate Vulnerability Report screen
+
+        Examples:
+            | fileName                                | filePath                   | Vulnerability  |
+            | quarkus-bom-3.8.3.redhat-00003.json.bz2 | /tests/common/assets/sbom/ | CVE-2025-48924 |
+            | exhort_mvn.json.bz2                     | /tests/common/assets/sbom/ | CVE-2023-1584  |
+
+    Scenario: Verify Filtering on Generate Vulnerability Report for an SBOM
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Clicks on Browse files Button
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        Then On the successful report generation the Application should render Vulnerability Report for the SBOM
+        When User Applies "<filter>" filter with "<value>" on the Vulnerability Report
+        Then Applied "<filter>" should be visible with "<value>" on the filter bar
+        Then The Vulnerabilities on the Vulnerability ID column should match with "<Vulnerabilities>"
+        When User Applies "Vulnerability ID" filter with "<Vulnerability>" on the Vulnerability Report
+        When User Enters "<Vulnerability>" in the Vulnerability ID Textbox
+        Then The "Severity" of the "<Vulnerability>" should match with "<severity:importer>"
+
+        Examples:
+            | fileName                                | filePath                   | filter   | value  | Vulnerabilities                                                                                        | Vulnerability  | severity:importer                                             |
+            | examples_sbom.json                      | /tests/common/assets/sbom/ | Severity | Medium | CVE-2025-48795,CVE-2025-48924                                                                          | CVE-2025-48924 | Medium(6.5): Unknown                                          |
+            | exhort_mvn.json.bz2                     | /tests/common/assets/sbom/ | Severity | Medium | CVE-2022-45787,CVE-2023-0481,CVE-2024-29025,CVE-2025-48924,CVE-2025-49128,CVE-2025-49574,CVE-2025-55668 | CVE-2023-0481  | Medium(5.3): Unknown,Low(3.3): Unknown,Medium(5.3): Unknown   |
+            | quarkus-bom-3.8.3.redhat-00003.json.bz2 | /tests/common/assets/sbom/ | Severity | High   | CVE-2024-2700,CVE-2025-55163                                                                           | CVE-2024-2700  | High(7): Unknown                                              |
+
+    Scenario: Verify Pagination on Generate Vulnerability Report for an SBOM
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Clicks on Browse files Button
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        Then Pagination of "Vulnerability" table works
+
+        Examples:
+            | fileName            | filePath                   |
+            | exhort_mvn.json.bz2 | /tests/common/assets/sbom/ |
+
+    Scenario: Verify Sorting on Generate Vulnerability Report for an SBOM
+        Given User Navigated to Generate Vulnerability Report screen
+        When User Clicks on Browse files Button
+        When User Selects SBOM "<fileName>" from "<filePath>" on the file explorer dialog window
+        Then Sorting of "Vulnerability" table for "<sortableColumns>" columns works
+
+        Examples:
+            | fileName            | filePath                   | sortableColumns                                 |
+            | exhort_mvn.json.bz2 | /tests/common/assets/sbom/ | Vulnerability ID,Affected packages,Published,Updated |

--- a/e2e/tests/ui/features/@sbom-scan/scan-sbom.step.ts
+++ b/e2e/tests/ui/features/@sbom-scan/scan-sbom.step.ts
@@ -1,11 +1,14 @@
 import { createBdd } from "playwright-bdd";
-import { expect } from "playwright/test";
 
 import { test } from "../../fixtures";
+
+import { expect } from "../../assertions";
+
+import { ToolbarTable } from "../../helpers/ToolbarTable";
+
 import { SbomListPage } from "../../pages/sbom-list/SbomListPage";
 import { SbomScanPage } from "../../pages/sbom-scan/SbomScanPage";
 import { Table } from "../../pages/Table";
-import { ToolbarTable } from "../../helpers/ToolbarTable";
 import {
   clickAndVerifyDownload,
   verifyChildElementsText,
@@ -27,11 +30,10 @@ Then(
   "The Application should navigate to Generate Vulnerability Report screen",
   async ({ page }) => {
     await expect(page).toHaveURL(/\/sboms\/scan$/);
-    await expect(
-      page.locator(
-        `xpath=//h1[contains(text(),'Generate vulnerability report')]`,
-      ),
-    ).toBeVisible();
+    const scanPage = await SbomScanPage.build(page);
+    await expect(scanPage.heading).toContainText(
+      "Generate vulnerability report",
+    );
   },
 );
 
@@ -39,9 +41,8 @@ Then(
   "The Page should contain Browse files option and instruction to Drag and drop files",
   async ({ page }) => {
     // From UploadFileForAnalysis.tsx browseButtonText="Browse Files" and titleText="Drag and drop files here"
-    await expect(
-      page.getByRole("button", { name: "Browse Files" }),
-    ).toBeVisible();
+    const scanPage = await SbomScanPage.build(page);
+    await expect(scanPage.browseFilesButton).toBeVisible();
     await expect(page.getByText("Drag and drop files here")).toBeVisible();
   },
 );
@@ -58,7 +59,8 @@ Given(
 );
 
 When("User Clicks on Browse files Button", async ({ page }) => {
-  await page.getByRole("button", { name: "Browse Files" }).click();
+  const scanPage = await SbomScanPage.build(page);
+  await scanPage.browseFilesButton.click();
 });
 
 When(
@@ -118,7 +120,10 @@ Then(
     );
     const tooltipButton = table.getColumnTooltipButton(column, tooltipMessage);
     await tooltipButton.hover();
-    await page.waitForTimeout(500);
+    // Wait for the specific tooltip with expected message to become visible
+    await expect(
+      page.getByRole("tooltip", { name: tooltipMessage }),
+    ).toBeVisible();
   },
 );
 
@@ -164,11 +169,10 @@ Then(
   "Application navigates to Generate Vulnerability Report screen",
   async ({ page }) => {
     await expect(page).toHaveURL(/\/sboms\/scan$/);
-    await expect(
-      page.locator(
-        `xpath=//h1[contains(text(),'Generate vulnerability report')]`,
-      ),
-    ).toBeVisible();
+    const scanPage = await SbomScanPage.build(page);
+    await expect(scanPage.heading).toContainText(
+      "Generate vulnerability report",
+    );
   },
 );
 
@@ -224,11 +228,11 @@ Then(
     }
 
     // Verify each expected ID is present at least once
-    for (const id of expectedIds) {
-      await expect
-        .soft(collectedIds, `Missing expected id: ${id}`)
-        .toContain(id);
-    }
+    const missingIds = expectedIds.filter((id) => !collectedIds.includes(id));
+    expect(
+      missingIds.length,
+      `Missing expected IDs: ${missingIds.join(", ")}. Found: ${collectedIds.join(", ")}`,
+    ).toBe(0);
   },
 );
 
@@ -327,11 +331,9 @@ When(
 );
 
 Then("Affected Package table should expand", async ({ page }) => {
-  // Wait for the expanded content to appear
-  await page.waitForTimeout(500);
   // Look for the nested grid with column headers Type, Namespace, etc.
-  // The expanded table has columnheader elements
-  const typeHeader = page.locator('role=columnheader[name="Type"]');
+  // The expanded table has columnheader elements - Playwright auto-waits for visibility
+  const typeHeader = page.getByRole("columnheader", { name: "Type" });
   await expect(typeHeader).toBeVisible();
 });
 
@@ -414,10 +416,8 @@ Then(
 Then(
   "A modal window should open with {string} message",
   async ({ page }, message: string) => {
-    // Wait for modal dialog to appear
-    await page.waitForTimeout(500);
-    // Check for modal with the message
-    const modal = page.locator('[role="dialog"]');
+    // Check for modal with the message - Playwright auto-waits for visibility
+    const modal = page.getByRole("dialog");
     await expect(modal).toBeVisible();
     await expect(modal.getByText(message)).toBeVisible();
   },
@@ -426,8 +426,7 @@ Then(
 When(
   "User Clicks on {string} button from the modal window",
   async ({ page }, buttonName: string) => {
-    const modal = page.locator('[role="dialog"]');
-    // Just click for non-download actions
+    const modal = page.getByRole("dialog");
     await modal.getByRole("button", { name: buttonName }).click();
   },
 );
@@ -435,13 +434,13 @@ When(
 When(
   "User Downloads CSV with default filename {string} and Leaves by clicking on {string} button from the modal window",
   async ({ page }, fileName: string, buttonName: string) => {
-    const modal = page.locator('[role="dialog"]');
+    const modal = page.getByRole("dialog");
     // Use the reusable helper for click + download verification
     const downloadedFileName = await clickAndVerifyDownload(page, () =>
       modal.getByRole("button", { name: buttonName }).click(),
     );
-    await expect(downloadedFileName).toContain(fileName);
-    await expect(downloadedFileName.endsWith(".csv")).toBeTruthy();
+    expect(downloadedFileName).toContain(fileName);
+    expect(downloadedFileName.endsWith(".csv")).toBeTruthy();
   },
 );
 

--- a/e2e/tests/ui/features/@sbom-search/sbom-search.feature
+++ b/e2e/tests/ui/features/@sbom-search/sbom-search.feature
@@ -10,10 +10,11 @@ Feature: SBOM Search Page
             | sbomName    |
             | quarkus-bom |
 
-     Scenario Outline: Add Labels to SBOM from SBOM List Page
+    Scenario Outline: Add Labels to SBOM from SBOM List Page
         Given An ingested SBOM "<sbomName>" is available
         When User Adds Labels "<Labels>" to "<sbomName>" SBOM from List Page
         Then The Label list "<Labels>" added to the SBOM "<sbomName>" on List Page
+
         Examples:
-        | sbomName    |     Labels    |
-        | quarkus-bom | RANDOM_LABELS |
+            | sbomName    | Labels        |
+            | quarkus-bom | RANDOM_LABELS |

--- a/e2e/tests/ui/features/@sbom-search/sbom-search.step.ts
+++ b/e2e/tests/ui/features/@sbom-search/sbom-search.step.ts
@@ -1,37 +1,54 @@
 import { createBdd } from "playwright-bdd";
 
 import { test } from "../../fixtures";
-import { DetailsPage } from "../../helpers/DetailsPage";
-import { ToolbarTable } from "../../helpers/ToolbarTable";
+
 import { expect } from "../../assertions";
 
-export const { Given, When, Then } = createBdd(test);
+import { DetailsPage } from "../../helpers/DetailsPage";
 
-const SBOM_TABLE_NAME = "sbom-table";
+import { SbomListPage } from "../../pages/sbom-list/SbomListPage";
+import { LabelsModal } from "../../pages/LabelsModal";
+
+export const { Given, When, Then } = createBdd(test);
 
 Given(
   "An ingested SBOM {string} containing Vulnerabilities",
   async ({ page }, sbomName) => {
-    const element = page.locator(
-      `xpath=(//tr[contains(.,'${sbomName}')]/td[@data-label='Vulnerabilities']/div)[1]`,
-    );
-    await expect(element, "SBOM have no vulnerabilities").toHaveText(
-      /^(?!0$).+/,
-    );
+    const listPage = await SbomListPage.build(page);
+    const toolbar = await listPage.getToolbar();
+    const table = await listPage.getTable();
+
+    await toolbar.applyFilter({ "Filter text": sbomName });
+    await expect(table).toHaveColumnWithValue("Name", sbomName);
+
+    // Check vulnerabilities column has non-zero value
+    const vulnColumn = await table.getColumn("Vulnerabilities");
+    await expect(vulnColumn.first()).not.toHaveText("0");
   },
 );
 
 When(
   "User Adds Labels {string} to {string} SBOM from List Page",
   async ({ page }, labelList, sbomName) => {
-    const toolbarTable = new ToolbarTable(page, SBOM_TABLE_NAME);
-    await toolbarTable.editLabelsListPage(sbomName);
+    const listPage = await SbomListPage.build(page);
+    const toolbar = await listPage.getToolbar();
+    const table = await listPage.getTable();
+
+    await toolbar.applyFilter({ "Filter text": sbomName });
+    await expect(table).toHaveColumnWithValue("Name", sbomName);
+
+    await table.clickAction("Edit labels", 0);
+
+    const labelsModal = await LabelsModal.build(page);
     const detailsPage = new DetailsPage(page);
 
     // Generate random labels if placeholder is used
     const labelsToAdd =
       labelList === "RANDOM_LABELS" ? detailsPage.generateLabels() : labelList;
-    await detailsPage.addLabels(labelsToAdd);
+    const labelsArray = labelsToAdd.split(",").map((l: string) => l.trim());
+
+    await labelsModal.addLabels(labelsArray);
+    await labelsModal.clickSave();
 
     // Store generated labels for verification
     // biome-ignore lint/suspicious/noExplicitAny: allowed

--- a/e2e/tests/ui/features/@vulnerability-explorer/vulnerability-explorer.feature
+++ b/e2e/tests/ui/features/@vulnerability-explorer/vulnerability-explorer.feature
@@ -4,7 +4,7 @@ Feature: Vulnerability Explorer - View Vulnerability details
 
     # Search for vulnerability
     Scenario: Search for a vulnerability using the general search bar
-        When User searches for "<vulnerabilityID>" in the general search bar
+        When User searches for a vulnerability named "<vulnerabilityID>" in the general search bar
         Then The vulnerability "<vulnerabilityID>" shows in the results
 
         Examples:
@@ -12,7 +12,7 @@ Feature: Vulnerability Explorer - View Vulnerability details
             | CVE-2023-1664   |
 
     Scenario: Search for a vulnerability using the dedicated search bar
-        When User searches for "<vulnerabilityID>" in the dedicated search bar
+        When User searches for a vulnerability "<vulnerabilityID>" in the dedicated search bar
         Then The vulnerability "<vulnerabilityID>" shows in the results
 
         Examples:
@@ -31,13 +31,11 @@ Feature: Vulnerability Explorer - View Vulnerability details
             | vulnerabilityID | severityDescription | severityScore | descriptionBeginsWith         | dateReserved | datePublished | dateLastModified |
             | CVE-2023-1664   | Medium              | 6.5           | A flaw was found in Keycloak. | Mar 27, 2023 | May 26, 2023  | Jan 15, 2025     |
 
-
     # Related products / SBOMs
     Scenario Outline: View related SBOMs
         Given User visits Vulnerability details Page of "<vulnerabilityID>"
         When Tab "Related SBOMs" is visible
         Then The page title is "<vulnerabilityID>"
-
         Then The SBOMs table is sorted by "Name"
         Then The SBOMs table total results is 1
         Then The "Name" column of the SBOM table contains "<sbomName>"
@@ -51,14 +49,13 @@ Feature: Vulnerability Explorer - View Vulnerability details
         Given User visits Vulnerability details Page of "<vulnerabilityID>"
         Then Tab "Advisories" is visible
         Then The page title is "<vulnerabilityID>"
-
         Then User navigates to the Related Advisories tab on the Vulnerability Overview page
         Then Pagination of "Advisory" table works
         Then A list of all active Advisories tied to the Vulnerability should display
         And The "ID, Title, Type, Revision, Vulnerabilities" information should be visible for each advisory
         And The advisories should be sorted by "<columnName>"
         Then User searches for "<advisoryID>"
-        Then User visits Advisory details Page of "<advisoryID>" with type "<advisoryType>"
+        And User navigates to Advisory details Page of "<advisoryID>" with type "<advisoryType>"
         Then The page title is "<advisoryID>"
 
         Examples:

--- a/e2e/tests/ui/features/@vulnerability-explorer/vulnerability-explorer.step.ts
+++ b/e2e/tests/ui/features/@vulnerability-explorer/vulnerability-explorer.step.ts
@@ -1,26 +1,33 @@
 import { createBdd } from "playwright-bdd";
-import { ToolbarTable } from "../../helpers/ToolbarTable";
-import { SearchPage } from "../../helpers/SearchPage";
-import { expect } from "@playwright/test";
+
 import { test } from "../../fixtures";
 
-export const { Given, When, Then } = createBdd(test);
+import { expect } from "../../assertions";
+
+import { SearchPage } from "../../helpers/SearchPage";
+import { ToolbarTable } from "../../helpers/ToolbarTable";
+
+import { VulnerabilityDetailsPage } from "../../pages/vulnerability-details/VulnerabilityDetailsPage";
+import { VulnerabilityListPage } from "../../pages/vulnerability-list/VulnerabilityListPage";
+import { AdvisoriesTab } from "../../pages/vulnerability-details/advisories/AdvisoriesTab";
+import { SbomsTab } from "../../pages/vulnerability-details/sboms/SbomsTab";
 
 const SBOM_TABLE_NAME = "Sbom table";
 const ADVISORY_TABLE_NAME = "Advisory table";
 
+export const { Given, When, Then } = createBdd(test);
+
+// Shared step - navigates to vulnerability details page
 Given(
   "User visits Vulnerability details Page of {string}",
-  async ({ page }, vulnerabilityID) => {
-    const searchPage = new SearchPage(page, "Vulnerabilities");
-    await searchPage.dedicatedSearch(vulnerabilityID);
-    await page.getByRole("link", { name: vulnerabilityID }).click();
+  async ({ page }, vulnerabilityID: string) => {
+    await VulnerabilityDetailsPage.build(page, vulnerabilityID);
   },
 );
 
 // Vulnerability Search
 When(
-  "User searches for {string} in the general search bar",
+  "User searches for a vulnerability named {string} in the general search bar",
   async ({ page }, item) => {
     const searchPage = new SearchPage(page, "Dashboard");
     await searchPage.generalSearch("Vulnerabilities", item);
@@ -28,10 +35,11 @@ When(
 );
 
 When(
-  "User searches for {string} in the dedicated search bar",
+  "User searches for a vulnerability {string} in the dedicated search bar",
   async ({ page }, vulnerabilityID) => {
-    const searchPage = new SearchPage(page, "Vulnerabilities");
-    await searchPage.dedicatedSearch(vulnerabilityID);
+    const listPage = await VulnerabilityListPage.build(page);
+    const toolbar = await listPage.getToolbar();
+    await toolbar.applyFilter({ "Filter text": vulnerabilityID });
   },
 );
 
@@ -82,8 +90,10 @@ Then(
 // SBOMS
 
 Then("The SBOMs table is sorted by {string}", async ({ page }, columnName) => {
-  const toolbarTable = new ToolbarTable(page, SBOM_TABLE_NAME);
-  await toolbarTable.verifyTableIsSortedBy(columnName);
+  const sbomsTab = await SbomsTab.fromCurrentPage(page);
+  const table = await sbomsTab.getTable();
+  const columnHeader = await table.getColumnHeader(columnName);
+  await expect(columnHeader).toHaveAttribute("aria-sort", "ascending");
 });
 
 Then(
@@ -107,8 +117,9 @@ Then(
 Then(
   "The {string} column of the SBOM table contains {string}",
   async ({ page }, columnName, expectedValue) => {
-    const toolbarTable = new ToolbarTable(page, SBOM_TABLE_NAME);
-    await toolbarTable.verifyColumnContainsText(columnName, expectedValue);
+    const sbomsTab = await SbomsTab.fromCurrentPage(page);
+    const table = await sbomsTab.getTable();
+    await expect(table).toHaveColumnWithValue(columnName, expectedValue);
   },
 );
 
@@ -116,7 +127,8 @@ Then(
 Then(
   "User navigates to the Related Advisories tab on the Vulnerability Overview page",
   async ({ page }) => {
-    await page.getByRole("tab", { name: "Advisories" }).click();
+    const detailsPage = await VulnerabilityDetailsPage.fromCurrentPage(page);
+    await detailsPage._layout.selectTab("Advisories");
   },
 );
 
@@ -136,12 +148,8 @@ Then(
       .map((column: string) => column.trim());
 
     for (const header of headers) {
-      const headerElement = page.getByRole("columnheader", { name: header });
-      if (await headerElement.count()) {
-        await expect(headerElement).toBeVisible();
-      } else {
-        await expect(page.getByRole("button", { name: header })).toBeVisible();
-      }
+      const columnHeader = page.getByRole("columnheader", { name: header });
+      await expect(columnHeader).toBeVisible();
     }
   },
 );
@@ -149,20 +157,29 @@ Then(
 Then(
   "The advisories should be sorted by {string}",
   async ({ page }, columnName) => {
-    const toolbarTable = new ToolbarTable(page, ADVISORY_TABLE_NAME);
-    await toolbarTable.verifyTableIsSortedBy(columnName);
+    const advisoriesTab = await AdvisoriesTab.fromCurrentPage(page);
+    const table = await advisoriesTab.getTable();
+    const columnHeader = await table.getColumnHeader(columnName);
+    await expect(columnHeader).toHaveAttribute("aria-sort", "ascending");
   },
 );
 
 Then("User searches for {string}", async ({ page }, advisoryID) => {
-  const searchPage = new ToolbarTable(page, ADVISORY_TABLE_NAME);
-  await searchPage.filterByText(advisoryID);
+  const advisoriesTab = await AdvisoriesTab.fromCurrentPage(page);
+  const toolbar = await advisoriesTab.getToolbar();
+  await toolbar.applyFilter({ "Filter text": advisoryID });
 });
 
+// Navigate to advisory details with type filter
 Then(
-  "User visits Advisory details Page of {string} with type {string}",
+  "User navigates to Advisory details Page of {string} with type {string}",
   async ({ page }, advisoryID, advisoryType) => {
-    const advisory = `xpath=//tr[contains(.,'${advisoryID}') and contains(.,'${advisoryType}')]/td/a`;
-    await page.locator(advisory).click();
+    const table = await AdvisoriesTab.fromCurrentPage(page);
+    const tableObj = await table.getTable();
+    const rows = await tableObj.getRowsByCellValue({
+      ID: advisoryID,
+      Type: advisoryType,
+    });
+    await rows.getByRole("link", { name: advisoryID, exact: true }).click();
   },
 );

--- a/e2e/tests/ui/pages/vulnerability-list/VulnerabilityListPage.ts
+++ b/e2e/tests/ui/pages/vulnerability-list/VulnerabilityListPage.ts
@@ -1,4 +1,7 @@
 import type { Page } from "@playwright/test";
+
+import { expect } from "../../assertions";
+
 import { Navigation } from "../Navigation";
 import { Pagination } from "../Pagination";
 import { Table } from "../Table";
@@ -14,6 +17,19 @@ export class VulnerabilityListPage {
   static async build(page: Page) {
     const navigation = await Navigation.build(page);
     await navigation.goToSidebar("Vulnerabilities");
+
+    return new VulnerabilityListPage(page);
+  }
+
+  /**
+   * Build the page object from the current page state WITHOUT navigating.
+   * Use when already on the Vulnerability List page.
+   */
+  static async fromCurrentPage(page: Page) {
+    // Verify we're on the vulnerability list page by checking for the page heading
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Vulnerabilities" }),
+    ).toBeVisible();
 
     return new VulnerabilityListPage(page);
   }

--- a/e2e/tests/ui/steps/auth.ts
+++ b/e2e/tests/ui/steps/auth.ts
@@ -1,7 +1,10 @@
 import { createBdd } from "playwright-bdd";
+
+import { test } from "../fixtures";
+
 import { login } from "../helpers/Auth";
 
-export const { Given, When, Then } = createBdd();
+export const { Given, When, Then } = createBdd(test);
 
 Given("User is authenticated", async ({ page }) => {
   await login(page);

--- a/e2e/tests/ui/steps/details-page.ts
+++ b/e2e/tests/ui/steps/details-page.ts
@@ -1,8 +1,12 @@
 import { createBdd } from "playwright-bdd";
-import { DetailsPage } from "../helpers/DetailsPage";
-import { expect } from "@playwright/test";
 
-export const { Given, When, Then } = createBdd();
+import { test } from "../fixtures";
+
+import { expect } from "../assertions";
+
+import { DetailsPage } from "../helpers/DetailsPage";
+
+export const { Given, When, Then } = createBdd(test);
 
 Then("The page title is {string}", async ({ page }, title) => {
   const pageWithTabs = new DetailsPage(page);
@@ -68,3 +72,11 @@ When("User clicks the {string} button", async ({ page }, buttonName) => {
   const detailsPage = new DetailsPage(page);
   await detailsPage.clickOnPageButton(buttonName);
 });
+
+When(
+  "User Clicks on Actions button and Selects Delete option from the drop down",
+  async ({ page }) => {
+    const detailsPage = new DetailsPage(page);
+    await detailsPage.clickOnPageAction("Delete");
+  },
+);

--- a/e2e/tests/ui/steps/list-page.ts
+++ b/e2e/tests/ui/steps/list-page.ts
@@ -1,8 +1,12 @@
 import { createBdd } from "playwright-bdd";
-import { SbomListPage } from "../pages/sbom-list/SbomListPage";
+
+import { test } from "../fixtures";
+
 import { expect } from "../assertions";
 
-export const { Given, When, Then } = createBdd();
+import { SbomListPage } from "../pages/sbom-list/SbomListPage";
+
+export const { Given, When, Then } = createBdd(test);
 
 Given("An ingested SBOM {string} is available", async ({ page }, sbomName) => {
   const sbomListPage = await SbomListPage.build(page);

--- a/e2e/tests/ui/steps/table.ts
+++ b/e2e/tests/ui/steps/table.ts
@@ -1,27 +1,36 @@
 import { createBdd } from "playwright-bdd";
+
+import { test } from "../fixtures";
+
 import { ToolbarTable } from "../helpers/ToolbarTable";
 
-export const { Given, When, Then } = createBdd();
+export const { Given, When, Then } = createBdd(test);
 
 When("User clear all filters", async ({ page }) => {
   await page.getByText("Clear all filters").click();
 });
 
-Then("Pagination of {string} table works", async ({ page }, table: string) => {
-  const tableLowerCase = table.charAt(0).toLowerCase() + table.slice(1);
-  const toolbarTable = new ToolbarTable(page, `${table} table`);
-  const vulnTableTopPagination = `xpath=//div[@id="${tableLowerCase}-table-pagination-top"]`;
-  await toolbarTable.verifyPagination(vulnTableTopPagination);
-});
-
+// Generic step for verifying pagination on any table
 Then(
-  "Sorting of {string} Columns Works",
-  async ({ page }, columnHeaders: string) => {
+  "Pagination of {string} table works",
+  async ({ page }, tableName: string) => {
+    const tableNameLowerCase = tableName.toLowerCase();
+    const toolbarTable = new ToolbarTable(page, `${tableName} table`);
+    const tableTopPagination = `xpath=//div[@id="${tableNameLowerCase}-table-pagination-top"]`;
+    await toolbarTable.verifyPagination(tableTopPagination);
+  },
+);
+
+// Generic step for verifying sorting on any table
+Then(
+  "Sorting of {string} table for {string} columns works",
+  async ({ page }, tableName: string, columnHeaders: string) => {
+    const tableNameLowerCase = tableName.toLowerCase();
     const headers = columnHeaders
       .split(`,`)
       .map((column: string) => column.trim());
-    const toolbarTable = new ToolbarTable(page, "Vulnerability table");
-    const vulnTableTopPagination = `xpath=//div[@id="vulnerability-table-pagination-top"]`;
-    await toolbarTable.verifySorting(vulnTableTopPagination, headers);
+    const toolbarTable = new ToolbarTable(page, `${tableName} table`);
+    const tableTopPagination = `xpath=//div[@id="${tableNameLowerCase}-table-pagination-top"]`;
+    await toolbarTable.verifySorting(tableTopPagination, headers);
   },
 );


### PR DESCRIPTION
Optimized existing tests and step definitions based on the rules and standards defined under `.claude/shared` directory with the help of AI assistant.

JIRA: TC-3470

## Summary by Sourcery

Align SBOM, advisory, and vulnerability E2E tests and shared step definitions with common Playwright-BDD patterns and page objects, improving readability, reusability, and table interaction coverage.

Enhancements:
- Refine SBOM Explorer, SBOM Scan, Advisory Explorer, Vulnerability Explorer, and SBOM Search step definitions to consistently use typed parameters, shared steps, and higher-level page objects instead of raw locators.
- Generalize pagination and sorting step definitions to work with any table by name, reducing duplication across scenarios.
- Update vulnerability, advisory, and SBOM list search steps to use dedicated list page toolbars and filters rather than direct XPath or SearchPage access.
- Improve tooltip, dialog, and nested table assertions to rely on semantic roles and page objects, reducing flaky timeout-based waits and direct XPath usage.
- Centralize the delete-from-details-page action into a reusable step and remove feature-specific duplicates.
- Add a fromCurrentPage constructor to VulnerabilityListPage for reuse when already on the list view.
- Normalize and re-indent multiple feature files (SBOM scan, explorer, advisory, vulnerability, and search) for consistent Background/Scenario structure and Scenario Outline examples formatting.

Tests:
- Adjust existing Gherkin feature files and step bindings to better match shared wording, table names, and reusable generic steps without changing test intent or coverage.