### PR TITLE
chore(claude): add github skill

### DIFF
--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -4,11 +4,12 @@ description: Create and manage GitHub issues, pull requests, and interact with r
 argument-hint: [ message ]
 disable-model-invocation: true
 allowed-tools:
-    - Bash(gh issue create *)                                                                                                                                                                                                                                                             
-    - Bash(gh issue list *)                                                                                                                                                                                                                                                               
-    - Bash(gh pr create *)                                                                                                                                                                                                                                                                
-    - Bash(gh pr view *)                                                                                                                                                                                                                                                                  
-    - Bash(gh pr comment *)      
+  - Bash(gh issue view *)
+  - Bash(gh issue create *)
+  - Bash(gh issue list *)
+  - Bash(gh pr view *)
+  - Bash(gh pr create *)
+  - Bash(gh pr comment *)
 ---
 
 # GitHub Assistant


### PR DESCRIPTION
See Skills documentation at https://code.claude.com/docs/en/skills

This PR introduces a Claude Code SKILL named "github"

Comes handy if you want to interact with github issues, pull requests, commits, etc. 

The skill is disabled by default and can be invoked with:
```
/github message to claude code
```

## Summary by Sourcery

Add a new Claude Code skill for interacting with GitHub via the GitHub CLI, including guidance for concise communication, PR TODO comments, git workflows, and result verification.

New Features:
- Introduce a configurable 'github' Claude Code skill for creating and managing GitHub issues, pull requests, labels, and CI-related interactions via the GitHub CLI.

Enhancements:
- Define conventions for concise GitHub communication, PR checkbox TODO comments, conventional commit messages, branch naming, and safety checks before committing to main within the new skill.