### PR TITLE
fix: Opening link for Packager or SBOMs related to Licenses in new window ignores the filter

### DIFF
--- a/client/src/app/components/OidcProvider.tsx
+++ b/client/src/app/components/OidcProvider.tsx
@@ -38,7 +38,7 @@ export const OidcProvider: React.FC<IOidcProviderProps> = ({ children }) => {
 
         AppRoutes.navigate(
           { pathname, search: search ? `?${search}` : "" },
-          { replace: true }
+          { replace: true },
         );
       }}
     >


### PR DESCRIPTION
This pr is trying to resolve this issue: https://issues.redhat.com/browse/TC-3294

The main problem was that whenever we open any url of tpa application in a new tab, in moment of initialization of an app inside OidcProvider any search params were ignored and cleared. Even when you tried to open something simple like `http://localhost:3000?test=123` it ended up looking like this `http://localhost:3000/`. 

So i added search params inside navigation inside OidcProvider.

I am not sure it this was made by accident and it is a bug or it is something that was made like this for reason but i couldn't find any possible pitfalls.

## Summary by Sourcery

Bug Fixes:
- Fix loss of URL query parameters when opening application links in a new tab and returning from OIDC authentication.