### PR TITLE
tests: add not-found page tests

### DIFF
--- a/e2e/tests/ui/pages/not-found/not-found.spec.ts
+++ b/e2e/tests/ui/pages/not-found/not-found.spec.ts
@@ -1,0 +1,49 @@
+// @ts-check
+
+import { expect } from "@playwright/test";
+
+import { test } from "../../fixtures";
+import { login } from "../../helpers/Auth";
+
+const NON_EXISTENT_UUID = "urn:uuid:00000000-0000-0000-0000-000000000000";
+
+const expectNotFound = async (page: import("@playwright/test").Page) => {
+  await expect(
+    page.getByRole("heading", { name: "404: That page does not exist" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Another page might have the information you need."),
+  ).toBeVisible();
+};
+
+test.describe("Not Found page", { tag: "@tier1" }, () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("Shows 404 page for undefined route", async ({ page }) => {
+    await page.goto("/this-page-does-not-exist");
+    await expectNotFound(page);
+  });
+
+  test("Shows 404 page for non-existent advisory", async ({ page }) => {
+    await page.goto(`/advisories/${NON_EXISTENT_UUID}`);
+    await expectNotFound(page);
+  });
+
+  test("Shows 404 page for non-existent SBOM", async ({ page }) => {
+    await page.goto(`/sboms/${NON_EXISTENT_UUID}`);
+    await expectNotFound(page);
+  });
+
+  test("Shows 404 page for non-existent vulnerability", async ({ page }) => {
+    await page.goto("/vulnerabilities/CVE-0000-00000");
+    await expectNotFound(page);
+  });
+
+  // Enable this test when https://issues.redhat.com/browse/TC-3626 is fixed
+  test.skip("Shows 404 page for non-existent package", async ({ page }) => {
+    await page.goto(`/packages/${NON_EXISTENT_UUID}`);
+    await expectNotFound(page);
+  });
+});


### PR DESCRIPTION
In case there are resources non existent or a page not defined in the UI the NotFound Page should be rendered. This PR should cover that scenario

One test is disable on purpose because the rest api for packages does not generate 404 NotFound HTTP response as reported here https://issues.redhat.com/browse/TC-3626

<img width="1884" height="729" alt="image" src="https://github.com/user-attachments/assets/b3a772c9-50c7-4ad6-8544-77fd76495cbd" />

## Summary by Sourcery

Add end-to-end coverage for the UI 404 Not Found page across undefined and non-existent resource routes.

Tests:
- Add Playwright E2E tests verifying the Not Found page renders for undefined routes and non-existent advisories, SBOMs, and vulnerabilities.
- Introduce a skipped test documenting the expected 404 behavior for non-existent packages pending backend support.