### PR TITLE
feat(download): add error notifications when document downloads fail

### DIFF
--- a/client/src/app/hooks/domain-controls/useDownload.test.ts
+++ b/client/src/app/hooks/domain-controls/useDownload.test.ts
@@ -1,0 +1,177 @@
+import { act, renderHook } from "@testing-library/react";
+import { AxiosError, AxiosHeaders } from "axios";
+import { saveAs } from "file-saver";
+
+import { downloadSbomLicense } from "@app/api/rest";
+import { downloadAdvisory, downloadSbom } from "@app/client";
+import { getAxiosErrorMessage } from "@app/utils/utils";
+
+import { useDownload } from "./useDownload";
+
+jest.mock("file-saver", () => ({ saveAs: jest.fn() }));
+jest.mock("@app/api/rest", () => ({ downloadSbomLicense: jest.fn() }));
+jest.mock("@app/client", () => ({
+  downloadAdvisory: jest.fn(),
+  downloadSbom: jest.fn(),
+}));
+jest.mock("@app/utils/utils", () => ({
+  getAxiosErrorMessage: jest.fn((err: AxiosError) => err.message),
+  getFilenameFromContentDisposition: jest.fn(() => "license.tar.gz"),
+}));
+
+const pushNotification = jest.fn();
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useContext: () => ({ pushNotification }),
+}));
+
+const createAxiosError = (message: string): AxiosError =>
+  new AxiosError(message, "ERR_BAD_REQUEST", undefined, undefined, {
+    status: 500,
+    statusText: "Internal Server Error",
+    data: {},
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  });
+
+/** Flushes the microtask queue so fire-and-forget promise chains settle before assertions. */
+const flushPromises = () => act(() => new Promise((r) => setTimeout(r, 0)));
+
+describe("useDownload", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /** Verifies that pushNotification is called with variant "danger" when downloadAdvisory rejects. */
+  it("should notify with danger variant when downloadAdvisory fails", async () => {
+    // Given a failing advisory download
+    const error = createAxiosError("advisory download failed");
+    (downloadAdvisory as jest.Mock).mockRejectedValue(error);
+
+    // When triggering the download
+    const { result } = renderHook(() => useDownload());
+    result.current.downloadAdvisory("adv-1");
+    await flushPromises();
+
+    // Then a danger notification is pushed
+    expect(pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Failed to download advisory",
+        variant: "danger",
+      }),
+    );
+  });
+
+  /** Verifies that pushNotification is called with variant "danger" when downloadSbom rejects. */
+  it("should notify with danger variant when downloadSbom fails", async () => {
+    // Given a failing SBOM download
+    const error = createAxiosError("sbom download failed");
+    (downloadSbom as jest.Mock).mockRejectedValue(error);
+
+    // When triggering the download
+    const { result } = renderHook(() => useDownload());
+    result.current.downloadSBOM("sbom-1");
+    await flushPromises();
+
+    // Then a danger notification is pushed
+    expect(pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Failed to download SBOM",
+        variant: "danger",
+      }),
+    );
+  });
+
+  /** Verifies that pushNotification is called with variant "danger" when downloadSbomLicense rejects. */
+  it("should notify with danger variant when downloadSbomLicense fails", async () => {
+    // Given a failing SBOM license download
+    const error = createAxiosError("license download failed");
+    (downloadSbomLicense as jest.Mock).mockRejectedValue(error);
+
+    // When triggering the download
+    const { result } = renderHook(() => useDownload());
+    result.current.downloadSBOMLicenses("sbom-1");
+    await flushPromises();
+
+    // Then a danger notification is pushed
+    expect(pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Failed to download SBOM licenses",
+        variant: "danger",
+      }),
+    );
+  });
+
+  /** Verifies that getAxiosErrorMessage is used to extract the error message for the notification. */
+  it("should use getAxiosErrorMessage to extract the error message", async () => {
+    // Given a failing advisory download
+    const error = createAxiosError("raw error");
+    (downloadAdvisory as jest.Mock).mockRejectedValue(error);
+
+    // When triggering the download
+    const { result } = renderHook(() => useDownload());
+    result.current.downloadAdvisory("adv-1");
+    await flushPromises();
+
+    // Then getAxiosErrorMessage is called with the error and its result is used as the message
+    expect(getAxiosErrorMessage).toHaveBeenCalledWith(error);
+    expect(pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "raw error",
+      }),
+    );
+  });
+
+  /** Verifies that the success path still calls saveAs with the expected blob for advisory download. */
+  it("should call saveAs on successful advisory download", async () => {
+    // Given a successful advisory download
+    const data = new ArrayBuffer(8);
+    (downloadAdvisory as jest.Mock).mockResolvedValue({ data });
+
+    // When triggering the download
+    const { result } = renderHook(() => useDownload());
+    result.current.downloadAdvisory("adv-1", "advisory.json");
+    await flushPromises();
+
+    // Then saveAs is called and no notification is pushed
+    expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), "advisory.json");
+    expect(pushNotification).not.toHaveBeenCalled();
+  });
+
+  /** Verifies that the success path still calls saveAs with the expected blob for SBOM download. */
+  it("should call saveAs on successful SBOM download", async () => {
+    // Given a successful SBOM download
+    const data = new ArrayBuffer(8);
+    (downloadSbom as jest.Mock).mockResolvedValue({ data });
+
+    // When triggering the download
+    const { result } = renderHook(() => useDownload());
+    result.current.downloadSBOM("sbom-1", "sbom.json");
+    await flushPromises();
+
+    // Then saveAs is called and no notification is pushed
+    expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), "sbom.json");
+    expect(pushNotification).not.toHaveBeenCalled();
+  });
+
+  /** Verifies that the success path still calls saveAs with the expected blob for SBOM license download. */
+  it("should call saveAs on successful SBOM license download", async () => {
+    // Given a successful SBOM license download
+    const data = new ArrayBuffer(8);
+    (downloadSbomLicense as jest.Mock).mockResolvedValue({
+      data,
+      headers: {
+        "content-disposition": 'attachment; filename="license.tar.gz"',
+      },
+    });
+
+    // When triggering the download
+    const { result } = renderHook(() => useDownload());
+    result.current.downloadSBOMLicenses("sbom-1");
+    await flushPromises();
+
+    // Then saveAs is called and no notification is pushed
+    expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), "license.tar.gz");
+    expect(pushNotification).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/app/hooks/domain-controls/useDownload.ts
+++ b/client/src/app/hooks/domain-controls/useDownload.ts
@@ -1,20 +1,42 @@
+import React from "react";
+
 import { saveAs } from "file-saver";
 
 import { downloadSbomLicense } from "@app/api/rest";
 import { client } from "@app/axios-config/apiInit";
 import { downloadAdvisory, downloadSbom } from "@app/client";
-import { getFilenameFromContentDisposition } from "@app/utils/utils";
+import { NotificationsContext } from "@app/components/NotificationsContext";
+import {
+  getAxiosErrorMessage,
+  getFilenameFromContentDisposition,
+} from "@app/utils/utils";
 
+/** Hook providing download functions for advisories, SBOMs, and SBOM licenses with error notifications. */
 export const useDownload = () => {
+  const { pushNotification } = React.useContext(NotificationsContext);
+
+  /** Pushes a danger toast notification with the given title and the error message extracted from the error. */
+  const notifyDownloadError = (title: string, error: unknown) => {
+    pushNotification({
+      title,
+      variant: "danger",
+      message: getAxiosErrorMessage(error),
+    });
+  };
+
   const onDownloadAdvisory = (id: string, filename?: string) => {
     downloadAdvisory({
       client,
       path: { key: id },
       responseType: "arraybuffer",
       headers: { Accept: "text/plain", responseType: "blob" },
-    }).then((response) => {
-      saveAs(new Blob([response.data as BlobPart]), filename || `${id}.json`);
-    });
+    })
+      .then((response) => {
+        saveAs(new Blob([response.data as BlobPart]), filename || `${id}.json`);
+      })
+      .catch((error) =>
+        notifyDownloadError("Failed to download advisory", error),
+      );
   };
 
   const onDownloadSBOM = (id: string, filename?: string) => {
@@ -23,22 +45,31 @@ export const useDownload = () => {
       path: { key: id },
       responseType: "arraybuffer",
       headers: { Accept: "text/plain", responseType: "blob" },
-    }).then((response) => {
-      saveAs(new Blob([response.data as BlobPart]), filename || `${id}.json`);
-    });
+    })
+      .then((response) => {
+        saveAs(new Blob([response.data as BlobPart]), filename || `${id}.json`);
+      })
+      .catch((error) => notifyDownloadError("Failed to download SBOM", error));
   };
 
   const onDownloadSBOMLicenses = (id: string) => {
-    downloadSbomLicense(id).then((response) => {
-      let filename: string | null = null;
+    downloadSbomLicense(id)
+      .then((response) => {
+        let filename: string | null = null;
 
-      const header = response.headers?.["content-disposition"]?.toString();
-      if (header) {
-        filename = getFilenameFromContentDisposition(header);
-      }
+        const header = response.headers?.["content-disposition"]?.toString();
+        if (header) {
+          filename = getFilenameFromContentDisposition(header);
+        }
 
-      saveAs(new Blob([response.data as BlobPart]), filename || `${id}.tar.gz`);
-    });
+        saveAs(
+          new Blob([response.data as BlobPart]),
+          filename || `${id}.tar.gz`,
+        );
+      })
+      .catch((error) =>
+        notifyDownloadError("Failed to download SBOM licenses", error),
+      );
   };
 
   return {

--- a/client/src/app/hooks/domain-controls/useDownload.ts
+++ b/client/src/app/hooks/domain-controls/useDownload.ts
@@ -6,6 +6,8 @@ import { downloadSbomLicense } from "@app/api/rest";
 import { client } from "@app/axios-config/apiInit";
 import { downloadAdvisory, downloadSbom } from "@app/client";
 import { NotificationsContext } from "@app/components/NotificationsContext";
+import type { AxiosError } from "axios";
+
 import {
   getAxiosErrorMessage,
   getFilenameFromContentDisposition,
@@ -16,7 +18,7 @@ export const useDownload = () => {
   const { pushNotification } = React.useContext(NotificationsContext);
 
   /** Pushes a danger toast notification with the given title and the error message extracted from the error. */
-  const notifyDownloadError = (title: string, error: unknown) => {
+  const notifyDownloadError = (title: string, error: AxiosError) => {
     pushNotification({
       title,
       variant: "danger",


### PR DESCRIPTION
## Summary

* Add `.catch()` error handlers to all three download functions in the `useDownload` hook (advisory, SBOM, SBOM licenses)
* Display "danger" toast notifications with descriptive titles and server error messages extracted via `getAxiosErrorMessage`
* Add 7 unit tests covering error notification and success path behavior

Implements [TC-4045](https://redhat.atlassian.net/browse/TC-4045)

## Test plan

- [x] Unit test: `pushNotification` called with `variant: "danger"` when `downloadAdvisory` rejects
- [x] Unit test: `pushNotification` called with `variant: "danger"` when `downloadSbom` rejects
- [x] Unit test: `pushNotification` called with `variant: "danger"` when `downloadSbomLicense` rejects
- [x] Unit test: `getAxiosErrorMessage` used to extract the error message
- [x] Unit test: success path still calls `saveAs` for advisory, SBOM, and SBOM license downloads
- [x] `npm run check` passes (biome lint/format)
- [x] `npm test` passes (all 9 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4045]: https://redhat.atlassian.net/browse/TC-4045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add error-handling and user notifications to document download hooks while verifying behavior with new unit tests.

New Features:
- Show danger toast notifications when advisory, SBOM, or SBOM license downloads fail, including server error messages extracted via getAxiosErrorMessage.

Tests:
- Add unit tests covering error notification behavior on download failures and ensuring successful downloads still trigger file saves without notifications.