### PR TITLE
fix: align ui to new severity rest models

### DIFF
--- a/client/openapi/trustd.yaml
+++ b/client/openapi/trustd.yaml
@@ -25,95 +25,6 @@ paths:
                   version:
                     type: string
   /api/v2/advisory:
-    get:
-      tags:
-      - advisory
-      summary: List advisories
-      operationId: listAdvisories
-      parameters:
-      - name: q
-        in: query
-        description: |
-          Query for advisories defined using the following EBNF grammar (ISO/IEC 14977):
-          ```text
-          (* Query Grammar - EBNF Compliant *)
-          query = ( values | filter ) , { "&" , query } ;
-          values = value , { "|" , value } ;
-          filter = field , operator , values ;
-          operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<" ;
-          field = ("id" | "identifier" | "version" | "document_id" | "deprecated" | "issuer_id" | "published" | "modified" | "withdrawn" | "title" | "ingested" | "label")
-          value = { value_char } ;
-          value_char = escaped_char | normal_char ;
-          escaped_char = "\" , special_char ;
-          normal_char = ? any character except '&', '|', '=', '!', '~', '>', '<', '\' ? ;
-          special_char = "&" | "|" | "=" | "!" | "~" | ">" | "<" | "\" ;
-          ```
-          Examples:
-          - Simple filter: title=example
-          - Multiple values filter: title=foo|bar|baz
-          - Complex filter: modified>2024-01-01
-          - Combined query: title=foo&average_severity=high
-          - Escaped characters: title=foo\\&bar
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        description: |-
-          EBNF grammar for the _sort_ parameter:
-          ```text
-              sort = field [ ':', order ] { ',' sort }
-              order = ( "asc" | "desc" )
-              field = ("id" | "identifier" | "version" | "document_id" | "deprecated" | "issuer_id" | "published" | "modified" | "withdrawn" | "title" | "ingested" | "label")
-          ```
-          The optional _order_ should be one of "asc" or "desc". If
-          omitted, the order defaults to "asc".
-
-          Each _field_ name must correspond to one of the columns of the
-          table holding the entities being queried. Those corresponding
-          to JSON objects in the database may use a ':' to delimit the
-          column name and the object key,
-          e.g. `purl:qualifiers:type:desc`
-        required: false
-        schema:
-          type: string
-      - name: offset
-        in: query
-        description: |-
-          The first item to return, skipping all that come before it.
-
-          NOTE: The order of items is defined by the API being called.
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: limit
-        in: query
-        description: |-
-          The maximum number of entries to return.
-
-          Zero means: no limit
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: deprecated
-        in: query
-        required: false
-        schema:
-          type: string
-          enum:
-          - Ignore
-          - Consider
-      responses:
-        '200':
-          description: Matching vulnerabilities
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedResults_AdvisorySummary'
     post:
       tags:
       - advisory
@@ -242,26 +153,6 @@ paths:
         '404':
           description: The advisory could not be found
   /api/v2/advisory/{key}:
-    get:
-      tags:
-      - advisory
-      summary: Get an advisory
-      operationId: getAdvisory
-      parameters:
-      - name: key
-        in: path
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
-      responses:
-        '200':
-          description: Matching advisory
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AdvisoryDetails'
-        '404':
-          description: The advisory could not be found
     delete:
       tags:
       - advisory
@@ -2286,34 +2177,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RecommendResponse'
-  /api/v2/purl/{key}:
-    get:
-      tags:
-      - purl
-      summary: Retrieve details of a fully-qualified pURL
-      operationId: getPurl
-      parameters:
-      - name: deprecated
-        in: query
-        required: false
-        schema:
-          type: string
-          enum:
-          - Ignore
-          - Consider
-      - name: key
-        in: path
-        description: opaque identifier for a fully-qualified PURL, or URL-encoded pURL itself
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Details for the qualified PURL
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PurlDetails'
   /api/v2/sbom:
     get:
       tags:
@@ -2744,29 +2607,6 @@ paths:
       responses:
         '204':
           description: Matching SBOM as deleted
-        '404':
-          description: The SBOM could not be found
-  /api/v2/sbom/{id}/advisory:
-    get:
-      tags:
-      - sbom
-      summary: Get advisories for an SBOM
-      operationId: getSbomAdvisories
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          $ref: '#/components/schemas/Id'
-      responses:
-        '200':
-          description: Matching SBOM
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/SbomAdvisory'
         '404':
           description: The SBOM could not be found
   /api/v2/sbom/{id}/all-license-ids:
@@ -3388,88 +3228,6 @@ paths:
           description: User preferences are deleted
         '412':
           description: The provided If-Match revision did not match the actual revision
-  /api/v2/vulnerability:
-    get:
-      tags:
-      - vulnerability
-      summary: List vulnerabilities
-      operationId: listVulnerabilities
-      parameters:
-      - name: q
-        in: query
-        description: |
-          Query for advisories defined using the following EBNF grammar (ISO/IEC 14977):
-          ```text
-          (* Query Grammar - EBNF Compliant *)
-          query = ( values | filter ) , { "&" , query } ;
-          values = value , { "|" , value } ;
-          filter = field , operator , values ;
-          operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<" ;
-          field = ("id" | "title" | "reserved" | "published" | "modified" | "withdrawn" | "cwes" | "base_score" | "base_severity")
-          value = { value_char } ;
-          value_char = escaped_char | normal_char ;
-          escaped_char = "\" , special_char ;
-          normal_char = ? any character except '&', '|', '=', '!', '~', '>', '<', '\' ? ;
-          special_char = "&" | "|" | "=" | "!" | "~" | ">" | "<" | "\" ;
-          ```
-          Examples:
-          - Simple filter: title=example
-          - Multiple values filter: title=foo|bar|baz
-          - Complex filter: modified>2024-01-01
-          - Combined query: title=foo&average_severity=high
-          - Escaped characters: title=foo\\&bar
-        required: false
-        schema:
-          type: string
-      - name: sort
-        in: query
-        description: |-
-          EBNF grammar for the _sort_ parameter:
-          ```text
-              sort = field [ ':', order ] { ',' sort }
-              order = ( "asc" | "desc" )
-              field = ("id" | "title" | "reserved" | "published" | "modified" | "withdrawn" | "cwes" | "base_score" | "base_severity")
-          ```
-          The optional _order_ should be one of "asc" or "desc". If
-          omitted, the order defaults to "asc".
-
-          Each _field_ name must correspond to one of the columns of the
-          table holding the entities being queried. Those corresponding
-          to JSON objects in the database may use a ':' to delimit the
-          column name and the object key,
-          e.g. `purl:qualifiers:type:desc`
-        required: false
-        schema:
-          type: string
-      - name: offset
-        in: query
-        description: |-
-          The first item to return, skipping all that come before it.
-
-          NOTE: The order of items is defined by the API being called.
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      - name: limit
-        in: query
-        description: |-
-          The maximum number of entries to return.
-
-          Zero means: no limit
-        required: false
-        schema:
-          type: integer
-          format: int64
-          minimum: 0
-      responses:
-        '200':
-          description: Matching vulnerabilities
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedResults_VulnerabilitySummary'
   /api/v2/vulnerability/analyze:
     post:
       tags:
@@ -3489,28 +3247,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AnalysisResponse'
-  /api/v2/vulnerability/{id}:
-    get:
-      tags:
-      - vulnerability
-      summary: Retrieve vulnerability details
-      operationId: getVulnerability
-      parameters:
-      - name: id
-        in: path
-        description: ID of the vulnerability
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Specified vulnerability
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VulnerabilityDetails'
-        '404':
-          description: The vulnerability could not be found
   /api/v2/weakness:
     get:
       tags:
@@ -3642,6 +3378,145 @@ paths:
                 $ref: '#/components/schemas/LicenseSummary'
         '404':
           description: The weakness could not be found
+  /api/v3/advisory:
+    get:
+      tags:
+      - advisory
+      summary: List advisories
+      operationId: listAdvisories
+      parameters:
+      - name: q
+        in: query
+        description: |
+          Query for advisories defined using the following EBNF grammar (ISO/IEC 14977):
+          ```text
+          (* Query Grammar - EBNF Compliant *)
+          query = ( values | filter ) , { "&" , query } ;
+          values = value , { "|" , value } ;
+          filter = field , operator , values ;
+          operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<" ;
+          field = ("id" | "identifier" | "version" | "document_id" | "deprecated" | "issuer_id" | "published" | "modified" | "withdrawn" | "title" | "ingested" | "label")
+          value = { value_char } ;
+          value_char = escaped_char | normal_char ;
+          escaped_char = "\" , special_char ;
+          normal_char = ? any character except '&', '|', '=', '!', '~', '>', '<', '\' ? ;
+          special_char = "&" | "|" | "=" | "!" | "~" | ">" | "<" | "\" ;
+          ```
+          Examples:
+          - Simple filter: title=example
+          - Multiple values filter: title=foo|bar|baz
+          - Complex filter: modified>2024-01-01
+          - Combined query: title=foo&average_severity=high
+          - Escaped characters: title=foo\\&bar
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        description: |-
+          EBNF grammar for the _sort_ parameter:
+          ```text
+              sort = field [ ':', order ] { ',' sort }
+              order = ( "asc" | "desc" )
+              field = ("id" | "identifier" | "version" | "document_id" | "deprecated" | "issuer_id" | "published" | "modified" | "withdrawn" | "title" | "ingested" | "label")
+          ```
+          The optional _order_ should be one of "asc" or "desc". If
+          omitted, the order defaults to "asc".
+
+          Each _field_ name must correspond to one of the columns of the
+          table holding the entities being queried. Those corresponding
+          to JSON objects in the database may use a ':' to delimit the
+          column name and the object key,
+          e.g. `purl:qualifiers:type:desc`
+        required: false
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: |-
+          The first item to return, skipping all that come before it.
+
+          NOTE: The order of items is defined by the API being called.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: limit
+        in: query
+        description: |-
+          The maximum number of entries to return.
+
+          Zero means: no limit
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: deprecated
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - Ignore
+          - Consider
+      responses:
+        '200':
+          description: Matching vulnerabilities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResults_AdvisorySummary'
+  /api/v3/advisory/{key}:
+    get:
+      tags:
+      - advisory
+      summary: Get an advisory
+      operationId: getAdvisory
+      parameters:
+      - name: key
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: Matching advisory
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvisoryDetails'
+        '404':
+          description: The advisory could not be found
+  /api/v3/purl/{key}:
+    get:
+      tags:
+      - purl
+      summary: Retrieve details of a fully-qualified pURL
+      operationId: getPurl
+      parameters:
+      - name: deprecated
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - Ignore
+          - Consider
+      - name: key
+        in: path
+        description: opaque identifier for a fully-qualified PURL, or URL-encoded pURL itself
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Details for the qualified PURL
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PurlDetails'
   /api/v3/sbom:
     get:
       tags:
@@ -3762,6 +3637,111 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResults_SbomPackageSummary'
+  /api/v3/sbom/{id}/advisory:
+    get:
+      tags:
+      - sbom
+      summary: Get advisories for an SBOM
+      operationId: getSbomAdvisories
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: Matching SBOM
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SbomAdvisory'
+        '404':
+          description: The SBOM could not be found
+  /api/v3/vulnerability:
+    get:
+      tags:
+      - vulnerability
+      summary: List vulnerabilities
+      operationId: listVulnerabilities
+      parameters:
+      - name: q
+        in: query
+        description: |
+          Query for advisories defined using the following EBNF grammar (ISO/IEC 14977):
+          ```text
+          (* Query Grammar - EBNF Compliant *)
+          query = ( values | filter ) , { "&" , query } ;
+          values = value , { "|" , value } ;
+          filter = field , operator , values ;
+          operator = "=" | "!=" | "~" | "!~" | ">=" | ">" | "<=" | "<" ;
+          field = ("id" | "title" | "reserved" | "published" | "modified" | "withdrawn" | "cwes" | "base_score" | "base_severity")
+          value = { value_char } ;
+          value_char = escaped_char | normal_char ;
+          escaped_char = "\" , special_char ;
+          normal_char = ? any character except '&', '|', '=', '!', '~', '>', '<', '\' ? ;
+          special_char = "&" | "|" | "=" | "!" | "~" | ">" | "<" | "\" ;
+          ```
+          Examples:
+          - Simple filter: title=example
+          - Multiple values filter: title=foo|bar|baz
+          - Complex filter: modified>2024-01-01
+          - Combined query: title=foo&average_severity=high
+          - Escaped characters: title=foo\\&bar
+        required: false
+        schema:
+          type: string
+      - name: sort
+        in: query
+        description: |-
+          EBNF grammar for the _sort_ parameter:
+          ```text
+              sort = field [ ':', order ] { ',' sort }
+              order = ( "asc" | "desc" )
+              field = ("id" | "title" | "reserved" | "published" | "modified" | "withdrawn" | "cwes" | "base_score" | "base_severity")
+          ```
+          The optional _order_ should be one of "asc" or "desc". If
+          omitted, the order defaults to "asc".
+
+          Each _field_ name must correspond to one of the columns of the
+          table holding the entities being queried. Those corresponding
+          to JSON objects in the database may use a ':' to delimit the
+          column name and the object key,
+          e.g. `purl:qualifiers:type:desc`
+        required: false
+        schema:
+          type: string
+      - name: offset
+        in: query
+        description: |-
+          The first item to return, skipping all that come before it.
+
+          NOTE: The order of items is defined by the API being called.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      - name: limit
+        in: query
+        description: |-
+          The maximum number of entries to return.
+
+          Zero means: no limit
+        required: false
+        schema:
+          type: integer
+          format: int64
+          minimum: 0
+      responses:
+        '200':
+          description: Matching vulnerabilities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResults_VulnerabilitySummary'
   /api/v3/vulnerability/analyze:
     post:
       tags:
@@ -3780,6 +3760,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AnalysisResponseV3'
+  /api/v3/vulnerability/{id}:
+    get:
+      tags:
+      - vulnerability
+      summary: Retrieve vulnerability details
+      operationId: getVulnerability
+      parameters:
+      - name: id
+        in: path
+        description: ID of the vulnerability
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Specified vulnerability
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VulnerabilityDetails'
+        '404':
+          description: The vulnerability could not be found
 components:
   schemas:
     AdvisoryDetails:
@@ -3789,21 +3791,7 @@ components:
       - type: object
         required:
         - vulnerabilities
-        - average_severity
-        - average_score
         properties:
-          average_score:
-            type:
-            - number
-            - 'null'
-            format: double
-            description: Average (arithmetic mean) score of the advisory aggregated from *all* related vulnerability assertions.
-            deprecated: true
-          average_severity:
-            oneOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/Severity'
-              description: Average (arithmetic mean) severity of the advisory aggregated from *all* related vulnerability assertions.
           vulnerabilities:
             type: array
             items:
@@ -3870,23 +3858,8 @@ components:
         description: Information pertaning to the underlying source document, if any.
       - type: object
         required:
-        - average_severity
-        - average_score
         - vulnerabilities
         properties:
-          average_score:
-            type:
-            - number
-            - 'null'
-            format: double
-            description: Average (arithmetic mean) score of the advisory aggregated from *all* related vulnerability assertions.
-            deprecated: true
-          average_severity:
-            type:
-            - string
-            - 'null'
-            description: Average (arithmetic mean) severity of the advisory aggregated from *all* related vulnerability assertions.
-            deprecated: true
           vulnerabilities:
             type: array
             items:
@@ -3896,43 +3869,17 @@ components:
       allOf:
       - $ref: '#/components/schemas/VulnerabilityHead'
       - type: object
+        required:
+        - scores
         properties:
-          score:
-            type:
-            - number
-            - 'null'
-            format: double
-            description: |-
-              The average (arithmetic mean) score this advisory assigns to
-              the particular vulnerability.
-          severity:
-            oneOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/Severity'
-              description: |-
-                The English-language word description of the severity of the given
-                vulnerability, as asserted by the advisory, using the CVSS bucketing
-                ranges.
-
-                Critical: 9.0–10.0
-                High: 7.0–8.9
-                Medium: 4.0–6.9
-                Low: 0.1–3.9
-                None: 0
+          scores:
+            type: array
+            items:
+              $ref: '#/components/schemas/ScoredVector'
+            description: All CVSS scores with their raw vector strings from the advisory for this vulnerability.
     AdvisoryVulnerabilitySummary:
       allOf:
       - $ref: '#/components/schemas/AdvisoryVulnerabilityHead'
-      - type: object
-        required:
-        - cvss3_scores
-        properties:
-          cvss3_scores:
-            type: array
-            items:
-              type: string
-            description: |-
-              All CVSS3 scores from the advisory for the given vulnerability.
-              May include several, varying by minor version of the CVSS3 vector.
       description: Summary of information from this advisory regarding a single specific vulnerability.
     AnalysisAdvisory:
       allOf:
@@ -4108,6 +4055,26 @@ components:
     BasePurlSummary:
       allOf:
       - $ref: '#/components/schemas/BasePurlHead'
+    BaseScore:
+      type: object
+      description: |-
+        Base score information in the context of a [`VulnerabilityHead`]. Notably, this excludes the
+        raw CVSS vector string.
+
+        Uses the same `ScoreType` and `Severity` serialization as [`crate::common::model::Score`]
+        so that all score-related fields in API responses are consistent.
+      required:
+      - type
+      - severity
+      - score
+      properties:
+        score:
+          type: number
+          format: double
+        severity:
+          $ref: '#/components/schemas/Severity'
+        type:
+          $ref: '#/components/schemas/ScoreType'
     BaseSummary:
       type: object
       required:
@@ -4825,23 +4792,8 @@ components:
               description: Information pertaning to the underlying source document, if any.
             - type: object
               required:
-              - average_severity
-              - average_score
               - vulnerabilities
               properties:
-                average_score:
-                  type:
-                  - number
-                  - 'null'
-                  format: double
-                  description: Average (arithmetic mean) score of the advisory aggregated from *all* related vulnerability assertions.
-                  deprecated: true
-                average_severity:
-                  type:
-                  - string
-                  - 'null'
-                  description: Average (arithmetic mean) severity of the advisory aggregated from *all* related vulnerability assertions.
-                  deprecated: true
                 vulnerabilities:
                   type: array
                   items:
@@ -5374,27 +5326,6 @@ components:
           items:
             allOf:
             - $ref: '#/components/schemas/VulnerabilityHead'
-            - type: object
-              required:
-              - average_severity
-              - average_score
-              - advisories
-              properties:
-                advisories:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/VulnerabilityAdvisoryHead'
-                average_score:
-                  type:
-                  - number
-                  - 'null'
-                  format: double
-                  description: Average (arithmetic mean) score of the vulnerability aggregated from *all* related advisories.
-                average_severity:
-                  oneOf:
-                  - type: 'null'
-                  - $ref: '#/components/schemas/Severity'
-                    description: Average (arithmetic mean) severity of the vulnerability aggregated from *all* related advisories.
         total:
           type: integer
           format: int64
@@ -5584,19 +5515,11 @@ components:
       - vulnerability
       - advisory
       - scores
-      - average_severity
-      - average_score
       - status
       - context
       properties:
         advisory:
           $ref: '#/components/schemas/AdvisoryHead'
-        average_score:
-          type: number
-          format: double
-          deprecated: true
-        average_severity:
-          $ref: '#/components/schemas/Severity'
         context:
           oneOf:
           - type: 'null'
@@ -5604,7 +5527,7 @@ components:
         scores:
           type: array
           items:
-            $ref: '#/components/schemas/Score'
+            $ref: '#/components/schemas/ScoredVector'
           description: All CVSS scores associated with the vulnerability
         status:
           type: string
@@ -6001,18 +5924,10 @@ components:
       - $ref: '#/components/schemas/VulnerabilityHead'
       - type: object
         required:
-        - average_severity
-        - average_score
         - status
         - packages
         - scores
         properties:
-          average_score:
-            type: number
-            format: double
-            deprecated: true
-          average_severity:
-            $ref: '#/components/schemas/Severity'
           context:
             oneOf:
             - type: 'null'
@@ -6024,7 +5939,7 @@ components:
           scores:
             type: array
             items:
-              $ref: '#/components/schemas/Score'
+              $ref: '#/components/schemas/ScoredVector'
           status:
             type: string
     SbomSummary:
@@ -6041,6 +5956,7 @@ components:
               $ref: '#/components/schemas/SbomPackage'
     Score:
       type: object
+      description: 'A parsed CVSS score: the scoring system version, numeric value, and derived severity.'
       required:
       - type
       - value
@@ -6048,14 +5964,18 @@ components:
       properties:
         severity:
           $ref: '#/components/schemas/Severity'
-          description: The derived severity
+          description: The severity band derived from the score value.
         type:
           $ref: '#/components/schemas/ScoreType'
-          description: The score type
+          description: The scoring system version.
         value:
           type: number
           format: double
-          description: The actual value
+          description: The numeric score, rounded to one decimal place.
+      example:
+        type: '3.1'
+        value: 7.5
+        severity: high
     ScoreType:
       type: string
       description: The type of score, indicating the scoring system and version used.
@@ -6069,22 +5989,40 @@ components:
       - CVSS v3.0 score
       - CVSS v3.1 score
       - CVSS v4.0 score
+    ScoredVector:
+      allOf:
+      - $ref: '#/components/schemas/Score'
+        description: The score type, value, and derived severity.
+      - type: object
+        required:
+        - vector
+        properties:
+          vector:
+            type: string
+            description: The raw CVSS vector string (e.g. `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`).
+      description: |-
+        A CVSS score combined with its raw vector string, for contexts where clients need both
+        the pre-parsed numeric values and the original vector for display or re-parsing.
+      example:
+        type: '3.1'
+        value: 7.5
+        severity: high
+        vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
     Severity:
       type: string
-      description: |-
-        Qualitative Severity Rating Scale
-
-        Described in CVSS v3.1 Specification: Section 5:
-        <https://www.first.org/cvss/specification-document#t17>
-
-        > For some purposes it is useful to have a textual representation of the
-        > numeric Base, Temporal and Environmental scores.
+      description: Severity rating derived from a CVSS score value.
       enum:
       - none
       - low
       - medium
       - high
       - critical
+      x-enum-descriptions:
+      - No impact (score = 0.0)
+      - Low severity (score 0.1–3.9)
+      - Medium severity (score 4.0–6.9)
+      - High severity (score 7.0–8.9)
+      - Critical severity (score 9.0–10.0)
     SourceDocument:
       type: object
       required:
@@ -6287,18 +6225,13 @@ components:
       - $ref: '#/components/schemas/AdvisoryHead'
       - type: object
         required:
-        - severity
-        - score
+        - scores
         properties:
-          score:
-            type:
-            - number
-            - 'null'
-            format: double
-          severity:
-            oneOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/Severity'
+          scores:
+            type: array
+            items:
+              $ref: '#/components/schemas/ScoredVector'
+            description: All CVSS scores with their raw vector strings from the advisory for this vulnerability.
     VulnerabilityAdvisoryStatus:
       type: object
       required:
@@ -6319,16 +6252,10 @@ components:
       - $ref: '#/components/schemas/VulnerabilityAdvisoryHead'
       - type: object
         required:
-        - cvss3_scores
         - purls
         - sboms
         - number_of_vulnerabilities
         properties:
-          cvss3_scores:
-            type: array
-            items:
-              type: string
-            description: CVSS3 scores from this advisory regarding the vulnerability.
           number_of_vulnerabilities:
             type: integer
             format: int64
@@ -6352,8 +6279,6 @@ components:
       - $ref: '#/components/schemas/VulnerabilityHead'
       - type: object
         required:
-        - average_severity
-        - average_score
         - advisories
         properties:
           advisories:
@@ -6361,18 +6286,6 @@ components:
             items:
               $ref: '#/components/schemas/VulnerabilityAdvisorySummary'
             description: Advisories addressing this vulnerability, if any.
-          average_score:
-            type:
-            - number
-            - 'null'
-            format: double
-            description: Average (arithmetic mean) score of the vulnerability aggregated from *all* related advisories.
-            deprecated: true
-          average_severity:
-            oneOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/Severity'
-              description: Average (arithmetic mean) severity of the vulnerability aggregated from *all* related advisories.
     VulnerabilityHead:
       type: object
       required:
@@ -6388,6 +6301,11 @@ components:
       - released
       - cwes
       properties:
+        base_score:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/BaseScore'
+            description: The main, base score.
         cwes:
           type: array
           items:
@@ -6490,24 +6408,3 @@ components:
     VulnerabilitySummary:
       allOf:
       - $ref: '#/components/schemas/VulnerabilityHead'
-      - type: object
-        required:
-        - average_severity
-        - average_score
-        - advisories
-        properties:
-          advisories:
-            type: array
-            items:
-              $ref: '#/components/schemas/VulnerabilityAdvisoryHead'
-          average_score:
-            type:
-            - number
-            - 'null'
-            format: double
-            description: Average (arithmetic mean) score of the vulnerability aggregated from *all* related advisories.
-          average_severity:
-            oneOf:
-            - type: 'null'
-            - $ref: '#/components/schemas/Severity'
-              description: Average (arithmetic mean) severity of the vulnerability aggregated from *all* related advisories.

--- a/client/src/app/hooks/domain-controls/useVulnerabilitiesOfPackage.ts
+++ b/client/src/app/hooks/domain-controls/useVulnerabilitiesOfPackage.ts
@@ -21,7 +21,7 @@ const areVulnerabilityOfPackageEqual = (
 interface FlatVulnerabilityOfPackage {
   vulnerability: VulnerabilityHead & {
     average_severity: ExtendedSeverity;
-    average_score: number;
+    average_score: number | null;
   };
   vulnerabilityStatus: VulnerabilityStatus;
   advisory: PurlAdvisory;
@@ -30,7 +30,7 @@ interface FlatVulnerabilityOfPackage {
 interface VulnerabilityOfPackage {
   vulnerability: VulnerabilityHead & {
     average_severity: ExtendedSeverity;
-    average_score: number;
+    average_score: number | null;
   };
   vulnerabilityStatus: VulnerabilityStatus;
   relatedSboms: {
@@ -69,14 +69,14 @@ const advisoryToModels = (advisories: PurlAdvisory[]) => {
     .flatMap((advisory) => {
       return (advisory.status ?? []).map((pkgStatus) => {
         const extendedSeverity = extendedSeverityFromSeverity(
-          pkgStatus.average_severity,
+          pkgStatus.vulnerability.base_score?.severity,
         );
 
         const result: FlatVulnerabilityOfPackage = {
           vulnerability: {
             ...pkgStatus.vulnerability,
             average_severity: extendedSeverity,
-            average_score: pkgStatus.average_score,
+            average_score: pkgStatus.vulnerability.base_score?.score ?? null,
           },
           vulnerabilityStatus: pkgStatus.status as VulnerabilityStatus,
           advisory: advisory,

--- a/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
+++ b/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
@@ -90,8 +90,8 @@ const advisoryToModels = (advisories: SbomAdvisory[]) => {
         );
 
         const vulnerabilityWithHighestScore =
-          existingElement.vulnerability.average_score >
-          current.vulnerability.average_score
+          (existingElement.vulnerability.base_score?.score ?? 0) >
+          (current.vulnerability.base_score?.score ?? 0)
             ? existingElement
             : current;
 
@@ -128,7 +128,7 @@ const advisoryToModels = (advisories: SbomAdvisory[]) => {
     (prev, current) => {
       const vulnStatus = current.vulnerabilityStatus;
       const severity = extendedSeverityFromSeverity(
-        current.vulnerability.average_severity,
+        current.vulnerability.base_score?.severity,
       );
 
       const prevVulnStatusValue = prev.vulnerabilityStatus[vulnStatus];

--- a/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
+++ b/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
@@ -168,7 +168,9 @@ export const VulnerabilitiesByAdvisory: React.FC<
                     >
                       {item.base_score && (
                         <SeverityShieldAndText
-                          value={extendedSeverityFromSeverity(item.base_score.severity)}
+                          value={extendedSeverityFromSeverity(
+                            item.base_score.severity,
+                          )}
                           score={item.base_score.score ?? null}
                           showLabel
                           showScore

--- a/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
+++ b/client/src/app/pages/advisory-details/vulnerabilities-by-advisory.tsx
@@ -166,10 +166,10 @@ export const VulnerabilitiesByAdvisory: React.FC<
                       modifier="truncate"
                       {...getTdProps({ columnKey: "score" })}
                     >
-                      {item.severity && (
+                      {item.base_score && (
                         <SeverityShieldAndText
-                          value={extendedSeverityFromSeverity(item.severity)}
-                          score={item.score ?? null}
+                          value={extendedSeverityFromSeverity(item.base_score.severity)}
+                          score={item.base_score.score ?? null}
                           showLabel
                           showScore
                         />

--- a/client/src/app/pages/advisory-list/advisory-table.tsx
+++ b/client/src/app/pages/advisory-list/advisory-table.tsx
@@ -132,7 +132,7 @@ export const AdvisoryTable: React.FC = () => {
 
             const severities = item.vulnerabilities.reduce((prev, current) => {
               const extendedSeverity = extendedSeverityFromSeverity(
-                current.severity,
+                current.base_score?.severity,
               );
               prev[extendedSeverity] = prev[extendedSeverity] + 1;
               return prev;

--- a/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
@@ -147,7 +147,7 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
     ],
     getSortValues: (item) => ({
       id: item.vulnerability.identifier,
-      cvss: item.vulnerability.average_score,
+      cvss: item.vulnerability.base_score?.score ?? 0,
       affectedDependencies: item.summary.totalPackages,
       published: item.vulnerability?.published
         ? dayjs(item.vulnerability.published).valueOf()
@@ -307,9 +307,9 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
                       <Td width={10} {...getTdProps({ columnKey: "cvss" })}>
                         <SeverityShieldAndText
                           value={extendedSeverityFromSeverity(
-                            item.vulnerability.average_severity,
+                            item.vulnerability.base_score?.severity,
                           )}
-                          score={item.vulnerability.average_score}
+                          score={item.vulnerability.base_score?.score ?? null}
                           showLabel
                           showScore
                         />

--- a/client/src/app/pages/vulnerability-details/vulnerability-details.tsx
+++ b/client/src/app/pages/vulnerability-details/vulnerability-details.tsx
@@ -69,9 +69,9 @@ export const VulnerabilityDetails: React.FC = () => {
             {vulnerability && (
               <SeverityShieldAndText
                 value={extendedSeverityFromSeverity(
-                  vulnerability.average_severity,
+                  vulnerability.base_score?.severity,
                 )}
-                score={vulnerability.average_score}
+                score={vulnerability.base_score?.score ?? null}
                 showLabel
                 showScore
               />

--- a/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
@@ -117,9 +117,9 @@ export const VulnerabilityTable: React.FC = () => {
                     <Td width={10} {...getTdProps({ columnKey: "severity" })}>
                       <SeverityShieldAndText
                         value={extendedSeverityFromSeverity(
-                          item.average_severity,
+                          item.base_score?.severity,
                         )}
-                        score={item.average_score}
+                        score={item.base_score?.score ?? null}
                         showLabel
                         showScore
                       />


### PR DESCRIPTION
Counterpart of https://github.com/guacsec/trustify/pull/2314

The average_severity and average_scores were removed in favor of base_score so aligning the UI to the upcoming new rest api

## Summary by Sourcery

Align the client OpenAPI spec and UI with the new vulnerability scoring model and v3 REST endpoints.

New Features:
- Introduce v3 API endpoints for advisories, purls, SBOM advisories, and vulnerabilities in the OpenAPI specification, including updated query and pagination parameters.

Bug Fixes:
- Ensure client-side types tolerate null scores when the base score is unavailable to prevent runtime errors.

Enhancements:
- Replace deprecated average severity/score fields with structured base_score and scored vector data across advisory and vulnerability models and related UI views.
- Update vulnerability- and advisory-related tables, detail pages, and hooks to compute and display severity and CVSS values from the new base_score and ScoredVector structures.
- Refine score and severity schema descriptions to better document CVSS scoring semantics and vector handling.