### PR TITLE
feat: add sbom details score breakdown

### DIFF
--- a/client/src/app/api/model-utils.ts
+++ b/client/src/app/api/model-utils.ts
@@ -151,13 +151,13 @@ const getScoreTypePriority = (val: ScoreType | null) => {
   }
 
   switch (val) {
-    case "3.1":
-      return 1;
-    case "3.0":
-      return 2;
-    case "4.0":
-      return 3;
     case "2.0":
+      return 1;
+    case "3.1":
+      return 2;
+    case "3.0":
+      return 3;
+    case "4.0":
       return 4;
     default:
       return 0;
@@ -181,4 +181,19 @@ export const extractPriorityScoreFromScores = (scores: Score[]) => {
   }
 
   return [...scores].sort(compareByScoreTypeFn((item) => item.type))[0];
+};
+
+export const extractPriorityItemBasedOnScoresType = <T>(
+  items: T[],
+  getScoreType: (item: T) => ScoreType | null,
+): T | null => {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return [...items].sort((a, b) => {
+    const scoreTypeA = getScoreType(a);
+    const scoreTypeB = getScoreType(b);
+    return getScoreTypePriority(scoreTypeA) - getScoreTypePriority(scoreTypeB);
+  })[0];
 };

--- a/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
+++ b/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
@@ -1,11 +1,23 @@
 import React from "react";
 
 import {
+  compareByScoreTypeFn,
+  extractPriorityItemBasedOnScoresType,
+} from "@app/api/model-utils";
+import {
   type ExtendedSeverity,
   type VulnerabilityStatus,
   extendedSeverityFromSeverity,
 } from "@app/api/models";
-import type { SbomAdvisory, SbomPackage, SbomStatus } from "@app/client";
+import type {
+  AdvisoryHead,
+  BaseScore,
+  PurlSummary,
+  SbomAdvisory,
+  SbomPackage,
+  SbomStatus,
+  ScoredVector,
+} from "@app/client";
 import {
   useFetchSbomsAdvisory,
   useFetchSbomsAdvisoryBatch,
@@ -24,17 +36,34 @@ const areVulnerabilityOfSbomEqual = (
 interface FlatVulnerabilityOfSbom {
   vulnerability: SbomStatus;
   vulnerabilityStatus: VulnerabilityStatus;
-  advisory: SbomAdvisory;
+  advisory: AdvisoryHead;
   packages: SbomPackage[];
+  base_score: BaseScore | null;
+  scores: ScoredVector[];
 }
+
+type AdvisoryFromAnalysis = {
+  advisory: AdvisoryHead;
+  base_score: BaseScore | null;
+  scores: ScoredVector[];
+  opinionatedScore: ScoredVector | null;
+  opinionatedExtendedSeverity: ExtendedSeverity;
+};
+
+type PurlAnalysis =
+  | { isOrphan: true; parentName: string }
+  | { isOrphan: false; purlSummary: PurlSummary };
 
 interface VulnerabilityOfSbom {
   vulnerability: SbomStatus;
   vulnerabilityStatus: VulnerabilityStatus;
-  relatedPackages: {
-    advisory: SbomAdvisory;
-    packages: SbomPackage[];
-  }[];
+  advisories: Map<string, AdvisoryFromAnalysis>;
+  purls: Map<string, PurlAnalysis>;
+  opinionatedAdvisory: {
+    advisory: AdvisoryHead | null;
+    score: ScoredVector | null;
+    extendedSeverity: ExtendedSeverity;
+  };
 }
 
 export type SeveritySummary = {
@@ -63,6 +92,34 @@ export const DEFAULT_SUMMARY: VulnerabilityOfSbomSummary = {
   },
 };
 
+const enrichPurlMapWithPackages = (
+  purls: Map<string, PurlAnalysis>,
+  packages: SbomPackage[],
+) => {
+  const packagePurls = packages.flatMap((pkg) => {
+    const hasNoPurlsButOnlyName = pkg.name && pkg.purl.length === 0;
+    const result: PurlAnalysis[] = hasNoPurlsButOnlyName
+      ? [
+          {
+            isOrphan: true,
+            parentName: pkg.name,
+          },
+        ]
+      : pkg.purl.map((p) => ({
+          isOrphan: false,
+          purlSummary: p,
+        }));
+    return result;
+  });
+  packagePurls.forEach((item) => {
+    if (item.isOrphan) {
+      purls.set(item.parentName, item);
+    } else {
+      purls.set(item.purlSummary.uuid, item);
+    }
+  });
+};
+
 const advisoryToModels = (advisories: SbomAdvisory[]) => {
   const vulnerabilities = advisories
     .flatMap((advisory) => {
@@ -72,6 +129,8 @@ const advisoryToModels = (advisories: SbomAdvisory[]) => {
           vulnerabilityStatus: sbomStatus.status as VulnerabilityStatus,
           advisory: advisory,
           packages: sbomStatus.packages,
+          base_score: sbomStatus.base_score ?? null,
+          scores: sbomStatus.scores || [],
         };
         return result;
       });
@@ -89,34 +148,115 @@ const advisoryToModels = (advisories: SbomAdvisory[]) => {
           (item) => !areVulnerabilityOfSbomEqual(item, existingElement),
         );
 
-        const vulnerabilityWithHighestScore =
-          (existingElement.vulnerability.base_score?.score ?? 0) >
-          (current.vulnerability.base_score?.score ?? 0)
-            ? existingElement
-            : current;
+        const score = extractPriorityItemBasedOnScoresType(
+          current.scores,
+          (item) => item.type,
+        );
+        const extendedSeverity = extendedSeverityFromSeverity(score?.severity);
 
-        const updatedItemInArray: VulnerabilityOfSbom = {
-          ...vulnerabilityWithHighestScore,
-          relatedPackages: [
-            ...existingElement.relatedPackages,
+        // new advisories
+        const advisories = new Map<string, AdvisoryFromAnalysis>(
+          existingElement.advisories,
+        );
+        advisories.set(current.advisory.identifier, {
+          advisory: current.advisory,
+          base_score: current.base_score,
+          scores: current.scores,
+          opinionatedScore: score,
+          opinionatedExtendedSeverity: extendedSeverity,
+        });
+
+        // new purls
+        const purls = new Map<string, PurlAnalysis>(existingElement.purls);
+        enrichPurlMapWithPackages(purls, current.packages);
+
+        // new opinionated advisory
+        let opinionatedAdvisory: AdvisoryHead | null = null;
+        let opinionatedScore: ScoredVector | null = null;
+        if (existingElement.opinionatedAdvisory.score?.type !== score?.type) {
+          const preferedAdvisoryScore = [
+            {
+              advisory: existingElement.opinionatedAdvisory.advisory,
+              score: existingElement.opinionatedAdvisory.score,
+            },
             {
               advisory: current.advisory,
-              packages: current.packages,
+              score: score,
             },
-          ],
+          ].sort(compareByScoreTypeFn((item) => item.score?.type ?? null))[0];
+
+          opinionatedAdvisory = preferedAdvisoryScore.advisory;
+          opinionatedScore = preferedAdvisoryScore.score;
+        } else {
+          const {
+            advisory: newOpinionatedAdvisory,
+            score: newOpinionatedScore,
+          } =
+            (score?.value ?? 0) >
+            (existingElement.opinionatedAdvisory.score?.value ?? 0)
+              ? {
+                  score: score,
+                  advisory: current.advisory,
+                }
+              : {
+                  score: existingElement.opinionatedAdvisory.score,
+                  advisory: existingElement.opinionatedAdvisory.advisory,
+                };
+
+          opinionatedAdvisory = newOpinionatedAdvisory;
+          opinionatedScore = newOpinionatedScore;
+        }
+
+        const opinionatedExtendedSeverity = extendedSeverityFromSeverity(
+          opinionatedScore?.severity,
+        );
+
+        const updatedItemInArray: VulnerabilityOfSbom = {
+          // existing element
+          vulnerability: existingElement.vulnerability,
+          vulnerabilityStatus: existingElement.vulnerabilityStatus,
+          // new values,
+          advisories,
+          purls,
+          opinionatedAdvisory: {
+            advisory: opinionatedAdvisory,
+            score: opinionatedScore,
+            extendedSeverity: opinionatedExtendedSeverity,
+          },
         };
 
         result = [...arrayWithoutExistingItem, updatedItemInArray];
       } else {
+        const score = extractPriorityItemBasedOnScoresType(
+          current.scores,
+          (item) => item.type,
+        );
+        const extendedSeverity = extendedSeverityFromSeverity(score?.severity);
+
+        // advisories
+        const advisories = new Map<string, AdvisoryFromAnalysis>();
+        advisories.set(current.advisory.identifier, {
+          advisory: current.advisory,
+          base_score: current.base_score,
+          scores: current.scores,
+          opinionatedExtendedSeverity: extendedSeverity,
+          opinionatedScore: score,
+        });
+
+        // purls
+        const purls = new Map<string, PurlAnalysis>();
+        enrichPurlMapWithPackages(purls, current.packages);
+
         const newItemInArray: VulnerabilityOfSbom = {
           vulnerability: current.vulnerability,
           vulnerabilityStatus: current.vulnerabilityStatus,
-          relatedPackages: [
-            {
-              advisory: current.advisory,
-              packages: current.packages,
-            },
-          ],
+          advisories,
+          purls,
+          opinionatedAdvisory: {
+            advisory: current.advisory,
+            score: score,
+            extendedSeverity: extendedSeverity,
+          },
         };
         result = [...prev.slice(), newItemInArray];
       }
@@ -127,9 +267,7 @@ const advisoryToModels = (advisories: SbomAdvisory[]) => {
   const summary = vulnerabilities.reduce(
     (prev, current) => {
       const vulnStatus = current.vulnerabilityStatus;
-      const severity = extendedSeverityFromSeverity(
-        current.vulnerability.base_score?.severity,
-      );
+      const severity = current.opinionatedAdvisory.extendedSeverity;
 
       const prevVulnStatusValue = prev.vulnerabilityStatus[vulnStatus];
 

--- a/client/src/app/pages/sbom-details/components/vulnerability-score-breakdown.tsx
+++ b/client/src/app/pages/sbom-details/components/vulnerability-score-breakdown.tsx
@@ -1,0 +1,68 @@
+import type React from "react";
+
+import { Flex, FlexItem, Stack, StackItem } from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
+import type { ExtendedSeverity } from "@app/api/models";
+import type { AdvisoryHead, ScoredVector } from "@app/client";
+import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
+import { extractImporterNameFromAdvisory } from "@app/pages/sbom-scan/scan-utils";
+
+interface IVulnerabilityScoreBreakdownProps {
+  opinionatedAdvisory: {
+    advisory: AdvisoryHead | null;
+    score: ScoredVector | null;
+    extendedSeverity: ExtendedSeverity;
+  };
+  advisories: {
+    advisory: AdvisoryHead;
+    opinionatedScore: ScoredVector | null;
+    opinionatedExtendedSeverity: ExtendedSeverity;
+  }[];
+}
+
+export const VulnerabilityScoreBreakdown: React.FC<
+  IVulnerabilityScoreBreakdownProps
+> = ({ opinionatedAdvisory, advisories }) => {
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Flex>
+          <FlexItem>Highest score:</FlexItem>
+          <FlexItem>
+            <SeverityShieldAndText
+              value={opinionatedAdvisory.extendedSeverity}
+              score={opinionatedAdvisory.score?.value ?? null}
+              showLabel
+              showScore
+            />
+          </FlexItem>
+        </Flex>
+      </StackItem>
+      <StackItem>
+        <Table aria-label="cvss-advisory-breakdown-table">
+          <Thead>
+            <Tr>
+              <Th>Source</Th>
+              <Th>Score</Th>
+              <Th>Severity</Th>
+              <Th>Version</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {advisories.map((item) => (
+              <Tr key={item.advisory.identifier}>
+                <Td dataLabel="Source">
+                  {extractImporterNameFromAdvisory(item.advisory)}
+                </Td>
+                <Td dataLabel="Score">{item.opinionatedScore?.value}</Td>
+                <Td dataLabel="Severity">{item.opinionatedExtendedSeverity}</Td>
+                <Td dataLabel="Version">{item.opinionatedScore?.type}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </StackItem>
+    </Stack>
+  );
+};

--- a/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
@@ -4,14 +4,18 @@ import { generatePath, Link } from "react-router-dom";
 import dayjs from "dayjs";
 
 import {
+  Button,
   Card,
   CardBody,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  Flex,
+  FlexItem,
   Grid,
   GridItem,
+  Popover,
   Stack,
   StackItem,
   Toolbar,
@@ -29,16 +33,6 @@ import {
   Tr,
 } from "@patternfly/react-table";
 
-import {
-  type VulnerabilityStatus,
-  extendedSeverityFromSeverity,
-} from "@app/api/models";
-import type {
-  PurlSummary,
-  SbomAdvisory,
-  SbomPackage,
-  SbomStatus,
-} from "@app/client";
 import { LoadingWrapper } from "@app/components/LoadingWrapper";
 import { PackageQualifiers } from "@app/components/PackageQualifiers";
 import { SbomVulnerabilitiesDonutChart } from "@app/components/SbomVulnerabilitiesDonutChart";
@@ -57,19 +51,7 @@ import { useFetchSBOMById } from "@app/queries/sboms";
 import { Paths } from "@app/Routes";
 import { useWithUiId } from "@app/utils/query-utils";
 import { decomposePurl, formatDate } from "@app/utils/utils";
-
-interface TableData {
-  vulnerability: SbomStatus;
-  vulnerabilityStatus: VulnerabilityStatus;
-  relatedPackages: {
-    advisory: SbomAdvisory;
-    packages: SbomPackage[];
-  }[];
-  summary: {
-    totalPackages: number;
-    allPackages: SbomPackage[];
-  };
-}
+import { VulnerabilityScoreBreakdown } from "./components/vulnerability-score-breakdown";
 
 interface VulnerabilitiesBySbomProps {
   sbomId: string;
@@ -95,31 +77,8 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
     );
   }, [vulnerabilities]);
 
-  const tableData = React.useMemo(() => {
-    return affectedVulnerabilities.map((item) => {
-      const allPackages = item.relatedPackages
-        .flatMap((i) => i.packages)
-        .reduce((prev, current) => {
-          const existingElement = prev.find((item) => item.id === current.id);
-          if (!existingElement) {
-            prev.push(current);
-          }
-          return prev;
-        }, [] as SbomPackage[]);
-      const result: TableData = {
-        ...item,
-        summary: {
-          totalPackages: allPackages.length,
-          allPackages,
-        },
-      };
-
-      return result;
-    });
-  }, [affectedVulnerabilities]);
-
   const tableDataWithUiId = useWithUiId(
-    tableData,
+    affectedVulnerabilities,
     (d) => `${d.vulnerability.identifier}-${d.vulnerabilityStatus}`,
   );
 
@@ -147,8 +106,8 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
     ],
     getSortValues: (item) => ({
       id: item.vulnerability.identifier,
-      cvss: item.vulnerability.base_score?.score ?? 0,
-      affectedDependencies: item.summary.totalPackages,
+      cvss: item.opinionatedAdvisory.score?.value ?? 0,
+      affectedDependencies: item.purls.size,
       published: item.vulnerability?.published
         ? dayjs(item.vulnerability.published).valueOf()
         : 0,
@@ -269,7 +228,7 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
                       rowIndex={rowIndex}
                     >
                       <Td
-                        width={15}
+                        width={10}
                         modifier="breakWord"
                         {...getTdProps({ columnKey: "id" })}
                       >
@@ -284,7 +243,7 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
                       <TdWithFocusStatus>
                         {(isFocused, setIsFocused) => (
                           <Td
-                            width={35}
+                            width={40}
                             modifier="truncate"
                             onFocus={() => setIsFocused(true)}
                             onBlur={() => setIsFocused(false)}
@@ -304,18 +263,48 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
                           </Td>
                         )}
                       </TdWithFocusStatus>
-                      <Td width={10} {...getTdProps({ columnKey: "cvss" })}>
-                        <SeverityShieldAndText
-                          value={extendedSeverityFromSeverity(
-                            item.vulnerability.base_score?.severity,
-                          )}
-                          score={item.vulnerability.base_score?.score ?? null}
-                          showLabel
-                          showScore
-                        />
+                      <Td width={20} {...getTdProps({ columnKey: "cvss" })}>
+                        <Flex>
+                          <FlexItem>
+                            <SeverityShieldAndText
+                              value={item.opinionatedAdvisory.extendedSeverity}
+                              score={
+                                item.opinionatedAdvisory.score?.value ?? null
+                              }
+                              showLabel
+                              showScore
+                            />
+                          </FlexItem>
+                          <FlexItem>
+                            <Popover
+                              hasAutoWidth
+                              aria-label="CVSS Score Breakdown"
+                              headerContent={<div>CVSS Score Breakdown</div>}
+                              bodyContent={
+                                <VulnerabilityScoreBreakdown
+                                  opinionatedAdvisory={{
+                                    advisory: item.opinionatedAdvisory.advisory,
+                                    score: item.opinionatedAdvisory.score,
+                                    extendedSeverity:
+                                      item.opinionatedAdvisory.extendedSeverity,
+                                  }}
+                                  advisories={Array.from(
+                                    item.advisories.values(),
+                                  )}
+                                />
+                              }
+                            >
+                              <Button
+                                variant="link"
+                                disabled
+                                size="sm"
+                              >{`${item.advisories.size} Sources`}</Button>
+                            </Popover>
+                          </FlexItem>
+                        </Flex>
                       </Td>
                       <Td
-                        width={15}
+                        width={10}
                         modifier="truncate"
                         {...getTdProps({
                           columnKey: "affectedDependencies",
@@ -324,7 +313,7 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
                           rowIndex,
                         })}
                       >
-                        {item.summary.totalPackages}
+                        {item.purls.size}
                       </Td>
                       <Td
                         width={10}
@@ -363,34 +352,9 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
                                 </Tr>
                               </Thead>
                               <Tbody>
-                                {item.summary.allPackages
-                                  .flatMap((item) => {
-                                    // Some packages do not have purl neither ID. So we render only the parent name meanwhile
-                                    type EnrichedPurlSummary = {
-                                      parentName: string;
-                                      purlSummary?: PurlSummary;
-                                    };
-
-                                    const hasNoPurlsButOnlyName =
-                                      item.name && item.purl.length === 0;
-
-                                    if (hasNoPurlsButOnlyName) {
-                                      const result: EnrichedPurlSummary = {
-                                        parentName: item.name,
-                                      };
-                                      return [result];
-                                    }
-
-                                    return item.purl.map((i) => {
-                                      const result: EnrichedPurlSummary = {
-                                        parentName: item.name,
-                                        purlSummary: i,
-                                      };
-                                      return result;
-                                    });
-                                  })
-                                  .map((purl, index) => {
-                                    if (purl.purlSummary) {
+                                {Array.from(item.purls.values()).map(
+                                  (purl, index) => {
+                                    if (!purl.isOrphan) {
                                       const decomposedPurl = decomposePurl(
                                         purl.purlSummary.purl,
                                       );
@@ -424,21 +388,22 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
                                           </Td>
                                         </Tr>
                                       );
+                                    } else {
+                                      return (
+                                        <Tr
+                                          key={`${purl.parentName}-${index}-name`}
+                                        >
+                                          <Td />
+                                          <Td />
+                                          <Td>{purl.parentName}</Td>
+                                          <Td />
+                                          <Td />
+                                          <Td />
+                                        </Tr>
+                                      );
                                     }
-
-                                    return (
-                                      <Tr
-                                        key={`${purl.parentName}-${index}-name`}
-                                      >
-                                        <Td />
-                                        <Td />
-                                        <Td>{purl.parentName}</Td>
-                                        <Td />
-                                        <Td />
-                                        <Td />
-                                      </Tr>
-                                    );
-                                  })}
+                                  },
+                                )}
                               </Tbody>
                             </Table>
                           ) : null}

--- a/client/src/app/pages/sbom-scan/hooks/useVulnerabilitiesOfSbom.ts
+++ b/client/src/app/pages/sbom-scan/hooks/useVulnerabilitiesOfSbom.ts
@@ -28,7 +28,7 @@ export interface VulnerabilityOfSbomFromAnalysis {
   status: VulnerabilityStatus;
   advisories: Map<string, AdvisoryFromAnalysis>;
   purls: Set<string>;
-  opinionatedAvisory: {
+  opinionatedAdvisory: {
     advisory: AdvisoryHead | null;
     score: Score | null;
     extendedSeverity: ExtendedSeverity;
@@ -115,11 +115,11 @@ export const useVulnerabilitiesOfSbomByPurls = (purls: string[]) => {
           // new opinionated advisory
           let opinionatedAdvisory: AdvisoryHead | null = null;
           let opinionatedScore: Score | null = null;
-          if (existingElement.opinionatedAvisory.score?.type !== score?.type) {
+          if (existingElement.opinionatedAdvisory.score?.type !== score?.type) {
             const preferedAdvisoryScore = [
               {
-                advisory: existingElement.opinionatedAvisory.advisory,
-                score: existingElement.opinionatedAvisory.score,
+                advisory: existingElement.opinionatedAdvisory.advisory,
+                score: existingElement.opinionatedAdvisory.score,
               },
               {
                 advisory: current.advisory,
@@ -135,14 +135,14 @@ export const useVulnerabilitiesOfSbomByPurls = (purls: string[]) => {
               score: newOpinionatedScore,
             } =
               (score?.value ?? 0) >
-              (existingElement.opinionatedAvisory.score?.value ?? 0)
+              (existingElement.opinionatedAdvisory.score?.value ?? 0)
                 ? {
                     score: score,
                     advisory: current.advisory,
                   }
                 : {
-                    score: existingElement.opinionatedAvisory.score,
-                    advisory: existingElement.opinionatedAvisory.advisory,
+                    score: existingElement.opinionatedAdvisory.score,
+                    advisory: existingElement.opinionatedAdvisory.advisory,
                   };
 
             opinionatedAdvisory = newOpinionatedAdvisory;
@@ -160,7 +160,7 @@ export const useVulnerabilitiesOfSbomByPurls = (purls: string[]) => {
             // new values,
             advisories,
             purls,
-            opinionatedAvisory: {
+            opinionatedAdvisory: {
               advisory: opinionatedAdvisory,
               score: opinionatedScore,
               extendedSeverity: opinionatedExtendedSeverity,
@@ -192,7 +192,7 @@ export const useVulnerabilitiesOfSbomByPurls = (purls: string[]) => {
             status: current.status,
             advisories,
             purls,
-            opinionatedAvisory: {
+            opinionatedAdvisory: {
               advisory: current.advisory,
               score: score,
               extendedSeverity: extendedSeverity,
@@ -207,7 +207,7 @@ export const useVulnerabilitiesOfSbomByPurls = (purls: string[]) => {
     const summary = vulnerabilities.reduce(
       (prev, current) => {
         const vulnStatus = current.status as VulnerabilityStatus;
-        const severity = current.opinionatedAvisory.extendedSeverity;
+        const severity = current.opinionatedAdvisory.extendedSeverity;
 
         const prevVulnStatusValue = prev.vulnerabilityStatus[vulnStatus];
 

--- a/e2e/tests/ui/helpers/ToolbarTable.ts
+++ b/e2e/tests/ui/helpers/ToolbarTable.ts
@@ -367,7 +367,7 @@ export class ToolbarTable {
    * @returns true if the given input is in CVSS format
    */
   isCVSS(cvssString: string): boolean {
-    const cvssRegex = /^.+\((\d*\.*\d+?)\)$/;
+    const cvssRegex = /^.+\((\d*\.*\d+?)\)/;
     return !!cvssRegex.test(cvssString);
   }
 
@@ -387,7 +387,7 @@ export class ToolbarTable {
    * @returns CVSS score if the given input is in CVSS format
    */
   getCVSS(cvssString: string): number {
-    const cvssRegex = /^.+\((\d*\.*\d+?)\)$/;
+    const cvssRegex = /^.+\((\d*\.*\d+?)\)/;
     const cvssScore = cvssString.match(cvssRegex);
     if (!cvssScore) {
       return 0;

--- a/e2e/tests/ui/pages/sbom-details/vulnerabilities/donutchart.spec.ts
+++ b/e2e/tests/ui/pages/sbom-details/vulnerabilities/donutchart.spec.ts
@@ -15,10 +15,10 @@ test.describe("DonutChart validations", { tag: "@tier1" }, () => {
     await VulnerabilitiesTab.build(page, "quarkus-bom");
 
     await expect(page.locator("#legend-labels-0")).toContainText("Critical: 0");
-    await expect(page.locator("#legend-labels-1")).toContainText("High: 3");
-    await expect(page.locator("#legend-labels-2")).toContainText("Medium: 10");
+    await expect(page.locator("#legend-labels-1")).toContainText("High: 2");
+    await expect(page.locator("#legend-labels-2")).toContainText("Medium: 13");
     await expect(page.locator("#legend-labels-3")).toContainText("Low: 1");
     await expect(page.locator("#legend-labels-4")).toContainText("None: 0");
-    await expect(page.locator("#legend-labels-5")).toContainText("Unknown: 2");
+    await expect(page.locator("#legend-labels-5")).toContainText("Unknown: 0");
   });
 });

--- a/e2e/tests/ui/pages/sbom-list/columns.spec.ts
+++ b/e2e/tests/ui/pages/sbom-list/columns.spec.ts
@@ -31,19 +31,15 @@ test.describe("Columns validations", { tag: "@tier1" }, () => {
     const expectedVulnerabilities = [
       {
         severity: "high",
-        count: 3,
+        count: 2,
       },
       {
         severity: "medium",
-        count: 10,
+        count: 13,
       },
       {
         severity: "low",
         count: 1,
-      },
-      {
-        severity: "unknown",
-        count: 2,
       },
     ];
 


### PR DESCRIPTION
Fixes: https://redhat.atlassian.net/browse/TC-4093

<img width="2519" height="1289" alt="image" src="https://github.com/user-attachments/assets/a23373b1-26c0-4aef-9732-47210f34dfb0" />

## Summary by Sourcery

Add an opinionated CVSS scoring model for SBOM vulnerabilities and surface a detailed score breakdown per vulnerability in the SBOM vulnerabilities view.

New Features:
- Expose an opinionated CVSS score, severity, and advisory selection for each SBOM vulnerability based on multiple advisory sources.
- Display a score breakdown popover in the SBOM vulnerabilities table showing per-source scores, severities, and CVSS versions.

Enhancements:
- Refactor vulnerability aggregation to track advisories and purls via maps and compute derived vulnerability summaries from these richer structures.
- Update affected dependency counts and package listings to be driven by normalized purl mappings instead of duplicated package arrays.
- Adjust score type prioritization logic and add a generic helper for selecting items by preferred CVSS version.