### PR TITLE
UI - CVSS Scores - SBOM Details Page - Vulnerabilities Tab

### DIFF
--- a/client/src/app/components/CvssScoreExpandedContent.tsx
+++ b/client/src/app/components/CvssScoreExpandedContent.tsx
@@ -1,0 +1,54 @@
+import type React from "react";
+
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+
+import { compareByScoreTypeFn } from "@app/api/model-utils";
+import { extendedSeverityFromSeverity } from "@app/api/models";
+import type { ScoredVector } from "@app/client";
+
+import { SeverityShieldAndText } from "./SeverityShieldAndText";
+
+interface CvssScoreExpandedContentProps {
+  scores: ScoredVector[];
+}
+
+export const CvssScoreExpandedContent: React.FC<
+  CvssScoreExpandedContentProps
+> = ({ scores }) => {
+  if (scores.length === 0) {
+    return <>-</>;
+  }
+
+  const sortedScores = [...scores].sort(
+    compareByScoreTypeFn((item) => item.type),
+  );
+
+  return (
+    <Table variant="compact">
+      <Thead>
+        <Tr>
+          <Th>CVSS Version</Th>
+          <Th>Score</Th>
+          <Th>Severity</Th>
+          <Th>Vector</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {sortedScores.map((score) => (
+          <Tr key={score.vector}>
+            <Td>{score.type}</Td>
+            <Td>{Math.round(score.value * 10) / 10}</Td>
+            <Td>
+              <SeverityShieldAndText
+                value={extendedSeverityFromSeverity(score.severity)}
+                score={null}
+                showLabel
+              />
+            </Td>
+            <Td modifier="breakWord">{score.vector}</Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  );
+};

--- a/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
+++ b/client/src/app/hooks/domain-controls/useVulnerabilitiesOfSbom.ts
@@ -5,7 +5,12 @@ import {
   type VulnerabilityStatus,
   extendedSeverityFromSeverity,
 } from "@app/api/models";
-import type { SbomAdvisory, SbomPackage, SbomStatus } from "@app/client";
+import type {
+  SbomAdvisory,
+  SbomPackage,
+  SbomStatus,
+  ScoredVector,
+} from "@app/client";
 import {
   useFetchSbomsAdvisory,
   useFetchSbomsAdvisoryBatch,
@@ -63,6 +68,15 @@ export const DEFAULT_SUMMARY: VulnerabilityOfSbomSummary = {
   },
 };
 
+const deduplicateScores = (scores: ScoredVector[]): ScoredVector[] => {
+  const seen = new Set<string>();
+  return scores.filter((s) => {
+    if (seen.has(s.vector)) return false;
+    seen.add(s.vector);
+    return true;
+  });
+};
+
 const advisoryToModels = (advisories: SbomAdvisory[]) => {
   const vulnerabilities = advisories
     .flatMap((advisory) => {
@@ -97,6 +111,13 @@ const advisoryToModels = (advisories: SbomAdvisory[]) => {
 
         const updatedItemInArray: VulnerabilityOfSbom = {
           ...vulnerabilityWithHighestScore,
+          vulnerability: {
+            ...vulnerabilityWithHighestScore.vulnerability,
+            scores: deduplicateScores([
+              ...existingElement.vulnerability.scores,
+              ...current.vulnerability.scores,
+            ]),
+          },
           relatedPackages: [
             ...existingElement.relatedPackages,
             {

--- a/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/vulnerabilities-by-sbom.tsx
@@ -42,6 +42,7 @@ import type {
 import { LoadingWrapper } from "@app/components/LoadingWrapper";
 import { PackageQualifiers } from "@app/components/PackageQualifiers";
 import { SbomVulnerabilitiesDonutChart } from "@app/components/SbomVulnerabilitiesDonutChart";
+import { CvssScoreExpandedContent } from "@app/components/CvssScoreExpandedContent";
 import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
@@ -304,7 +305,15 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
                           </Td>
                         )}
                       </TdWithFocusStatus>
-                      <Td width={10} {...getTdProps({ columnKey: "cvss" })}>
+                      <Td
+                        width={10}
+                        {...getTdProps({
+                          columnKey: "cvss",
+                          isCompoundExpandToggle: true,
+                          item: item,
+                          rowIndex,
+                        })}
+                      >
                         <SeverityShieldAndText
                           value={extendedSeverityFromSeverity(
                             item.vulnerability.base_score?.severity,
@@ -350,6 +359,11 @@ export const VulnerabilitiesBySbom: React.FC<VulnerabilitiesBySbomProps> = ({
                         })}
                       >
                         <ExpandableRowContent>
+                          {isCellExpanded(item, "cvss") ? (
+                            <CvssScoreExpandedContent
+                              scores={item.vulnerability.scores}
+                            />
+                          ) : null}
                           {isCellExpanded(item, "affectedDependencies") ? (
                             <Table variant="compact">
                               <Thead>

--- a/e2e/tests/ui/pages/sbom-details/vulnerabilities/columns.spec.ts
+++ b/e2e/tests/ui/pages/sbom-details/vulnerabilities/columns.spec.ts
@@ -44,6 +44,12 @@ test.describe("Columns validations", { tag: "@tier1" }, () => {
       idIndex,
     );
 
+    // CVSS expanded content
+    const expandedCvssCell = await table.expandCell("CVSS", idIndex);
+    await expect(expandedCvssCell).toContainText("3.1");
+    await expect(expandedCvssCell).toContainText("8.1");
+
+    // Affected dependencies expanded content (clicking collapses CVSS due to compound expansion)
     const expandedCell = await table.expandCell(
       "Affected dependencies",
       idIndex,


### PR DESCRIPTION
Closes https://redhat.atlassian.net/browse/TC-4093

UI - CVSS Scores - SBOM Details Page - Vulnerabilities Tab

Implement the mockups from

## Summary by Sourcery

Add expandable CVSS score details to the SBOM vulnerabilities table and ensure scores are unique per vulnerability.

New Features:
- Display detailed CVSS scores in an expanded view within the SBOM vulnerabilities table, including version, numeric score, severity, and vector.

Bug Fixes:
- Deduplicate CVSS score entries when aggregating vulnerability data for SBOM advisories.

Tests:
- Extend SBOM vulnerabilities column e2e tests to cover the new CVSS expanded content behavior.