### PR TITLE
feat: CVSS Scores - Vulnerabilities Table page

### DIFF
--- a/client/src/app/pages/vulnerability-list/components/CvssVersionBadge.test.tsx
+++ b/client/src/app/pages/vulnerability-list/components/CvssVersionBadge.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+
+import type { ScoreType } from "@app/client";
+
+import { CvssVersionBadge } from "./CvssVersionBadge";
+
+describe("CvssVersionBadge", () => {
+  it("renders nothing when version is undefined", () => {
+    const { container } = render(<CvssVersionBadge version={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it.each<ScoreType>([
+    "2.0",
+    "3.0",
+    "3.1",
+    "4.0",
+  ])("renders a label with 'v%s' for version '%s'", (version) => {
+    render(<CvssVersionBadge version={version} />);
+    expect(screen.getByText(`v${version}`)).toBeInTheDocument();
+  });
+});

--- a/client/src/app/pages/vulnerability-list/components/CvssVersionBadge.test.tsx
+++ b/client/src/app/pages/vulnerability-list/components/CvssVersionBadge.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
 
 import type { ScoreType } from "@app/client";
 

--- a/client/src/app/pages/vulnerability-list/components/CvssVersionBadge.tsx
+++ b/client/src/app/pages/vulnerability-list/components/CvssVersionBadge.tsx
@@ -1,0 +1,23 @@
+import type React from "react";
+
+import { Label } from "@patternfly/react-core";
+
+import type { ScoreType } from "@app/client";
+
+interface CvssVersionBadgeProps {
+  version: ScoreType | undefined;
+}
+
+export const CvssVersionBadge: React.FC<CvssVersionBadgeProps> = ({
+  version,
+}) => {
+  if (!version) {
+    return null;
+  }
+
+  return (
+    <Label isCompact color="grey">
+      v{version}
+    </Label>
+  );
+};

--- a/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
@@ -11,7 +11,7 @@ import {
   Tr,
 } from "@patternfly/react-table";
 
-import { Flex } from "@patternfly/react-core";
+import { Flex, FlexItem } from "@patternfly/react-core";
 
 import { extendedSeverityFromSeverity } from "@app/api/models";
 import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
@@ -123,15 +123,19 @@ export const VulnerabilityTable: React.FC = () => {
                         gap={{ default: "gapSm" }}
                         flexWrap={{ default: "nowrap" }}
                       >
-                        <SeverityShieldAndText
-                          value={extendedSeverityFromSeverity(
-                            item.base_score?.severity,
-                          )}
-                          score={item.base_score?.score ?? null}
-                          showLabel
-                          showScore
-                        />
-                        <CvssVersionBadge version={item.base_score?.type} />
+                        <FlexItem>
+                          <SeverityShieldAndText
+                            value={extendedSeverityFromSeverity(
+                              item.base_score?.severity,
+                            )}
+                            score={item.base_score?.score ?? null}
+                            showLabel
+                            showScore
+                          />
+                        </FlexItem>
+                        <FlexItem>
+                          <CvssVersionBadge version={item.base_score?.type} />
+                        </FlexItem>
                       </Flex>
                     </Td>
                     <Td width={10} {...getTdProps({ columnKey: "published" })}>

--- a/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
@@ -11,6 +11,8 @@ import {
   Tr,
 } from "@patternfly/react-table";
 
+import { Flex } from "@patternfly/react-core";
+
 import { extendedSeverityFromSeverity } from "@app/api/models";
 import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
 import { SimplePagination } from "@app/components/SimplePagination";
@@ -24,6 +26,7 @@ import { Paths } from "@app/Routes";
 import { formatDate } from "@app/utils/utils";
 
 import { TdWithFocusStatus } from "@app/components/TdWithFocusStatus";
+import { CvssVersionBadge } from "./components/CvssVersionBadge";
 import { SbomsCount } from "./components/SbomsCount";
 import { VulnerabilitySearchContext } from "./vulnerability-context";
 
@@ -115,14 +118,21 @@ export const VulnerabilityTable: React.FC = () => {
                       )}
                     </TdWithFocusStatus>
                     <Td width={10} {...getTdProps({ columnKey: "severity" })}>
-                      <SeverityShieldAndText
-                        value={extendedSeverityFromSeverity(
-                          item.base_score?.severity,
-                        )}
-                        score={item.base_score?.score ?? null}
-                        showLabel
-                        showScore
-                      />
+                      <Flex
+                        alignItems={{ default: "alignItemsCenter" }}
+                        gap={{ default: "gapSm" }}
+                        flexWrap={{ default: "nowrap" }}
+                      >
+                        <SeverityShieldAndText
+                          value={extendedSeverityFromSeverity(
+                            item.base_score?.severity,
+                          )}
+                          score={item.base_score?.score ?? null}
+                          showLabel
+                          showScore
+                        />
+                        <CvssVersionBadge version={item.base_score?.type} />
+                      </Flex>
                     </Td>
                     <Td width={10} {...getTdProps({ columnKey: "published" })}>
                       {formatDate(item.published)}

--- a/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
+++ b/client/src/app/pages/vulnerability-list/vulnerability-table.tsx
@@ -55,7 +55,7 @@ export const VulnerabilityTable: React.FC = () => {
                 {...getThProps({ columnKey: "severity" })}
                 info={{
                   tooltip:
-                    "The Common Vulnerability Scoring System measuring the severity of security flaws.",
+                    "Scores shown are the original CVSS records from the CVE Project. Refer to the SBOM view for product-specific impact assessments.",
                 }}
               />
               <Th {...getThProps({ columnKey: "published" })} />

--- a/client/src/mocks/fileMock.ts
+++ b/client/src/mocks/fileMock.ts
@@ -1,0 +1,1 @@
+export default "test-file-stub";

--- a/client/src/mocks/styleMock.ts
+++ b/client/src/mocks/styleMock.ts
@@ -1,0 +1,1 @@
+export default {};


### PR DESCRIPTION
JIRA: [TC-4091](https://redhat.atlassian.net/browse/TC-4091)

## Changes

**Tooltip text**:
<img width="1771" height="1141" alt="image" src="https://github.com/user-attachments/assets/9efcd9b8-dcb7-46e0-a8e3-2f00b9134933" />

**CVSS Version Badges**:
<img width="1771" height="1141" alt="image" src="https://github.com/user-attachments/assets/6a1aa0a1-f201-4b0b-a25c-def15e1bf9c5" />


[TC-4091]: https://redhat.atlassian.net/browse/TC-4091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Display CVSS version information alongside vulnerability severity scores in the vulnerabilities table and clarify the CVSS tooltip description.

New Features:
- Show a compact CVSS version badge next to each vulnerability severity score in the vulnerabilities table.

Enhancements:
- Update the severity column tooltip to clarify that CVSS scores come from original CVE Project records and that SBOM view provides product-specific impact.

Tests:
- Add unit tests and supporting mocks for the new CVSS version badge component.