### PR TITLE
fix: avoid bundler to load all icons

### DIFF
--- a/client/src/app/api/model-utils.ts
+++ b/client/src/app/api/model-utils.ts
@@ -1,14 +1,12 @@
 import type React from "react";
 
 import type { LabelProps, ProgressProps } from "@patternfly/react-core";
-import {
-  SeverityCriticalIcon,
-  SeverityImportantIcon,
-  SeverityMinorIcon,
-  SeverityModerateIcon,
-  SeverityNoneIcon,
-  SeverityUndefinedIcon,
-} from "@patternfly/react-icons";
+import SeverityCriticalIcon from "@patternfly/react-icons/dist/esm/icons/severity-critical-icon";
+import SeverityImportantIcon from "@patternfly/react-icons/dist/esm/icons/severity-important-icon";
+import SeverityMinorIcon from "@patternfly/react-icons/dist/esm/icons/severity-minor-icon";
+import SeverityModerateIcon from "@patternfly/react-icons/dist/esm/icons/severity-moderate-icon";
+import SeverityNoneIcon from "@patternfly/react-icons/dist/esm/icons/severity-none-icon";
+import SeverityUndefinedIcon from "@patternfly/react-icons/dist/esm/icons/severity-undefined-icon";
 import {
   t_global_icon_color_severity_critical_default as criticalColor,
   t_global_icon_color_severity_important_default as importantColor,

--- a/client/src/app/components/Autocomplete/Autocomplete.tsx
+++ b/client/src/app/components/Autocomplete/Autocomplete.tsx
@@ -15,7 +15,7 @@ import {
   SelectList,
   SelectOption,
 } from "@patternfly/react-core";
-import { ExclamationCircleIcon } from "@patternfly/react-icons";
+import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
 
 import { getString } from "@app/utils/utils";
 

--- a/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
+++ b/client/src/app/components/FilterToolbar/MultiselectFilterControl.tsx
@@ -15,7 +15,7 @@ import {
   ToolbarFilter,
   type ToolbarLabel,
 } from "@patternfly/react-core";
-import { TimesIcon } from "@patternfly/react-icons";
+import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
 
 import type { IFilterControlProps } from "./FilterControl";
 import type {


### PR DESCRIPTION
###  import { TimesIcon } from "@patternfly/react-icons";

The bundler has to load and parse that barrel file, which pulls in references to all ~1,000 icons. Whether those unused icons end up in the final bundle depends on how well tree-shaking

works — and in practice it's fragile (side effects, CommonJS fallbacks, or bundler limitations can defeat it).

###  import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
With the direct path:

The bundler loads exactly one small file containing one icon. There's nothing to tree-shake because nothing extra was imported in the first place.

This PR also aligns the Icon imports to the Examples from the official Patternfly website

## Summary by Sourcery

Enhancements:
- Switch PatternFly icon imports from the package barrel to per-icon module paths to reduce unnecessary bundle loading.