### PR TITLE
feat: add a read-only mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ test-results/
 managed_context/
 test_suite_analysis/
 .claude/settings.local.json
+.serena/
+.playwright-mcp/

--- a/client/rsbuild.config.ts
+++ b/client/rsbuild.config.ts
@@ -161,6 +161,10 @@ export default defineConfig({
         target: TRUSTIFICATION_ENV.TRUSTIFY_API_URL || "http://localhost:8080",
         changeOrigin: true,
       },
+      "/.well-known/trustify": {
+        target: TRUSTIFICATION_ENV.TRUSTIFY_API_URL || "http://localhost:8080",
+        changeOrigin: true,
+      },
     },
   },
 });

--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider, type ThemeMode } from "tsd-ui";
 import { useLocalStorage } from "@app/hooks/useStorage";
 
 import { NotificationsProvider } from "./components/NotificationsContext";
+import { ReadOnlyProvider } from "./components/ReadOnlyContext";
 import { DefaultLayout } from "./layout";
 
 import "@patternfly/patternfly/patternfly.css";
@@ -23,11 +24,13 @@ const App: React.FC = () => {
 
   return (
     <ThemeProvider mode={mode} setMode={setMode}>
-      <NotificationsProvider>
-        <DefaultLayout>
-          <Outlet />
-        </DefaultLayout>
-      </NotificationsProvider>
+      <ReadOnlyProvider>
+        <NotificationsProvider>
+          <DefaultLayout>
+            <Outlet />
+          </DefaultLayout>
+        </NotificationsProvider>
+      </ReadOnlyProvider>
     </ThemeProvider>
   );
 };

--- a/client/src/app/api/trustifyInfo.ts
+++ b/client/src/app/api/trustifyInfo.ts
@@ -1,0 +1,6 @@
+import type { InfoResponse } from "@app/client";
+
+// Extends the generated type until the backend OpenAPI spec includes readOnly
+export type TrustifyInfo = InfoResponse & {
+  readOnly?: boolean;
+};

--- a/client/src/app/axios-config/apiInit.test.ts
+++ b/client/src/app/axios-config/apiInit.test.ts
@@ -1,0 +1,80 @@
+import { queryClient } from "@app/queries/config";
+import { TrustifyInfoQueryKey } from "@app/queries/trustifyInfo";
+
+import { readOnlyRejectionHandler } from "./apiInit";
+
+jest.mock("@app/queries/config", () => ({
+  queryClient: {
+    invalidateQueries: jest.fn(),
+  },
+}));
+
+jest.mock("@app/queries/trustifyInfo", () => ({
+  TrustifyInfoQueryKey: "trustifyInfo",
+}));
+
+jest.mock("@app/Constants", () => ({
+  isAuthRequired: false,
+}));
+
+jest.mock("@app/client/client", () => ({
+  createClient: jest.fn(() => ({})),
+}));
+
+jest.mock("@app/oidc", () => ({
+  OIDC_CLIENT_ID: "test",
+  OIDC_SERVER_URL: "http://localhost",
+  oidcClientSettings: {},
+  oidcSignoutArgs: {},
+}));
+
+const mockInvalidateQueries =
+  queryClient.invalidateQueries as jest.MockedFunction<
+    typeof queryClient.invalidateQueries
+  >;
+
+describe("readOnlyRejectionHandler", () => {
+  beforeEach(() => {
+    mockInvalidateQueries.mockClear();
+  });
+
+  it("invalidates trustify info query on 503 ReadOnly response", async () => {
+    const error = {
+      response: { status: 503, data: { error: "ReadOnly" } },
+    };
+
+    await expect(readOnlyRejectionHandler(error)).rejects.toBe(error);
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: [TrustifyInfoQueryKey],
+    });
+  });
+
+  it("does not invalidate on a regular 503 without ReadOnly error", async () => {
+    const error = {
+      response: { status: 503, data: { message: "Service Unavailable" } },
+    };
+
+    await expect(readOnlyRejectionHandler(error)).rejects.toBe(error);
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it("does not invalidate on non-503 errors", async () => {
+    const error = {
+      response: { status: 500, data: { error: "InternalError" } },
+    };
+
+    await expect(readOnlyRejectionHandler(error)).rejects.toBe(error);
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it("still rejects the error so mutation onError handlers fire", async () => {
+    const error = {
+      response: { status: 503, data: { error: "ReadOnly" } },
+    };
+
+    await expect(readOnlyRejectionHandler(error)).rejects.toBe(error);
+  });
+});

--- a/client/src/app/axios-config/apiInit.ts
+++ b/client/src/app/axios-config/apiInit.ts
@@ -10,6 +10,8 @@ import {
 
 import { createClient } from "@app/client/client";
 import { isAuthRequired } from "@app/Constants";
+import { queryClient } from "@app/queries/config";
+import { TrustifyInfoQueryKey } from "@app/queries/trustifyInfo";
 
 export const client = createClient({
   // set default base url for requests
@@ -28,7 +30,20 @@ function getUser() {
   return User.fromStorageString(oidcStorage);
 }
 
+/** Detects 503 "ReadOnly" responses and invalidates the trustify info cache. */
+export const readOnlyRejectionHandler = (error: unknown) => {
+  const resp = (
+    error as { response?: { status?: number; data?: { error?: string } } }
+  ).response;
+  if (resp?.status === 503 && resp?.data?.error === "ReadOnly") {
+    queryClient.invalidateQueries({ queryKey: [TrustifyInfoQueryKey] });
+  }
+  return Promise.reject(error);
+};
+
 export const initInterceptors = () => {
+  axios.interceptors.response.use(undefined, readOnlyRejectionHandler);
+
   if (!isAuthRequired) {
     return;
   }

--- a/client/src/app/components/ReadOnlyButton.tsx
+++ b/client/src/app/components/ReadOnlyButton.tsx
@@ -1,0 +1,20 @@
+import type React from "react";
+
+import { Button, type ButtonProps, Tooltip } from "@patternfly/react-core";
+
+import { READ_ONLY_TOOLTIP, useReadOnlyContext } from "./ReadOnlyContext";
+
+/** Button that is automatically aria-disabled with a tooltip when the instance is in read-only mode. */
+export const ReadOnlyButton: React.FC<ButtonProps> = (props) => {
+  const { isReadOnly } = useReadOnlyContext();
+
+  if (isReadOnly) {
+    return (
+      <Tooltip content={READ_ONLY_TOOLTIP}>
+        <Button {...props} isAriaDisabled />
+      </Tooltip>
+    );
+  }
+
+  return <Button {...props} />;
+};

--- a/client/src/app/components/ReadOnlyContext.test.tsx
+++ b/client/src/app/components/ReadOnlyContext.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { ReadOnlyProvider, useReadOnlyContext } from "./ReadOnlyContext";
+
+import * as trustifyInfoModule from "@app/queries/trustifyInfo";
+
+jest.mock("@app/queries/trustifyInfo");
+
+const mockedUseFetchTrustifyInfo =
+  trustifyInfoModule.useFetchTrustifyInfo as jest.MockedFunction<
+    typeof trustifyInfoModule.useFetchTrustifyInfo
+  >;
+
+const ReadOnlyConsumer: React.FC = () => {
+  const { isReadOnly, isLoading } = useReadOnlyContext();
+  return (
+    <div>
+      <span data-testid="read-only">{String(isReadOnly)}</span>
+      <span data-testid="loading">{String(isLoading)}</span>
+    </div>
+  );
+};
+
+const renderWithProvider = () => {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ReadOnlyProvider>
+        <ReadOnlyConsumer />
+      </ReadOnlyProvider>
+    </QueryClientProvider>,
+  );
+};
+
+describe("ReadOnlyContext", () => {
+  it("provides isReadOnly=true when the endpoint returns readOnly: true", () => {
+    mockedUseFetchTrustifyInfo.mockReturnValue({
+      trustifyInfo: { version: "0.5.0", readOnly: true },
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProvider();
+
+    expect(screen.getByTestId("read-only")).toHaveTextContent("true");
+    expect(screen.getByTestId("loading")).toHaveTextContent("false");
+  });
+
+  it("provides isReadOnly=false when the endpoint returns readOnly: false", () => {
+    mockedUseFetchTrustifyInfo.mockReturnValue({
+      trustifyInfo: { version: "0.5.0", readOnly: false },
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProvider();
+
+    expect(screen.getByTestId("read-only")).toHaveTextContent("false");
+  });
+
+  it("defaults to isReadOnly=false when the field is absent", () => {
+    mockedUseFetchTrustifyInfo.mockReturnValue({
+      trustifyInfo: { version: "0.5.0" },
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProvider();
+
+    expect(screen.getByTestId("read-only")).toHaveTextContent("false");
+  });
+
+  it("treats isReadOnly as true while loading", () => {
+    mockedUseFetchTrustifyInfo.mockReturnValue({
+      trustifyInfo: undefined,
+      isLoading: true,
+      error: null,
+    });
+
+    renderWithProvider();
+
+    expect(screen.getByTestId("read-only")).toHaveTextContent("true");
+    expect(screen.getByTestId("loading")).toHaveTextContent("true");
+  });
+
+  it("defaults to isReadOnly=false when the fetch errors", () => {
+    mockedUseFetchTrustifyInfo.mockReturnValue({
+      trustifyInfo: undefined,
+      isLoading: false,
+      error: new Error("network error"),
+    });
+
+    renderWithProvider();
+
+    expect(screen.getByTestId("read-only")).toHaveTextContent("false");
+  });
+});

--- a/client/src/app/components/ReadOnlyContext.tsx
+++ b/client/src/app/components/ReadOnlyContext.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+
+import { useFetchTrustifyInfo } from "@app/queries/trustifyInfo";
+
+interface IReadOnlyContext {
+  isReadOnly: boolean;
+  isLoading: boolean;
+}
+
+const ReadOnlyContext = React.createContext<IReadOnlyContext>({
+  isReadOnly: false,
+  isLoading: true,
+});
+
+interface IReadOnlyProvider {
+  children: React.ReactNode;
+}
+
+/** Provides the server's read-only mode flag to the component tree. */
+export const ReadOnlyProvider: React.FunctionComponent<IReadOnlyProvider> = ({
+  children,
+}) => {
+  const { trustifyInfo, isLoading } = useFetchTrustifyInfo();
+  const isReadOnly = isLoading || (trustifyInfo?.readOnly ?? false);
+
+  return (
+    <ReadOnlyContext.Provider value={{ isReadOnly, isLoading }}>
+      {children}
+    </ReadOnlyContext.Provider>
+  );
+};
+
+export const useReadOnlyContext = () => React.useContext(ReadOnlyContext);
+
+export const READ_ONLY_TOOLTIP = "Not available in read-only mode";
+
+/** Returns props that disable an ActionsColumn item when read-only, including a click guard. */
+export const readOnlyActionProps = (isReadOnly: boolean) =>
+  isReadOnly
+    ? {
+        isAriaDisabled: true,
+        tooltipProps: { content: READ_ONLY_TOOLTIP },
+        onClick: () => {},
+      }
+    : {};

--- a/client/src/app/layout/default-layout.test.tsx
+++ b/client/src/app/layout/default-layout.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import * as ReadOnlyContextModule from "@app/components/ReadOnlyContext";
+
+import { DefaultLayout } from "./default-layout";
+
+jest.mock("@app/components/ReadOnlyContext");
+jest.mock("./header", () => ({
+  HeaderApp: () => <div data-testid="header" />,
+}));
+jest.mock("./sidebar", () => ({
+  SidebarApp: () => <div data-testid="sidebar" />,
+}));
+jest.mock("@app/components/Notifications", () => ({
+  Notifications: () => null,
+}));
+jest.mock("@app/components/PageDrawerContext", () => ({
+  PageContentWithDrawerProvider: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div>{children}</div>,
+}));
+jest.mock("@patternfly/react-core", () => {
+  const actual = jest.requireActual("@patternfly/react-core");
+  return {
+    ...actual,
+    Page: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="page">{children}</div>
+    ),
+    SkipToContent: () => null,
+  };
+});
+
+const mockedUseReadOnlyContext =
+  ReadOnlyContextModule.useReadOnlyContext as jest.MockedFunction<
+    typeof ReadOnlyContextModule.useReadOnlyContext
+  >;
+
+const renderLayout = () => {
+  return render(
+    <DefaultLayout>
+      <div data-testid="page-content">Page content</div>
+    </DefaultLayout>,
+  );
+};
+
+describe("DefaultLayout", () => {
+  it("shows a read-only banner when isReadOnly is true", () => {
+    mockedUseReadOnlyContext.mockReturnValue({
+      isReadOnly: true,
+      isLoading: false,
+    });
+
+    renderLayout();
+
+    expect(screen.getByText(/running in read-only mode/i)).toBeInTheDocument();
+    expect(screen.getByTestId("page-content")).toBeInTheDocument();
+  });
+
+  it("does not show a banner when isReadOnly is false", () => {
+    mockedUseReadOnlyContext.mockReturnValue({
+      isReadOnly: false,
+      isLoading: false,
+    });
+
+    renderLayout();
+
+    expect(
+      screen.queryByText(/running in read-only mode/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("page-content")).toBeInTheDocument();
+  });
+});

--- a/client/src/app/layout/default-layout.tsx
+++ b/client/src/app/layout/default-layout.tsx
@@ -1,9 +1,17 @@
 import type React from "react";
 
-import { Page, SkipToContent } from "@patternfly/react-core";
+import {
+  Banner,
+  Flex,
+  FlexItem,
+  Page,
+  SkipToContent,
+} from "@patternfly/react-core";
+import InfoCircleIcon from "@patternfly/react-icons/dist/esm/icons/info-circle-icon";
 
 import { Notifications } from "@app/components/Notifications";
 import { PageContentWithDrawerProvider } from "@app/components/PageDrawerContext";
+import { useReadOnlyContext } from "@app/components/ReadOnlyContext";
 import { HeaderApp } from "./header";
 import { SidebarApp } from "./sidebar";
 
@@ -12,6 +20,7 @@ interface DefaultLayoutProps {
 }
 
 export const DefaultLayout: React.FC<DefaultLayoutProps> = ({ children }) => {
+  const { isReadOnly } = useReadOnlyContext();
   const pageId = "main-content-page-layout-horizontal-nav";
   const PageSkipToContent = (
     <SkipToContent href={`#${pageId}`}>Skip to content</SkipToContent>
@@ -25,6 +34,27 @@ export const DefaultLayout: React.FC<DefaultLayoutProps> = ({ children }) => {
       skipToContent={PageSkipToContent}
       mainContainerId={pageId}
     >
+      {isReadOnly && (
+        <Banner
+          isSticky
+          status="info"
+          screenReaderText="Info banner: application is in read-only mode"
+        >
+          <Flex
+            justifyContent={{ default: "justifyContentCenter" }}
+            alignItems={{ default: "alignItemsCenter" }}
+            gap={{ default: "gapSm" }}
+          >
+            <FlexItem>
+              <InfoCircleIcon />
+            </FlexItem>
+            <FlexItem>
+              This instance is running in read-only mode. Uploads, imports, and
+              other modifications are disabled.
+            </FlexItem>
+          </Flex>
+        </Banner>
+      )}
       <PageContentWithDrawerProvider>
         {children}
         <Notifications />

--- a/client/src/app/pages/advisory-details/overview.tsx
+++ b/client/src/app/pages/advisory-details/overview.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import prettyBytes from "pretty-bytes";
 
 import {
-  Button,
   ButtonVariant,
   Card,
   CardBody,
@@ -22,6 +21,7 @@ import PenIcon from "@patternfly/react-icons/dist/esm/icons/pen-icon";
 
 import type { AdvisorySummary } from "@app/client";
 import { LabelsAsList } from "@app/components/LabelsAsList";
+import { ReadOnlyButton } from "@app/components/ReadOnlyButton";
 import { formatDate } from "@app/utils/utils";
 
 import { AdvisoryEditLabelsForm } from "../advisory-list/components/AdvisoryEditLabelsForm";
@@ -66,7 +66,7 @@ export const Overview: React.FC<InfoProps> = ({ advisory }) => {
                 <DescriptionListGroup>
                   <DescriptionListTerm>
                     Labels {""}
-                    <Button
+                    <ReadOnlyButton
                       variant={ButtonVariant.link}
                       size="sm"
                       icon={<PenIcon />}
@@ -74,7 +74,7 @@ export const Overview: React.FC<InfoProps> = ({ advisory }) => {
                       onClick={() => setShowEditLabels(true)}
                     >
                       Edit
-                    </Button>
+                    </ReadOnlyButton>
                   </DescriptionListTerm>
                   <DescriptionListDescription>
                     <Card isCompact>

--- a/client/src/app/pages/advisory-list/advisory-table.tsx
+++ b/client/src/app/pages/advisory-list/advisory-table.tsx
@@ -28,6 +28,10 @@ import type { AdvisorySummary } from "@app/client";
 import { ConfirmDialog } from "@app/components/ConfirmDialog.tsx";
 import { LabelsAsList } from "@app/components/LabelsAsList.tsx";
 import { NotificationsContext } from "@app/components/NotificationsContext.tsx";
+import {
+  readOnlyActionProps,
+  useReadOnlyContext,
+} from "@app/components/ReadOnlyContext";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
@@ -46,6 +50,7 @@ import { advisoryDeleteDialogProps } from "@app/Constants";
 
 export const AdvisoryTable: React.FC = () => {
   const { pushNotification } = React.useContext(NotificationsContext);
+  const { isReadOnly } = useReadOnlyContext();
 
   const { isFetching, fetchError, totalItemCount, tableControls } =
     React.useContext(AdvisorySearchContext);
@@ -218,6 +223,7 @@ export const AdvisoryTable: React.FC = () => {
                             onClick: () => {
                               setEditLabelsModalState(item);
                             },
+                            ...readOnlyActionProps(isReadOnly),
                           },
                           {
                             title: "Download",
@@ -234,6 +240,7 @@ export const AdvisoryTable: React.FC = () => {
                             onClick: () => {
                               setAdvisoryToDelete(item);
                             },
+                            ...readOnlyActionProps(isReadOnly),
                           },
                         ]}
                       />

--- a/client/src/app/pages/advisory-list/advisory-toolbar.tsx
+++ b/client/src/app/pages/advisory-list/advisory-toolbar.tsx
@@ -2,14 +2,10 @@ import React from "react";
 
 import { useNavigate } from "react-router-dom";
 
-import {
-  Button,
-  Toolbar,
-  ToolbarContent,
-  ToolbarItem,
-} from "@patternfly/react-core";
+import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 
 import { FilterToolbar } from "@app/components/FilterToolbar";
+import { ReadOnlyButton } from "@app/components/ReadOnlyButton";
 import { SimplePagination } from "@app/components/SimplePagination";
 import { Paths } from "@app/Routes";
 
@@ -43,12 +39,12 @@ export const AdvisoryToolbar: React.FC<AdvisoryToolbarProps> = ({
         {showFilters && <FilterToolbar {...filterToolbarProps} />}
         {showActions && (
           <ToolbarItem>
-            <Button
+            <ReadOnlyButton
               variant="primary"
               onClick={() => navigate(Paths.advisoryUpload)}
             >
               Upload Advisory
-            </Button>
+            </ReadOnlyButton>
           </ToolbarItem>
         )}
         <ToolbarItem {...paginationToolbarItemProps}>

--- a/client/src/app/pages/advisory-upload/advisory-upload.tsx
+++ b/client/src/app/pages/advisory-upload/advisory-upload.tsx
@@ -7,15 +7,21 @@ import {
   Breadcrumb,
   BreadcrumbItem,
   Content,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
   PageSection,
 } from "@patternfly/react-core";
+import LockIcon from "@patternfly/react-icons/dist/esm/icons/lock-icon";
 
+import { DocumentMetadata } from "@app/components/DocumentMetadata";
+import { useReadOnlyContext } from "@app/components/ReadOnlyContext";
 import { UploadFiles } from "@app/components/UploadFiles";
 import { useUploadAdvisory } from "@app/queries/advisories";
 import { Paths } from "@app/Routes";
-import { DocumentMetadata } from "@app/components/DocumentMetadata";
 
 export const AdvisoryUpload: React.FC = () => {
+  const { isReadOnly } = useReadOnlyContext();
   const { uploads, handleUpload, handleRemoveUpload } = useUploadAdvisory();
 
   return (
@@ -29,28 +35,52 @@ export const AdvisoryUpload: React.FC = () => {
           <BreadcrumbItem isActive>Upload Advisory</BreadcrumbItem>
         </Breadcrumb>
       </PageSection>
-      <PageSection>
-        <Content>
-          <Content component="h1">Upload Advisory</Content>
-          <Content component="p">Upload a CSAF, CVE, or OSV Advisory.</Content>
-        </Content>
-      </PageSection>
-      <PageSection>
-        <UploadFiles
-          fileUploadProps={{ "aria-label": "advisory-uploader" }}
-          uploads={uploads}
-          handleUpload={handleUpload}
-          handleRemoveUpload={handleRemoveUpload}
-          extractSuccessMessage={(
-            response: AxiosResponse<{ document_id: string }>,
-          ) => {
-            return `${response.data.document_id} uploaded`;
-          }}
-          extractErrorMessage={(error: AxiosError) =>
-            error.response?.data ? error.message : "Error while uploading file"
-          }
-        />
-      </PageSection>
+      {isReadOnly ? (
+        <PageSection>
+          <EmptyState
+            headingLevel="h1"
+            icon={LockIcon}
+            titleText="Uploads unavailable"
+          >
+            <EmptyStateBody>
+              This instance is running in read-only mode. Uploading advisories
+              is not available.
+            </EmptyStateBody>
+            <EmptyStateFooter>
+              <Link to={Paths.advisories}>Return to advisories</Link>
+            </EmptyStateFooter>
+          </EmptyState>
+        </PageSection>
+      ) : (
+        <>
+          <PageSection>
+            <Content>
+              <Content component="h1">Upload Advisory</Content>
+              <Content component="p">
+                Upload a CSAF, CVE, or OSV Advisory.
+              </Content>
+            </Content>
+          </PageSection>
+          <PageSection>
+            <UploadFiles
+              fileUploadProps={{ "aria-label": "advisory-uploader" }}
+              uploads={uploads}
+              handleUpload={handleUpload}
+              handleRemoveUpload={handleRemoveUpload}
+              extractSuccessMessage={(
+                response: AxiosResponse<{ document_id: string }>,
+              ) => {
+                return `${response.data.document_id} uploaded`;
+              }}
+              extractErrorMessage={(error: AxiosError) =>
+                error.response?.data
+                  ? error.message
+                  : "Error while uploading file"
+              }
+            />
+          </PageSection>
+        </>
+      )}
     </>
   );
 };

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -37,6 +37,10 @@ import {
 } from "@app/components/ConfirmDialog";
 import { NotificationsContext } from "@app/components/NotificationsContext";
 import {
+  readOnlyActionProps,
+  useReadOnlyContext,
+} from "@app/components/ReadOnlyContext";
+import {
   useFetchImporterReports,
   useFetchImporters,
   useUpdateImporterMutation,
@@ -83,6 +87,7 @@ const getImporterStatus = (importer: Importer): ImporterStatus => {
 
 export const ImporterList: React.FC = () => {
   const { pushNotification } = React.useContext(NotificationsContext);
+  const { isReadOnly } = useReadOnlyContext();
 
   // Actions that each row can trigger
   type RowAction = "enable" | "disable" | "run";
@@ -392,6 +397,7 @@ export const ImporterList: React.FC = () => {
                                       onClick: () => {
                                         prepareActionOnRow("enable", item);
                                       },
+                                      ...readOnlyActionProps(isReadOnly),
                                     },
                                   ]
                                 : [
@@ -400,13 +406,17 @@ export const ImporterList: React.FC = () => {
                                       onClick: () => {
                                         prepareActionOnRow("run", item);
                                       },
-                                      isDisabled: importerStatus === "running",
+                                      isAriaDisabled:
+                                        isReadOnly ||
+                                        importerStatus === "running",
+                                      ...readOnlyActionProps(isReadOnly),
                                     },
                                     {
                                       title: "Disable",
                                       onClick: () => {
                                         prepareActionOnRow("disable", item);
                                       },
+                                      ...readOnlyActionProps(isReadOnly),
                                     },
                                   ]),
                             ]}

--- a/client/src/app/pages/sbom-details/overview.tsx
+++ b/client/src/app/pages/sbom-details/overview.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import prettyBytes from "pretty-bytes";
 
 import {
-  Button,
   ButtonVariant,
   Card,
   CardBody,
@@ -24,6 +23,7 @@ import PenIcon from "@patternfly/react-icons/dist/esm/icons/pen-icon";
 
 import type { SbomSummary } from "@app/client";
 import { LabelsAsList } from "@app/components/LabelsAsList";
+import { ReadOnlyButton } from "@app/components/ReadOnlyButton";
 import { formatDate } from "@app/utils/utils";
 
 import { SBOMEditLabelsForm } from "../sbom-list/components/SBOMEditLabelsForm";
@@ -116,7 +116,7 @@ export const Overview: React.FC<InfoProps> = ({ sbom }) => {
                 <DescriptionListGroup>
                   <DescriptionListTerm>
                     Labels {""}
-                    <Button
+                    <ReadOnlyButton
                       variant={ButtonVariant.link}
                       size="sm"
                       icon={<PenIcon />}
@@ -124,7 +124,7 @@ export const Overview: React.FC<InfoProps> = ({ sbom }) => {
                       onClick={() => setShowEditLabels(true)}
                     >
                       Edit
-                    </Button>
+                    </ReadOnlyButton>
                   </DescriptionListTerm>
                   <DescriptionListDescription>
                     <Card isCompact>

--- a/client/src/app/pages/sbom-groups/sbom-groups-table.tsx
+++ b/client/src/app/pages/sbom-groups/sbom-groups-table.tsx
@@ -17,6 +17,10 @@ import type { Group } from "@app/client";
 import { ConfirmDialog } from "@app/components/ConfirmDialog.tsx";
 import { LoadingWrapper } from "@app/components/LoadingWrapper";
 import { NotificationsContext } from "@app/components/NotificationsContext.tsx";
+import {
+  readOnlyActionProps,
+  useReadOnlyContext,
+} from "@app/components/ReadOnlyContext";
 import { SimplePagination } from "@app/components/SimplePagination";
 import { TableCellError } from "@app/components/TableCellError";
 import { ConditionalTableBody } from "@app/components/TableControls";
@@ -152,15 +156,19 @@ const SbomGroupRow: React.FC<{
     isExpanded || hasBeenExpanded.current,
   );
 
+  const { isReadOnly } = useReadOnlyContext();
+
   const actions: IAction[] = [
     {
       title: "Edit",
       onClick: () => onEdit(node),
+      ...readOnlyActionProps(isReadOnly),
     },
     {
       title: "Delete",
       onClick: () => onDelete(node),
-      isDisabled: !!node.number_of_groups,
+      isDisabled: !isReadOnly && !!node.number_of_groups,
+      ...readOnlyActionProps(isReadOnly),
     },
   ];
 

--- a/client/src/app/pages/sbom-groups/sbom-groups-toolbar.tsx
+++ b/client/src/app/pages/sbom-groups/sbom-groups-toolbar.tsx
@@ -1,13 +1,9 @@
 import React from "react";
 
-import {
-  Button,
-  Toolbar,
-  ToolbarContent,
-  ToolbarItem,
-} from "@patternfly/react-core";
+import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
 
 import { FilterToolbar } from "@app/components/FilterToolbar";
+import { ReadOnlyButton } from "@app/components/ReadOnlyButton";
 import { SimplePagination } from "@app/components/SimplePagination";
 
 import { SbomGroupsContext } from "./sbom-groups-context";
@@ -30,12 +26,12 @@ export const SbomGroupsToolbar: React.FC = () => {
       <ToolbarContent>
         <FilterToolbar {...filterToolbarProps} />
         <ToolbarItem>
-          <Button
+          <ReadOnlyButton
             variant="primary"
             onClick={() => setGroupCreateUpdateModalState("create")}
           >
             Create group
-          </Button>
+          </ReadOnlyButton>
         </ToolbarItem>
         <ToolbarItem {...paginationToolbarItemProps}>
           <SimplePagination

--- a/client/src/app/pages/sbom-list/sbom-table.tsx
+++ b/client/src/app/pages/sbom-list/sbom-table.tsx
@@ -20,6 +20,10 @@ import type { SbomSummary } from "@app/client";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { LabelsAsList } from "@app/components/LabelsAsList";
 import { NotificationsContext } from "@app/components/NotificationsContext";
+import {
+  readOnlyActionProps,
+  useReadOnlyContext,
+} from "@app/components/ReadOnlyContext";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
@@ -42,6 +46,7 @@ import { SbomSearchContext } from "./sbom-context";
 
 export const SbomTable: React.FC = () => {
   const { pushNotification } = React.useContext(NotificationsContext);
+  const { isReadOnly } = useReadOnlyContext();
 
   const {
     isFetching,
@@ -227,6 +232,7 @@ export const SbomTable: React.FC = () => {
                             onClick: () => {
                               setEditLabelsModalState(item);
                             },
+                            ...readOnlyActionProps(isReadOnly),
                           },
                           {
                             isSeparator: true,
@@ -251,6 +257,7 @@ export const SbomTable: React.FC = () => {
                             onClick: () => {
                               setSbomToDelete(item);
                             },
+                            ...readOnlyActionProps(isReadOnly),
                           },
                         ]}
                       />

--- a/client/src/app/pages/sbom-list/sbom-toolbar.tsx
+++ b/client/src/app/pages/sbom-list/sbom-toolbar.tsx
@@ -2,16 +2,21 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 
 import {
-  Button,
   DropdownItem,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
+  Tooltip,
 } from "@patternfly/react-core";
 
 import type { Group } from "@app/client";
 import { FilterToolbar } from "@app/components/FilterToolbar";
 import { KebabDropdown } from "@app/components/KebabDropdown";
+import { ReadOnlyButton } from "@app/components/ReadOnlyButton";
+import {
+  READ_ONLY_TOOLTIP,
+  useReadOnlyContext,
+} from "@app/components/ReadOnlyContext";
 import { SimplePagination } from "@app/components/SimplePagination";
 import { ToolbarBulkSelector } from "@app/components/ToolbarBulkSelector";
 import { Paths } from "@app/Routes";
@@ -30,6 +35,7 @@ export const SbomToolbar: React.FC<SbomToolbarProps> = ({
   showActions,
 }) => {
   const navigate = useNavigate();
+  const { isReadOnly } = useReadOnlyContext();
 
   // Create Form Modal
   const [saveGroupModalState, setSaveGroupModalState] = React.useState<
@@ -78,33 +84,40 @@ export const SbomToolbar: React.FC<SbomToolbarProps> = ({
           {showActions && (
             <>
               <ToolbarItem>
-                <Button
+                <ReadOnlyButton
                   variant="primary"
                   onClick={() => setSaveGroupModalState("create")}
                 >
                   Create group
-                </Button>
+                </ReadOnlyButton>
               </ToolbarItem>
               <ToolbarItem>
-                <Button
+                <ReadOnlyButton
                   variant="secondary"
                   isDisabled={selectedItems.length === 0}
                   onClick={() => setIsAddToGroupModalOpen(true)}
                 >
                   Add to group
-                </Button>
+                </ReadOnlyButton>
               </ToolbarItem>
               <ToolbarItem>
                 <KebabDropdown
                   ariaLabel="SBOM actions"
                   dropdownItems={[
-                    <DropdownItem
-                      key="upload-sbom"
-                      component="button"
-                      onClick={() => navigate(Paths.sbomUpload)}
+                    <Tooltip
+                      key="upload-sbom-tooltip"
+                      content={READ_ONLY_TOOLTIP}
+                      trigger={isReadOnly ? "mouseenter focus" : "manual"}
                     >
-                      Upload SBOM
-                    </DropdownItem>,
+                      <DropdownItem
+                        key="upload-sbom"
+                        component="button"
+                        isAriaDisabled={isReadOnly}
+                        onClick={() => navigate(Paths.sbomUpload)}
+                      >
+                        Upload SBOM
+                      </DropdownItem>
+                    </Tooltip>,
                     <DropdownItem
                       key="scan-sbom"
                       component="button"

--- a/client/src/app/pages/sbom-upload/sbom-upload.tsx
+++ b/client/src/app/pages/sbom-upload/sbom-upload.tsx
@@ -7,15 +7,21 @@ import {
   Breadcrumb,
   BreadcrumbItem,
   Content,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
   PageSection,
 } from "@patternfly/react-core";
+import LockIcon from "@patternfly/react-icons/dist/esm/icons/lock-icon";
 
+import { DocumentMetadata } from "@app/components/DocumentMetadata";
+import { useReadOnlyContext } from "@app/components/ReadOnlyContext";
 import { UploadFiles } from "@app/components/UploadFiles";
 import { useUploadSBOM } from "@app/queries/sboms";
 import { Paths } from "@app/Routes";
-import { DocumentMetadata } from "@app/components/DocumentMetadata";
 
 export const SbomUpload: React.FC = () => {
+  const { isReadOnly } = useReadOnlyContext();
   const { uploads, handleUpload, handleRemoveUpload } = useUploadSBOM();
 
   return (
@@ -29,32 +35,54 @@ export const SbomUpload: React.FC = () => {
           <BreadcrumbItem isActive>Upload SBOM</BreadcrumbItem>
         </Breadcrumb>
       </PageSection>
-      <PageSection>
-        <Content>
-          <Content component="h1">Upload SBOM</Content>
-          <Content component="p">
-            Upload a Software Bill of Materials (SBOM) document. We accept
-            CycloneDX versions 1.3, 1.4, 1.5 and 1.6, and System Package Data
-            Exchange (SPDX) versions 2.2, and 2.3.
-          </Content>
-        </Content>
-      </PageSection>
-      <PageSection>
-        <UploadFiles
-          fileUploadProps={{ "aria-label": "sbom-uploader" }}
-          uploads={uploads}
-          handleUpload={handleUpload}
-          handleRemoveUpload={handleRemoveUpload}
-          extractSuccessMessage={(
-            response: AxiosResponse<{ document_id: string }>,
-          ) => {
-            return `${response.data.document_id} uploaded`;
-          }}
-          extractErrorMessage={(error: AxiosError) =>
-            error.response?.data ? error.message : "Error while uploading file"
-          }
-        />
-      </PageSection>
+      {isReadOnly ? (
+        <PageSection>
+          <EmptyState
+            headingLevel="h1"
+            icon={LockIcon}
+            titleText="Uploads unavailable"
+          >
+            <EmptyStateBody>
+              This instance is running in read-only mode. Uploading SBOMs is not
+              available.
+            </EmptyStateBody>
+            <EmptyStateFooter>
+              <Link to={Paths.sboms}>Return to SBOMs</Link>
+            </EmptyStateFooter>
+          </EmptyState>
+        </PageSection>
+      ) : (
+        <>
+          <PageSection>
+            <Content>
+              <Content component="h1">Upload SBOM</Content>
+              <Content component="p">
+                Upload a Software Bill of Materials (SBOM) document. We accept
+                CycloneDX versions 1.3, 1.4, 1.5 and 1.6, and System Package
+                Data Exchange (SPDX) versions 2.2, and 2.3.
+              </Content>
+            </Content>
+          </PageSection>
+          <PageSection>
+            <UploadFiles
+              fileUploadProps={{ "aria-label": "sbom-uploader" }}
+              uploads={uploads}
+              handleUpload={handleUpload}
+              handleRemoveUpload={handleRemoveUpload}
+              extractSuccessMessage={(
+                response: AxiosResponse<{ document_id: string }>,
+              ) => {
+                return `${response.data.document_id} uploaded`;
+              }}
+              extractErrorMessage={(error: AxiosError) =>
+                error.response?.data
+                  ? error.message
+                  : "Error while uploading file"
+              }
+            />
+          </PageSection>
+        </>
+      )}
     </>
   );
 };

--- a/client/src/app/queries/trustifyInfo.ts
+++ b/client/src/app/queries/trustifyInfo.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+
+import type { TrustifyInfo } from "@app/api/trustifyInfo";
+import { client } from "@app/axios-config/apiInit";
+import { info } from "@app/client";
+
+export const TrustifyInfoQueryKey = "trustifyInfo";
+
+/** Fetches instance metadata from GET /.well-known/trustify (cached for the session lifetime). */
+export const useFetchTrustifyInfo = () => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: [TrustifyInfoQueryKey],
+    queryFn: () => info({ client }),
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    retry: 3,
+  });
+
+  return {
+    trustifyInfo: data?.data as TrustifyInfo | undefined,
+    isLoading,
+    error,
+  };
+};

--- a/server/src/proxies.js
+++ b/server/src/proxies.js
@@ -66,6 +66,12 @@ export const proxyMap = {
       },
     },
   },
+  wellKnown: {
+    pathFilter: "/.well-known/trustify",
+    target: TRUSTIFICATION_ENV.TRUSTIFY_API_URL || "http://localhost:8080",
+    logger,
+    changeOrigin: true,
+  },
   openapi: {
     pathFilter: "/openapi",
     target: TRUSTIFICATION_ENV.TRUSTIFY_API_URL || "http://localhost:8080",


### PR DESCRIPTION
This includes a banner and removing some buttons.

Also see: https://github.com/guacsec/trustify/pull/2337
Also see: TC-4162

## Summary by Sourcery

Introduce a client-wide read-only mode surfaced from server metadata and gate write operations behind it.

New Features:
- Add a ReadOnlyContext backed by a trustify info endpoint to expose the server read-only flag across the React app.
- Display a global banner when the instance is in read-only mode to inform users that modifications are disabled.
- Fetch instance metadata via a new /.well-known/trustify endpoint, wired through client and dev-server proxy configuration.

Enhancements:
- Hide or disable upload, group management, label editing, delete, and importer control actions across SBOM and advisory workflows when in read-only mode.