### PR TITLE
tests: Replace /api/v3 for /api/v2 endpoints to prevent failures on downstream builds

### DIFF
--- a/e2e/tests/api/features/advisory.ts
+++ b/e2e/tests/api/features/advisory.ts
@@ -9,7 +9,7 @@ test.describe("Advisory sorting validation", () => {
   test("Sort advisories by ID ascending", async ({ axios }) => {
     const items = await testBasicSort(
       axios,
-      "/api/v3/advisory",
+      "/api/v2/advisory",
       "identifier",
       "asc",
     );
@@ -19,7 +19,7 @@ test.describe("Advisory sorting validation", () => {
   test("Sort advisories by ID descending", async ({ axios }) => {
     const items = await testBasicSort(
       axios,
-      "/api/v3/advisory",
+      "/api/v2/advisory",
       "identifier",
       "desc",
     );
@@ -29,7 +29,7 @@ test.describe("Advisory sorting validation", () => {
   test("Sort advisories by modified date ascending", async ({ axios }) => {
     const items = await testBasicSort(
       axios,
-      "/api/v3/advisory",
+      "/api/v2/advisory",
       "modified",
       "asc",
     );
@@ -39,7 +39,7 @@ test.describe("Advisory sorting validation", () => {
   test("Sort advisories by modified date descending", async ({ axios }) => {
     const items = await testBasicSort(
       axios,
-      "/api/v3/advisory",
+      "/api/v2/advisory",
       "modified",
       "desc",
     );

--- a/e2e/tests/api/features/vulnerability.ts
+++ b/e2e/tests/api/features/vulnerability.ts
@@ -3,7 +3,7 @@ import {
   testBasicSort,
   validateDateSorting,
   validateNumericSorting,
-  validateSortDirectionDiffers,
+  validateStringSorting,
 } from "../helpers/sorting-helpers";
 
 test.skip("Filter Vulnerabilities by severity - vanilla", async ({ axios }) => {
@@ -29,22 +29,29 @@ test.skip("Filter Vulnerabilities by severity - vanilla", async ({ axios }) => {
 
 test.describe("Vulnerability sorting validation", () => {
   test("Sort vulnerabilities by ID ascending", async ({ axios }) => {
-    await testBasicSort(axios, "/api/v3/vulnerability", "id", "asc");
+    const items = await testBasicSort(
+      axios,
+      "/api/v2/vulnerability",
+      "id",
+      "asc",
+    );
+    validateStringSorting(items, "identifier", "ascending");
   });
 
   test("Sort vulnerabilities by ID descending", async ({ axios }) => {
-    await validateSortDirectionDiffers(
+    const items = await testBasicSort(
       axios,
-      "/api/v3/vulnerability",
+      "/api/v2/vulnerability",
       "id",
-      (item) => item.identifier,
+      "desc",
     );
+    validateStringSorting(items, "identifier", "descending");
   });
 
   test("Sort vulnerabilities by CVSS score ascending", async ({ axios }) => {
     const items = await testBasicSort(
       axios,
-      "/api/v3/vulnerability",
+      "/api/v2/vulnerability",
       "base_score",
       "asc",
     );
@@ -54,7 +61,7 @@ test.describe("Vulnerability sorting validation", () => {
   test("Sort vulnerabilities by CVSS score descending", async ({ axios }) => {
     const items = await testBasicSort(
       axios,
-      "/api/v3/vulnerability",
+      "/api/v2/vulnerability",
       "base_score",
       "desc",
     );
@@ -66,7 +73,7 @@ test.describe("Vulnerability sorting validation", () => {
   }) => {
     const items = await testBasicSort(
       axios,
-      "/api/v3/vulnerability",
+      "/api/v2/vulnerability",
       "published",
       "asc",
     );
@@ -78,7 +85,7 @@ test.describe("Vulnerability sorting validation", () => {
   }) => {
     const items = await testBasicSort(
       axios,
-      "/api/v3/vulnerability",
+      "/api/v2/vulnerability",
       "published",
       "desc",
     );


### PR DESCRIPTION
## Summary by Sourcery

Update e2e API sorting tests to target the v2 advisory and vulnerability endpoints and align assertions with the v2 response shape.

Tests:
- Switch vulnerability and advisory sorting tests from /api/v3 to /api/v2 endpoints.
- Adapt vulnerability ID sorting checks to use string-based sorting validation on the identifier field.