### PR TITLE
tests: Allow e2e to use injected token (cli) for UI access

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -38,12 +38,14 @@ General:
 
 For UI tests:
 
-| Variable                 | Default Value         | Description                              |
-|--------------------------|-----------------------|------------------------------------------|
-| TRUSTIFY_UI_URL          | http://localhost:3000 | The UI URL                               |
-| AUTH_REQUIRED            | true                  | Whether or not auth is enabled in the UI |
-| PLAYWRIGHT_AUTH_USER     | admin                 | User name to be used when authenticating |
-| PLAYWRIGHT_AUTH_PASSWORD | admin                 | Password to be used when authenticating  |
+| Variable                 | Default Value         | Description                                                                                                                   |
+|--------------------------|-----------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| TRUSTIFY_UI_URL          | http://localhost:3000 | The UI URL                                                                                                                    |
+| AUTH_REQUIRED            | true                  | Whether or not auth is enabled in the UI                                                                                      |
+| PLAYWRIGHT_AUTH_USER     | admin                 | User name to be used when authenticating (form mode)                                                                          |
+| PLAYWRIGHT_AUTH_PASSWORD | admin                 | Password to be used when authenticating (form mode)                                                                           |
+| PLAYWRIGHT_UI_AUTH_MODE  | form                  | Auth mode: `form` (fill login form) or `token_injection` (client credentials)                                                 |
+| PLAYWRIGHT_AUTH_SCOPE    |                       | OAuth2 scope for client_credentials token requests (required for token_injection, for EntraID e.g. `api://<app-id>/.default`) |
 
 For API tests:
 
@@ -54,6 +56,7 @@ For API tests:
 | PLAYWRIGHT_AUTH_URL           |                                                 | OIDC Base URL, e.g. `http://localhost:9090/realms/trustd`. If not set, we will try to discover it from `index.html` |
 | PLAYWRIGHT_AUTH_CLIENT_ID     | cli                                             | OIDC Client ID                                                                                                      |
 | PLAYWRIGHT_AUTH_CLIENT_SECRET | secret                                          | OIDC Client Secret                                                                                                  |
+| PLAYWRIGHT_AUTH_SCOPE         |                                                 | OAuth2 scope for client_credentials (required for Entra ID, e.g. `api://<app-id>/.default`)                         |
 
 ## Available Commands
 

--- a/e2e/tests/api/fixtures.ts
+++ b/e2e/tests/api/fixtures.ts
@@ -6,6 +6,7 @@ import {
   AUTH_CLIENT_ID,
   AUTH_CLIENT_SECRET,
   AUTH_REQUIRED,
+  AUTH_SCOPE,
   AUTH_URL,
   logger,
   TRUSTIFY_API_URL,
@@ -53,6 +54,9 @@ const getToken = async (baseURL?: string) => {
   data.append("grant_type", "client_credentials");
   data.append("client_id", AUTH_CLIENT_ID);
   data.append("client_secret", AUTH_CLIENT_SECRET);
+  if (AUTH_SCOPE) {
+    data.append("scope", AUTH_SCOPE);
+  }
 
   return await axios.post<TokenResponse>(tokenServiceURL, data, {
     headers: {

--- a/e2e/tests/common/constants.ts
+++ b/e2e/tests/common/constants.ts
@@ -5,18 +5,22 @@ export const TRUSTIFY_API_URL =
   "http://localhost:8080/";
 
 /**
- * API only environment variables
+ * Shared auth environment variables (used by both API and UI tests)
  */
 export const AUTH_URL = process.env.PLAYWRIGHT_AUTH_URL;
 export const AUTH_CLIENT_ID = process.env.PLAYWRIGHT_AUTH_CLIENT_ID ?? "cli";
 export const AUTH_CLIENT_SECRET =
   process.env.PLAYWRIGHT_AUTH_CLIENT_SECRET ?? "secret";
+export const AUTH_SCOPE = process.env.PLAYWRIGHT_AUTH_SCOPE;
 
 /**
  * UI only environment variables
  */
 export const AUTH_USER = process.env.PLAYWRIGHT_AUTH_USER ?? "admin";
 export const AUTH_PASSWORD = process.env.PLAYWRIGHT_AUTH_PASSWORD ?? "admin";
+export const UI_AUTH_MODE = process.env.PLAYWRIGHT_UI_AUTH_MODE ?? "form";
+export const TRUSTIFY_UI_URL =
+  process.env.TRUSTIFY_UI_URL ?? "http://localhost:3000/";
 
 /**
  * Log definition

--- a/e2e/tests/ui/helpers/Auth.ts
+++ b/e2e/tests/ui/helpers/Auth.ts
@@ -1,23 +1,142 @@
 import { expect, type Page } from "@playwright/test";
+import axios from "axios";
+import https from "node:https";
+
 import {
+  AUTH_CLIENT_ID,
+  AUTH_CLIENT_SECRET,
   AUTH_PASSWORD,
   AUTH_REQUIRED,
+  AUTH_SCOPE,
+  AUTH_URL,
   AUTH_USER,
+  TRUSTIFY_UI_URL,
+  UI_AUTH_MODE,
+  logger,
 } from "../../common/constants";
 
+const httpsAgent = new https.Agent({ rejectUnauthorized: false });
+
+const discoverFrontendOidcConfig = async (baseURL: string) => {
+  const response = await axios.get<string>(baseURL, {
+    maxRedirects: 0,
+    httpsAgent,
+    timeout: 5000,
+    timeoutErrorMessage: `Could not fetch index.html from ${baseURL}`,
+  });
+
+  const matcher = response.data.match(/window._env\s*=\s*"([^"]+)"/);
+  const serverConfig = matcher?.[1];
+  if (!serverConfig) {
+    throw new Error(
+      "Could not discover OIDC config from frontend index.html. " +
+        "Set PLAYWRIGHT_AUTH_URL explicitly.",
+    );
+  }
+
+  const envInfo: Record<string, string> = JSON.parse(atob(serverConfig));
+  return {
+    oidcServerUrl: envInfo.OIDC_SERVER_URL,
+    oidcClientId: envInfo.OIDC_CLIENT_ID || "frontend",
+  };
+};
+
+const getClientCredentialsToken = async (authUrl: string) => {
+  const oidcConfigResponse = await axios.get(
+    `${authUrl}/.well-known/openid-configuration`,
+    { httpsAgent },
+  );
+  const tokenEndpoint = oidcConfigResponse.data.token_endpoint;
+  expect(
+    tokenEndpoint,
+    "Could not discover token_endpoint from OIDC configuration",
+  ).toBeTruthy();
+
+  const data = new URLSearchParams();
+  data.append("grant_type", "client_credentials");
+  data.append("client_id", AUTH_CLIENT_ID);
+  data.append("client_secret", AUTH_CLIENT_SECRET);
+  if (AUTH_SCOPE) {
+    data.append("scope", AUTH_SCOPE);
+  }
+
+  const response = await axios.post(tokenEndpoint, data, {
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    httpsAgent,
+  });
+
+  return response.data as {
+    access_token: string;
+    expires_in: number;
+    token_type: string;
+  };
+};
+
+const loginWithTokenInjection = async (page: Page) => {
+  const { oidcServerUrl, oidcClientId } =
+    await discoverFrontendOidcConfig(TRUSTIFY_UI_URL);
+  logger.info(
+    `Discovered frontend OIDC config: server=${oidcServerUrl}, clientId=${oidcClientId}`,
+  );
+
+  const authUrl = AUTH_URL || oidcServerUrl;
+  if (!authUrl) {
+    throw new Error(
+      "Auth URL not available. Set PLAYWRIGHT_AUTH_URL or ensure the frontend exposes OIDC_SERVER_URL.",
+    );
+  }
+
+  const tokenResponse = await getClientCredentialsToken(authUrl);
+  logger.info("Obtained access token via client_credentials");
+
+  const expiresAt =
+    Math.floor(Date.now() / 1000) + (tokenResponse.expires_in || 3600);
+
+  const storageKey = `oidc.user:${oidcServerUrl}:${oidcClientId}`;
+  const userObject = JSON.stringify({
+    access_token: tokenResponse.access_token,
+    token_type: "Bearer",
+    scope: AUTH_SCOPE || "openid",
+    expires_at: expiresAt,
+    profile: {
+      sub: AUTH_CLIENT_ID,
+    },
+  });
+
+  logger.debug(`Injecting token into sessionStorage key: ${storageKey}`);
+
+  await page.addInitScript(
+    ({ key, value }: { key: string; value: string }) => {
+      sessionStorage.setItem(key, value);
+    },
+    { key: storageKey, value: userObject },
+  );
+
+  await page.goto("/importers");
+  await expect(page.getByRole("heading", { name: "Importers" })).toHaveCount(1);
+};
+
+const loginWithForm = async (page: Page) => {
+  const userName = AUTH_USER;
+  const userPassword = AUTH_PASSWORD;
+
+  await page.goto("/importers");
+
+  await page.fill('input[name="username"]:visible', userName);
+  await page.fill('input[name="password"]:visible', userPassword);
+  await page.keyboard.press("Enter");
+
+  await expect(page.getByRole("heading", { name: "Importers" })).toHaveCount(1);
+};
+
 export const login = async (page: Page) => {
-  if (AUTH_REQUIRED === "true") {
-    const userName = AUTH_USER;
-    const userPassword = AUTH_PASSWORD;
+  if (AUTH_REQUIRED !== "true") {
+    return;
+  }
 
-    await page.goto("/importers");
-
-    await page.fill('input[name="username"]:visible', userName);
-    await page.fill('input[name="password"]:visible', userPassword);
-    await page.keyboard.press("Enter");
-
-    await expect(page.getByRole("heading", { name: "Importers" })).toHaveCount(
-      1,
-    ); // Ensure login was successful
+  if (UI_AUTH_MODE === "token_injection") {
+    await loginWithTokenInjection(page);
+  } else {
+    await loginWithForm(page);
   }
 };


### PR DESCRIPTION
# Entra ID E2E Test Authentication via Token Injection

## Problem

Running e2e tests against a TPA instance configured with Microsoft Entra ID as
OIDC provider is not possible when the only available user accounts are
corporate SSO-federated identities requiring 2FA. The existing e2e auth flow
fills a browser login form with `PLAYWRIGHT_AUTH_USER` / `PLAYWRIGHT_AUTH_PASSWORD`,
which cannot work with SSO/MFA-protected accounts. Creating local test users in
Entra ID is also not an option when user management permissions are restricted.

## Solution

Added a `token_injection` auth mode for UI tests. Instead of filling a login
form, the test runner:

1. Fetches the deployed frontend's `index.html` to discover `OIDC_SERVER_URL`
   and `OIDC_CLIENT_ID` from the `window._env` configuration.
2. Obtains an access token from Entra ID using the OAuth2 `client_credentials`
   grant with an App Registration's `client_id` + `client_secret`.
3. Injects the token into `sessionStorage` (via Playwright's `addInitScript`)
   using the key format `oidc.user:{authority}:{clientId}` before the React app
   loads.
4. When the app initializes, `react-oidc-context` finds the token in
   sessionStorage, considers the user authenticated, and skips the OIDC login
   redirect.

This requires an Azure App Registration with a client secret and appropriate
API permissions for the TPA backend, but does **not** require creating any user
accounts.

## Files Changed

### `e2e/tests/common/constants.ts`

Added three new exports:

- `UI_AUTH_MODE` (`PLAYWRIGHT_UI_AUTH_MODE`) - Selects auth mode: `form`
  (default, existing behavior) or `token_injection`.
- `AUTH_SCOPE` (`PLAYWRIGHT_AUTH_SCOPE`) - OAuth2 scope for the
  `client_credentials` token request (e.g., `api://<app-id>/.default`).
- `TRUSTIFY_UI_URL` (`TRUSTIFY_UI_URL`) - Frontend URL used to auto-discover
  OIDC settings from the deployment.

### `e2e/tests/ui/helpers/Auth.ts`

Restructured into two auth paths dispatched by `UI_AUTH_MODE`:

- `loginWithForm()` - Original browser form login, unchanged.
- `loginWithTokenInjection()` - New path using client credentials and
  sessionStorage injection.
- `login()` - Public entry point that selects the mode.

The token injection path reuses the existing `PLAYWRIGHT_AUTH_CLIENT_ID`,
`PLAYWRIGHT_AUTH_CLIENT_SECRET`, and `PLAYWRIGHT_AUTH_URL` env vars (shared
with API tests).

### `e2e/README.md`

Documented the new environment variables in the "For UI tests" table.

## Usage

```bash
export TRUSTIFY_UI_URL=https://your-tpa-instance.example.com
export AUTH_REQUIRED=true
export PLAYWRIGHT_UI_AUTH_MODE=token_injection
export PLAYWRIGHT_AUTH_CLIENT_ID=<App Registration client ID>
export PLAYWRIGHT_AUTH_CLIENT_SECRET=<App Registration client secret>
export PLAYWRIGHT_AUTH_SCOPE=api://<backend-app-id-uri>/.default
# Optional - auto-discovered from frontend if not set:
# export PLAYWRIGHT_AUTH_URL=https://login.microsoftonline.com/<tenant-id>/v2.0
```

## Permissions / Authorization

The `client_credentials` token represents an application identity, not a user.
Authorization depends on how the TPA backend is configured:

- **With `auth.yaml` on `trustd`**: If the backend's `auth.yaml` directly maps
  the API/CLI client ID to internal permissions (e.g., `read.sbom`,
  `create.advisory`), the token works without any `roles` claim in the JWT.
  This is useful when you lack Entra ID admin permissions to grant app role
  consent.
- **With Entra ID app roles**: If relying on the standard setup from the TPA
  docs, the API App Registration needs app roles (`API App / create:document`, etc.)
  assigned and admin-consented in API Permissions
  so they appear in the token's `roles` claim.
  The backend's `scopeMappings` then maps these to internal permissions.

## Other Limitations

The UI will display the API client ID (e.g., `660ae41f-...`) as the username
in the top-right corner, since the token has no user profile information. This
is cosmetic and does not affect test execution.

## Summary by Sourcery

Add a new token injection authentication mode for Playwright UI tests that uses client credentials to obtain an access token and injects it into the browser session, while keeping the existing form-based login as the default behavior.

New Features:
- Introduce a configurable UI auth mode that supports both traditional form login and a new token injection flow based on OAuth2 client credentials.
- Enable automatic discovery of frontend OIDC configuration from the deployed UI to support token-based authentication in e2e tests.

Enhancements:
- Share auth-related environment variables between API and UI tests, including optional OAuth2 scope configuration.
- Extend API test token acquisition to include an optional OAuth2 scope parameter derived from environment configuration.

Documentation:
- Update e2e testing documentation to describe the new UI auth mode, required environment variables, and OAuth2 scope configuration for both UI and API tests.