### PR TITLE
fix: auto-merge should use BOT_APPROVE_TOKEN

### DIFF
--- a/.github/workflows/auto-merge-bots.yaml
+++ b/.github/workflows/auto-merge-bots.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Enable auto-merge
         if: steps.check-files.outputs.auto_merge == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_APPROVE_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr merge "$PR_NUMBER" --repo "${{ github.repository }}" --auto --squash
@@ -86,7 +86,7 @@ jobs:
       - name: Enable auto-merge (patch and minor only)
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_APPROVE_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr merge "$PR_NUMBER" --repo "${{ github.repository }}" --auto --squash


### PR DESCRIPTION
Seems like when we use `github.token` then the CI workflows cannot be triggered. So need to use the already existing `secrets.BOT_APPROVE_TOKEN`

This PR https://github.com/guacsec/trustify-ui/pull/1011 is an example of the problem.
- The PR was added to the merge queue but it is indefinitely waiting for the workflows to finish but they never start.

## Summary by Sourcery

CI:
- Switch auto-merge workflow steps to use BOT_APPROVE_TOKEN instead of the default GitHub token when enabling auto-merge.