### PR TITLE
feat: set new "total" request parameter

### DIFF
--- a/client/src/app/hooks/table-controls/getHubRequestParams.ts
+++ b/client/src/app/hooks/table-controls/getHubRequestParams.ts
@@ -72,6 +72,8 @@ interface HubRequestParamsQuery {
    * NOTE: The order of items is defined by the API being called.
    */
   offset?: number;
+  /** Whether to compute and return the total count of matching items. */
+  total?: boolean;
   q?: string;
   sort?: string;
 }
@@ -84,9 +86,11 @@ export const requestParamsQuery = (
 ): HubRequestParamsQuery => {
   let limit = undefined as number | undefined;
   let offset = undefined as number | undefined;
+  let total = undefined as boolean | undefined;
   if (p.page) {
     limit = p.page.itemsPerPage;
     offset = (p.page.pageNumber - 1) * p.page.itemsPerPage;
+    total = true;
   }
 
   let sort = undefined as string | undefined;
@@ -108,7 +112,7 @@ export const requestParamsQuery = (
       .join("&");
   }
 
-  return { limit, offset, q, sort };
+  return { limit, offset, total, q, sort };
 };
 
 export const labelRequestParamsQuery = (labels: Label[] = []) => {


### PR DESCRIPTION
In order to request totals for pagination, we must now explicitly request them. This change adds the parameter to the request.

## Summary by Sourcery

Add support for optionally requesting total counts for paginated API responses and align client request/response models with this behavior.

New Features:
- Introduce an optional `total` query parameter on multiple paginated API endpoints to request computation of the total number of matching items.

Enhancements:
- Make paginated result schemas treat the `total` field as optional and nullable instead of always required.
- Update client table-control request parameter builder to send `total=true` when pagination is used so totals are returned where supported.