### PR TITLE
tests: add SBOM list and details smoke tests (WIP)

### DIFF
--- a/e2e/tests/ui/pages/sbom-details/sbom-details-smoke.spec.ts
+++ b/e2e/tests/ui/pages/sbom-details/sbom-details-smoke.spec.ts
@@ -1,0 +1,60 @@
+// @ts-check
+
+// NOTE: These imports are relative to e2e/tests/ui/pages/sbom-details/
+// To run, copy this file to: e2e/tests/ui/pages/sbom-details/
+import { expect } from "@playwright/test";
+
+import { test } from "../../fixtures";
+import { login } from "../../helpers/Auth";
+import { SbomDetailsPage } from "./SbomDetailsPage";
+
+test.describe("SBOM Details - Smoke tests", { tag: "@smoke" }, () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("Navigate to quarkus-bom and verify page header", async ({ page }) => {
+    const detailsPage = await SbomDetailsPage.build(page, "quarkus-bom");
+
+    await detailsPage._layout.verifyPageHeader("quarkus-bom");
+  });
+
+  test("Info tab is selected by default", async ({ page }) => {
+    const detailsPage = await SbomDetailsPage.build(page, "quarkus-bom");
+
+    await detailsPage._layout.verifyTabIsSelected("Info");
+  });
+
+  test("All expected tabs are visible", async ({ page }) => {
+    const detailsPage = await SbomDetailsPage.build(page, "quarkus-bom");
+
+    await detailsPage._layout.verifyTabIsVisible("Info");
+    await detailsPage._layout.verifyTabIsVisible("Packages");
+    await detailsPage._layout.verifyTabIsVisible("Vulnerabilities");
+    await detailsPage._layout.verifyTabIsVisible("Models");
+  });
+
+  test("Can switch to Packages tab", async ({ page }) => {
+    const detailsPage = await SbomDetailsPage.build(page, "quarkus-bom");
+
+    await detailsPage._layout.selectTab("Packages");
+    await detailsPage._layout.verifyTabIsSelected("Packages");
+
+    // Verify packages table loads with data
+    await expect(
+      page.locator("table[aria-label='Package table']"),
+    ).toBeVisible();
+  });
+
+  test("Can switch to Vulnerabilities tab", async ({ page }) => {
+    const detailsPage = await SbomDetailsPage.build(page, "quarkus-bom");
+
+    await detailsPage._layout.selectTab("Vulnerabilities");
+    await detailsPage._layout.verifyTabIsSelected("Vulnerabilities");
+
+    // Verify vulnerabilities table loads with data
+    await expect(
+      page.locator("table[aria-label='Vulnerability table']"),
+    ).toBeVisible();
+  });
+});

--- a/e2e/tests/ui/pages/sbom-list/sbom-list-smoke.spec.ts
+++ b/e2e/tests/ui/pages/sbom-list/sbom-list-smoke.spec.ts
@@ -1,0 +1,63 @@
+// @ts-check
+
+// NOTE: These imports are relative to e2e/tests/ui/pages/sbom-list/
+// To run, copy this file to: e2e/tests/ui/pages/sbom-list/
+import { expect } from "../../assertions";
+import { test } from "../../fixtures";
+import { login } from "../../helpers/Auth";
+import { SbomListPage } from "./SbomListPage";
+
+test.describe("SBOM List - Smoke tests", { tag: "@smoke" }, () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("Page loads with correct structure", async ({ page }) => {
+    const listPage = await SbomListPage.build(page);
+    const table = await listPage.getTable();
+
+    // Table has data
+    await expect(table).toHaveNumberOfRows({ greaterThan: 0 });
+
+    // Verify expected columns exist by checking a known SBOM
+    const toolbar = await listPage.getToolbar();
+    await toolbar.applyFilter({ "Filter text": "quarkus-bom" });
+    await expect(table).toHaveColumnWithValue("Name", "quarkus-bom");
+  });
+
+  test("Default sort is Name ascending", async ({ page }) => {
+    const listPage = await SbomListPage.build(page);
+    const table = await listPage.getTable();
+
+    await expect(table).toBeSortedBy("Name", "ascending");
+  });
+
+  test("Filter by text shows matching results", async ({ page }) => {
+    const listPage = await SbomListPage.build(page);
+    const toolbar = await listPage.getToolbar();
+    const table = await listPage.getTable();
+
+    // Filter for quarkus
+    await toolbar.applyFilter({ "Filter text": "quarkus" });
+    await expect(table).toHaveColumnWithValue("Name", "quarkus-bom");
+
+    // Clear and verify more results return
+    await toolbar.clearAllFilters();
+    await expect(toolbar).toHaveNoLabels();
+    await expect(table).toHaveNumberOfRows({ greaterThan: 1 });
+  });
+
+  test("Pagination controls work", async ({ page }) => {
+    const listPage = await SbomListPage.build(page);
+    const pagination = await listPage.getPagination();
+    const table = await listPage.getTable();
+
+    // Set items per page to 10
+    await pagination.selectItemsPerPage(10);
+    await expect(table).toHaveNumberOfRows({ equal: 10 });
+
+    // Verify first page state
+    await expect(pagination).toBeFirstPage();
+    await expect(pagination).toHaveNextPage();
+  });
+});


### PR DESCRIPTION
## Summary

- Add 9 basic smoke tests for SBOM List and SBOM Details pages
- SBOM List: page structure, default sort, text filter, pagination
- SBOM Details: page header, default tab, tab visibility, tab switching