### PR TITLE
fix: model list page - add sbom counts

### DIFF
--- a/client/src/app/pages/model-list/model-context.tsx
+++ b/client/src/app/pages/model-list/model-context.tsx
@@ -18,7 +18,7 @@ import type { SbomModel } from "@app/client";
 interface IModelSearchContext {
   tableControls: ITableControls<
     SbomModel,
-    "name" | "suppliedBy" | "licenses",
+    "name" | "suppliedBy" | "licenses" | "sboms",
     "name",
     "",
     string
@@ -41,13 +41,7 @@ interface IModelProvider {
 export const ModelSearchProvider: React.FunctionComponent<IModelProvider> = ({
   children,
 }) => {
-  const tableControlState = useTableControlState<
-    SbomModel,
-    "name" | "suppliedBy" | "licenses",
-    "name",
-    "",
-    string
-  >({
+  const tableControlState = useTableControlState({
     tableName: "model",
     persistenceKeyPrefix: TablePersistenceKeyPrefixes.models,
     persistTo: "urlParams",
@@ -55,6 +49,7 @@ export const ModelSearchProvider: React.FunctionComponent<IModelProvider> = ({
       name: "Name",
       suppliedBy: "Supplied by",
       licenses: "License",
+      sboms: "SBOMs",
     },
     isPaginationEnabled: true,
     isSortEnabled: true,

--- a/client/src/app/pages/model-list/model-table.tsx
+++ b/client/src/app/pages/model-list/model-table.tsx
@@ -38,6 +38,7 @@ export const ModelTable: React.FC = () => {
               <Th {...getThProps({ columnKey: "name" })} />
               <Th {...getThProps({ columnKey: "suppliedBy" })} />
               <Th {...getThProps({ columnKey: "licenses" })} />
+              <Th {...getThProps({ columnKey: "sboms" })} />
             </TableHeaderContentWithControls>
           </Tr>
         </Thead>
@@ -80,7 +81,7 @@ export const ModelTable: React.FC = () => {
                       {props.suppliedBy || "-"}
                     </Td>
                     <Td
-                      width={30}
+                      width={15}
                       modifier="breakWord"
                       {...getTdProps({
                         columnKey: "licenses",
@@ -89,6 +90,17 @@ export const ModelTable: React.FC = () => {
                       })}
                     >
                       {props.licenses || "-"}
+                    </Td>
+                    <Td
+                      width={15}
+                      modifier="breakWord"
+                      {...getTdProps({
+                        columnKey: "sboms",
+                        item: item,
+                        rowIndex,
+                      })}
+                    >
+                      {item.sbom_count}
                     </Td>
                   </TableRowContentWithControls>
                 </Tr>

--- a/client/src/app/pages/sbom-details/models-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/models-by-sbom.tsx
@@ -61,12 +61,12 @@ export const ModelsBySbom: React.FC<ModelsProps> = ({ sbomId }) => {
     result: { data: models, total: totalItemCount },
     isFetching,
     fetchError,
-  } = useFetchModelsBySbomId(
-    sbomId,
-    getHubRequestParams({
+  } = useFetchModelsBySbomId(sbomId, {
+    ...getHubRequestParams({
       ...tableControlState,
     }),
-  );
+    total: true,
+  });
 
   const tableControls = useTableControlProps({
     ...tableControlState,

--- a/client/src/app/queries/models.ts
+++ b/client/src/app/queries/models.ts
@@ -17,7 +17,7 @@ export const useFetchAllModels = (
     queryFn: () => {
       return listAllModels({
         client,
-        query: { ...requestParamsQuery(params) },
+        query: { ...requestParamsQuery(params), counts: true },
       });
     },
     enabled: !disableQuery,


### PR DESCRIPTION
Addresses: https://redhat.atlassian.net/browse/TC-4385

This PR adds a new column "SBOMs" to the Model List page

<img width="1777" height="746" alt="image" src="https://github.com/user-attachments/assets/386d0a59-572e-4d2b-81f4-105e51161721" />

## Summary by Sourcery

Add SBOM count visibility to the models list and ensure model queries return count data for SBOM-related views.

New Features:
- Display an SBOMs column with per-model SBOM counts on the Model List page.

Enhancements:
- Extend model table controls and context to support the new SBOMs column.
- Adjust SBOM details model listing to request total counts via the models-by-SBOM query.
- Include count metadata in the all-models query to support SBOM count display.