### PR TITLE
fix: model list page - add models details

### DIFF
--- a/client/src/app/components/AIModelDetails.tsx
+++ b/client/src/app/components/AIModelDetails.tsx
@@ -55,13 +55,11 @@ const parseExternalReferences = (json?: string): ExternalReference[] => {
   }
 };
 
-interface ModelDetailDrawerProps {
+interface IAIModelDetailsProps {
   model: SbomModel;
 }
 
-export const ModelDetailDrawer: React.FC<ModelDetailDrawerProps> = ({
-  model,
-}) => {
+export const AIModelDetails: React.FC<IAIModelDetailsProps> = ({ model }) => {
   const props = getModelProperties(model.properties);
   const externalRefs = parseExternalReferences(props.external_references);
 

--- a/client/src/app/pages/model-list/model-table.tsx
+++ b/client/src/app/pages/model-list/model-table.tsx
@@ -2,6 +2,12 @@ import React from "react";
 
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 
+import type { SbomModel } from "@app/client";
+import {
+  AIModelDetails,
+  getModelProperties,
+} from "@app/components/AIModelDetails";
+import { PageDrawerContent } from "@app/components/PageDrawerContext";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,
@@ -9,11 +15,14 @@ import {
   TableRowContentWithControls,
 } from "@app/components/TableControls";
 
-import { getModelProperties } from "@app/pages/sbom-details/model-detail-drawer";
-
+import { Button, Content } from "@patternfly/react-core";
 import { ModelSearchContext } from "./model-context";
 
 export const ModelTable: React.FC = () => {
+  const [selectedModel, setSelectedModel] = React.useState<SbomModel | null>(
+    null,
+  );
+
   const { isFetching, fetchError, tableControls } =
     React.useContext(ModelSearchContext);
 
@@ -67,7 +76,13 @@ export const ModelTable: React.FC = () => {
                         rowIndex,
                       })}
                     >
-                      {item.name}
+                      <Button
+                        variant="link"
+                        isInline
+                        onClick={() => setSelectedModel(item)}
+                      >
+                        {item.name}
+                      </Button>
                     </Td>
                     <Td
                       width={30}
@@ -114,6 +129,15 @@ export const ModelTable: React.FC = () => {
         isTop={false}
         paginationProps={paginationProps}
       />
+
+      <PageDrawerContent
+        isExpanded={selectedModel !== null}
+        onCloseClick={() => setSelectedModel(null)}
+        header={<Content component="h2">{selectedModel?.name}</Content>}
+        pageKey="sbom-details-models"
+      >
+        {selectedModel && <AIModelDetails model={selectedModel} />}
+      </PageDrawerContent>
     </>
   );
 };

--- a/client/src/app/pages/sbom-details/models-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/models-by-sbom.tsx
@@ -17,6 +17,10 @@ import {
 import text from "@patternfly/react-styles/css/utilities/Text/text";
 
 import type { SbomModel } from "@app/client";
+import {
+  AIModelDetails,
+  getModelProperties,
+} from "@app/components/AIModelDetails";
 import { ConditionalDataListBody } from "@app/components/DataListControls";
 import { FilterToolbar, FilterType } from "@app/components/FilterToolbar";
 import { PageDrawerContent } from "@app/components/PageDrawerContext";
@@ -28,8 +32,6 @@ import {
   useTableControlState,
 } from "@app/hooks/table-controls";
 import { useFetchModelsBySbomId } from "@app/queries/sboms";
-
-import { getModelProperties, ModelDetailDrawer } from "./model-detail-drawer";
 
 interface ModelsProps {
   sbomId: string;
@@ -187,7 +189,7 @@ export const ModelsBySbom: React.FC<ModelsProps> = ({ sbomId }) => {
         header={<Content component="h2">{selectedModel?.name}</Content>}
         pageKey="sbom-details-models"
       >
-        {selectedModel && <ModelDetailDrawer model={selectedModel} />}
+        {selectedModel && <AIModelDetails model={selectedModel} />}
       </PageDrawerContent>
     </>
   );


### PR DESCRIPTION
Addresses: https://redhat.atlassian.net/browse/TC-4391

- Renamed `model-details-drawer.tsx` to `AIModelDetails.tsx` and moved it to `client/src/app/components/AIModelDetails.tsx`
- Reuse the same `AIModelDetails.tsx` for the SBOM Details page as well as for the Models List page

This is how this PR changes should look like:

https://github.com/user-attachments/assets/d84bed2f-ba59-483a-8506-d50f20a3a044

## Summary by Sourcery

Unify AI model details rendering and enable model details drawer from the models list page.

New Features:
- Allow opening an AI model details drawer directly from the models list table by clicking a model name.

Enhancements:
- Extract and rename the model details drawer component to a shared AIModelDetails component reused by both SBOM details and models list pages.