### PR TITLE
fix: add codecov flags

### DIFF
--- a/.github/workflows/ci-coverage.yaml
+++ b/.github/workflows/ci-coverage.yaml
@@ -64,4 +64,5 @@ jobs:
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: e2e
           slug: ${{ github.repository_owner }}/trustify-ui

--- a/.github/workflows/ci-repo.yaml
+++ b/.github/workflows/ci-repo.yaml
@@ -44,3 +44,10 @@ jobs:
       - name: Crate Clippy
         working-directory: ./crate
         run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit
+          slug: ${{ github.repository_owner }}/trustify-ui
+          directory: client/coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,9 @@ coverage:
     patch:
       default:
         informational: true
+
+flags:
+  unit:
+    carryforward: true
+  e2e:
+    carryforward: true


### PR DESCRIPTION
Addresses: https://redhat.atlassian.net/browse/TC-4486

Adds flags so unit and e2e tests are tracked by codecov

## Summary by Sourcery

Track unit and end-to-end test coverage separately in Codecov and ensure their results are persisted across runs.

Enhancements:
- Define Codecov flags for unit and e2e coverage with carryforward settings to maintain coverage history between runs.

Build:
- Configure the CI workflows to upload coverage to Codecov with distinct flags for unit and e2e tests.

CI:
- Add a Codecov upload step to the main CI workflow for unit-test coverage and flag existing coverage uploads as e2e in the coverage workflow.