### PR TITLE
fix: upgrade axios to 1.16.1 (Release 0.4.z)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4495,14 +4495,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {


### PR DESCRIPTION
## Summary

- Bump axios from 1.15.0 to 1.16.1 to remediate CVE-2026-42035 (arbitrary HTTP header injection via prototype pollution)
- The semver spec `^1.15.0` in `client/package.json` already allows 1.16.1, so only `package-lock.json` is updated
- Fix threshold: axios >= 1.15.1

Implements [TC-4541](https://redhat.atlassian.net/browse/TC-4541)

## Context

The previous remediation task (TC-4540) was incorrectly closed because it only checked `main` where the fix was already present (axios 1.16.1 via Dependabot PR #1022). The `release/0.4.z` branch was still on axios 1.15.0.

Note: the vulnerable code path (`lib/adapters/http.js`) is Node.js-only and not reachable in the browser where trustify-ui runs, but the bump is needed for scanner compliance.

[TC-4541]: https://redhat.atlassian.net/browse/TC-4541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Upgrade the locked axios dependency version in the client to address a security vulnerability on the release/0.4.z branch.

Bug Fixes:
- Remediate the axios arbitrary HTTP header injection vulnerability by bumping the locked version to 1.16.1 in package-lock.json.

Build:
- Update package-lock.json to align with the existing axios semver range and include the secure version.