### PR TITLE
chore(eslint): enable @eslint-react/static-components rule

### DIFF
--- a/client/src/app/components/IconedStatus.tsx
+++ b/client/src/app/components/IconedStatus.tsx
@@ -41,6 +41,60 @@ export interface IIconedStatusProps {
   tooltipCount?: number;
 }
 
+const presets: IconedStatusPresetType = {
+  Canceled: {
+    icon: <TimesCircleIcon />,
+    status: "info",
+    label: "Canceled",
+  },
+  Completed: {
+    icon: <CheckCircleIcon />,
+    status: "success",
+    label: "Completed",
+  },
+  Error: {
+    icon: <ExclamationCircleIcon />,
+    status: "danger",
+    label: "Error",
+  },
+  Failed: {
+    icon: <ExclamationCircleIcon />,
+    status: "danger",
+    label: "Failed",
+  },
+  InProgress: {
+    icon: <InProgressIcon />,
+    status: "info",
+    label: "In-progress",
+  },
+  NotStarted: {
+    icon: <TimesCircleIcon />,
+    label: "Not started",
+  },
+  Ok: {
+    icon: <CheckCircleIcon />,
+    status: "success",
+  },
+  Scheduled: {
+    icon: <PendingIcon />,
+    status: "info",
+    label: "Scheduled",
+  },
+  Unknown: {
+    icon: <UnknownIcon />,
+  },
+};
+
+const IconWithOptionalTooltip: React.FC<{
+  tooltipMessage?: string;
+  children: React.ReactElement;
+}> = ({ tooltipMessage, children }) =>
+  tooltipMessage ? (
+    <Tooltip content={tooltipMessage}>{children}</Tooltip>
+  ) : (
+    children
+  );
+
 export const IconedStatus: React.FC<IIconedStatusProps> = ({
   preset,
   status,
@@ -48,58 +102,7 @@ export const IconedStatus: React.FC<IIconedStatusProps> = ({
   className = "",
   label,
 }: IIconedStatusProps) => {
-  const presets: IconedStatusPresetType = {
-    Canceled: {
-      icon: <TimesCircleIcon />,
-      status: "info",
-      label: "Canceled",
-    },
-    Completed: {
-      icon: <CheckCircleIcon />,
-      status: "success",
-      label: "Completed",
-    },
-    Error: {
-      icon: <ExclamationCircleIcon />,
-      status: "danger",
-      label: "Error",
-    },
-    Failed: {
-      icon: <ExclamationCircleIcon />,
-      status: "danger",
-      label: "Failed",
-    },
-    InProgress: {
-      icon: <InProgressIcon />,
-      status: "info",
-      label: "In-progress",
-    },
-    NotStarted: {
-      icon: <TimesCircleIcon />,
-      label: "Not started",
-    },
-    Ok: {
-      icon: <CheckCircleIcon />,
-      status: "success",
-    },
-    Scheduled: {
-      icon: <PendingIcon />,
-      status: "info",
-      label: "Scheduled",
-    },
-    Unknown: {
-      icon: <UnknownIcon />,
-    },
-  };
   const presetProps = preset && presets[preset];
-  const IconWithOptionalTooltip: React.FC<{ children: React.ReactElement }> = ({
-    children,
-  }) =>
-    presetProps?.tooltipMessage ? (
-      <Tooltip content={presetProps?.tooltipMessage}>{children}</Tooltip>
-    ) : (
-      children
-    );
 
   return (
     <Flex
@@ -107,7 +110,7 @@ export const IconedStatus: React.FC<IIconedStatusProps> = ({
       spaceItems={{ default: "spaceItemsSm" }}
     >
       <FlexItem>
-        <IconWithOptionalTooltip>
+        <IconWithOptionalTooltip tooltipMessage={presetProps?.tooltipMessage}>
           <Icon status={status || presetProps?.status} className={className}>
             {icon || presetProps?.icon || <UnknownIcon />}
           </Icon>

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -539,30 +539,6 @@ interface TableReportData {
   };
 }
 
-const LogButton: React.FC<{
-  messages?: TableReportData["messages"];
-  setLogData: (data: string[]) => void;
-  toggleLogModal: () => void;
-  children: React.ReactNode;
-}> = ({ messages, setLogData, toggleLogModal, children }) => {
-  if (messages) {
-    return (
-      <Button
-        isInline
-        variant="link"
-        onClick={() => {
-          const newLogData = messagesToLogData(messages);
-          setLogData(newLogData);
-          toggleLogModal();
-        }}
-      >
-        {children}
-      </Button>
-    );
-  }
-  return children;
-};
-
 interface ImporterExpandedAreaProps {
   importer: Importer;
 }
@@ -693,6 +669,12 @@ export const ImporterExpandedArea: React.FC<ImporterExpandedAreaProps> = ({
           numRenderedColumns={numRenderedColumns}
         >
           {currentPageItems?.map((item, rowIndex) => {
+            const statusIcon = item.error ? (
+              <IconedStatus preset="Failed" label={item.error} />
+            ) : (
+              <IconedStatus preset="Completed" label="Finished successfully" />
+            );
+
             return (
               <Tbody key={item.id}>
                 <Tr {...getTrProps({ item })}>
@@ -729,21 +711,19 @@ export const ImporterExpandedArea: React.FC<ImporterExpandedAreaProps> = ({
                     >
                       {item.isRunning ? (
                         <ImporterStatusIcon state="running" />
-                      ) : (
-                        <LogButton
-                          messages={item.messages}
-                          setLogData={setLogData}
-                          toggleLogModal={toggleLogModal}
+                      ) : item.messages ? (
+                        <Button
+                          isInline
+                          variant="link"
+                          onClick={() => {
+                            setLogData(messagesToLogData(item.messages ?? {}));
+                            toggleLogModal();
+                          }}
                         >
-                          {item.error ? (
-                            <IconedStatus preset="Failed" label={item.error} />
-                          ) : (
-                            <IconedStatus
-                              preset="Completed"
-                              label="Finished successfully"
-                            />
-                          )}
-                        </LogButton>
+                          {statusIcon}
+                        </Button>
+                      ) : (
+                        statusIcon
                       )}
                     </Td>
                     <Td

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -539,6 +539,30 @@ interface TableReportData {
   };
 }
 
+const LogButton: React.FC<{
+  messages?: TableReportData["messages"];
+  setLogData: (data: string[]) => void;
+  toggleLogModal: () => void;
+  children: React.ReactNode;
+}> = ({ messages, setLogData, toggleLogModal, children }) => {
+  if (messages) {
+    return (
+      <Button
+        isInline
+        variant="link"
+        onClick={() => {
+          const newLogData = messagesToLogData(messages);
+          setLogData(newLogData);
+          toggleLogModal();
+        }}
+      >
+        {children}
+      </Button>
+    );
+  }
+  return children;
+};
+
 interface ImporterExpandedAreaProps {
   importer: Importer;
 }
@@ -669,25 +693,6 @@ export const ImporterExpandedArea: React.FC<ImporterExpandedAreaProps> = ({
           numRenderedColumns={numRenderedColumns}
         >
           {currentPageItems?.map((item, rowIndex) => {
-            const LogButton = ({ children }: { children: React.ReactNode }) => {
-              if (item.messages) {
-                return (
-                  <Button
-                    isInline
-                    variant="link"
-                    onClick={() => {
-                      const newLogData = messagesToLogData(item.messages ?? {});
-                      setLogData(newLogData);
-                      toggleLogModal();
-                    }}
-                  >
-                    {children}
-                  </Button>
-                );
-              }
-              return children;
-            };
-
             return (
               <Tbody key={item.id}>
                 <Tr {...getTrProps({ item })}>
@@ -725,7 +730,11 @@ export const ImporterExpandedArea: React.FC<ImporterExpandedAreaProps> = ({
                       {item.isRunning ? (
                         <ImporterStatusIcon state="running" />
                       ) : (
-                        <LogButton>
+                        <LogButton
+                          messages={item.messages}
+                          setLogData={setLogData}
+                          toggleLogModal={toggleLogModal}
+                        >
                           {item.error ? (
                             <IconedStatus preset="Failed" label={item.error} />
                           ) : (

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,7 +42,6 @@ export default defineConfig([
       "@eslint-react/use-state": "off",
       "@eslint-react/no-unnecessary-use-prefix": "off",
       "@typescript-eslint/no-unused-vars": "off",
-      "@eslint-react/static-components": "off",
       "@eslint-react/exhaustive-deps": "off",
       "@eslint-react/no-nested-component-definitions": "off",
       "@tanstack/query/prefer-query-options": "off",


### PR DESCRIPTION
## Summary
- Remove the `@eslint-react/static-components` override from ESLint config
- Move `presets` object and `IconWithOptionalTooltip` component outside of `IconedStatus` render to avoid re-creation on each render

## Test plan
- [x] `npm run lint` passes with 0 warnings

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Summary by Sourcery

Enable the @eslint-react/static-components rule by refactoring React components to avoid nested definitions and repeated object creation.

Enhancements:
- Hoist the IconedStatus presets configuration and tooltip wrapper component out of the component render path to prevent re-creation on each render.
- Simplify importer status cell rendering by extracting a reusable status icon expression and inlining the log button behavior only when messages are present.

Build:
- Remove the ESLint override that disabled the @eslint-react/static-components rule so it now runs with the rest of the lint configuration.