### PR TITLE
chore(eslint): enable @eslint-react/rules-of-hooks rule

### DIFF
--- a/client/src/app/Routes.tsx
+++ b/client/src/app/Routes.tsx
@@ -77,7 +77,7 @@ export const Paths = {
   sbomGroupDetails: `/sbom-groups/:${PathParam.SBOM_GROUP_ID}`,
 } as const;
 
-export const usePathFromParams = (
+export const getPathFromParams = (
   params: Params<string>,
   pathParam: PathParam,
 ) => {
@@ -118,7 +118,7 @@ export const AppRoutes = createBrowserRouter([
         ),
         errorElement: <RouteErrorBoundary />,
         loader: async ({ params }) => {
-          const advisoryId = usePathFromParams(params, PathParam.ADVISORY_ID);
+          const advisoryId = getPathFromParams(params, PathParam.ADVISORY_ID);
           const response = await queryClient.ensureQueryData(
             advisoryByIdQueryOptions(advisoryId),
           );
@@ -179,7 +179,7 @@ export const AppRoutes = createBrowserRouter([
         ),
         errorElement: <RouteErrorBoundary />,
         loader: async ({ params }) => {
-          const packageId = usePathFromParams(params, PathParam.PACKAGE_ID);
+          const packageId = getPathFromParams(params, PathParam.PACKAGE_ID);
           const response = await queryClient.ensureQueryData(
             packageByIdQueryOptions(packageId),
           );
@@ -204,7 +204,7 @@ export const AppRoutes = createBrowserRouter([
         ),
         errorElement: <RouteErrorBoundary />,
         loader: async ({ params }) => {
-          const sbomId = usePathFromParams(params, PathParam.SBOM_ID);
+          const sbomId = getPathFromParams(params, PathParam.SBOM_ID);
           const response = await queryClient.ensureQueryData(
             sbomByIdQueryOptions(sbomId),
           );
@@ -253,7 +253,7 @@ export const AppRoutes = createBrowserRouter([
         ),
         errorElement: <RouteErrorBoundary />,
         loader: async ({ params }) => {
-          const vulnerabilityId = usePathFromParams(
+          const vulnerabilityId = getPathFromParams(
             params,
             PathParam.VULNERABILITY_ID,
           );
@@ -284,7 +284,7 @@ export const AppRoutes = createBrowserRouter([
         ),
         errorElement: <RouteErrorBoundary />,
         loader: async ({ params }) => {
-          const sbomGroupId = usePathFromParams(
+          const sbomGroupId = getPathFromParams(
             params,
             PathParam.SBOM_GROUP_ID,
           );

--- a/client/src/app/layout/header.tsx
+++ b/client/src/app/layout/header.tsx
@@ -48,7 +48,8 @@ export const HeaderApp: React.FC = () => {
     masthead: { leftBrand, leftTitle, rightBrand, supportUrl },
   } = useBranding();
 
-  const auth = (isAuthRequired && useAuth()) || undefined;
+  const authFromHook = useAuth();
+  const auth = isAuthRequired ? authFromHook : undefined;
 
   const navigate = useNavigate();
 

--- a/client/src/app/layout/header.tsx
+++ b/client/src/app/layout/header.tsx
@@ -48,8 +48,8 @@ export const HeaderApp: React.FC = () => {
     masthead: { leftBrand, leftTitle, rightBrand, supportUrl },
   } = useBranding();
 
-  const authFromHook = useAuth();
-  const auth = isAuthRequired ? authFromHook : undefined;
+  // eslint-disable-next-line @eslint-react/rules-of-hooks -- Required for conditional auth enablement
+  const auth = (isAuthRequired && useAuth()) || undefined;
 
   const navigate = useNavigate();
 

--- a/client/src/app/layout/header.tsx
+++ b/client/src/app/layout/header.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import { useReducer, useState } from "react";
-import { useAuth } from "react-oidc-context";
+import { type AuthContextProps, useAuth } from "react-oidc-context";
 import { useNavigate } from "react-router-dom";
 
 import {
@@ -44,12 +44,26 @@ import imgAvatar from "../images/avatar.svg";
 import { AboutApp } from "./about";
 
 export const HeaderApp: React.FC = () => {
+  return isAuthRequired ? <HeaderWithAuth /> : <HeaderWithoutAuth />;
+};
+
+const HeaderWithAuth: React.FC = () => {
+  const auth = useAuth();
+  return <HeaderAppInner auth={auth} />;
+};
+
+const HeaderWithoutAuth: React.FC = () => {
+  return <HeaderAppInner auth={null} />;
+};
+
+interface IHeaderAppInnerProps {
+  auth: AuthContextProps | null;
+}
+
+const HeaderAppInner: React.FC<IHeaderAppInnerProps> = ({ auth }) => {
   const {
     masthead: { leftBrand, leftTitle, rightBrand, supportUrl },
   } = useBranding();
-
-  // eslint-disable-next-line @eslint-react/rules-of-hooks -- Required for conditional auth enablement
-  const auth = (isAuthRequired && useAuth()) || undefined;
 
   const navigate = useNavigate();
 

--- a/e2e/tests/api/fixtures.ts
+++ b/e2e/tests/api/fixtures.ts
@@ -162,6 +162,7 @@ export const test = base.extend<ApiClientFixture>({
       await initAxiosInstance(axiosInstance, TRUSTIFY_API_URL);
     }
 
+    // eslint-disable-next-line @eslint-react/rules-of-hooks -- Playwright fixture use(), not React
     await use(axiosInstance);
   },
 });

--- a/e2e/tests/ui/fixtures.ts
+++ b/e2e/tests/ui/fixtures.ts
@@ -30,6 +30,7 @@ export const test = base.extend({
       },
     );
 
+    // eslint-disable-next-line @eslint-react/rules-of-hooks
     await use(context);
 
     for (const page of context.pages()) {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,6 @@ export default defineConfig([
       "@eslint-react/set-state-in-effect": "off",
       "@eslint-react/no-use-context": "off",
       "@eslint-react/no-context-provider": "off",
-      "@eslint-react/rules-of-hooks": "off",
       "@eslint-react/naming-convention-ref-name": "off",
       "@eslint-react/no-array-index-key": "off",
       "@eslint-react/use-state": "off",


### PR DESCRIPTION
## Summary
- Remove the `@eslint-react/rules-of-hooks` override from ESLint config
- Rename `usePathFromParams` → `getPathFromParams` since it's a plain utility, not a React hook
- Call `useAuth()` unconditionally in `header.tsx` (was conditionally called via `&&`)
- Suppress false positive for Playwright's `use()` fixture function in e2e tests

## Test plan
- [x] `npm run lint` passes with 0 warnings

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Summary by Sourcery

Enable React hooks linting rule and update code to comply while suppressing specific non-React false positives.

Bug Fixes:
- Ensure the authentication hook in the header layout is treated as unconditionally invoked for linting purposes while preserving conditional auth behavior.
- Suppress false positives from the React hooks lint rule for Playwright fixture use() calls in e2e tests.

Enhancements:
- Rename the route parameter helper from a hook-style name to a plain utility name and update its usages to reflect that it is not a React hook.

Build:
- Remove the project-wide override that disabled the @eslint-react/rules-of-hooks rule in the ESLint configuration.