### PR TITLE
chore(eslint): enable @eslint-react/exhaustive-deps rule

### DIFF
--- a/client/src/app/components/OidcProvider.tsx
+++ b/client/src/app/components/OidcProvider.tsx
@@ -58,7 +58,7 @@ const AuthEnabledOidcProvider: React.FC<IOidcProviderProps> = ({
         url_state: window.location.pathname + window.location.search,
       });
     }
-  }, [auth.isAuthenticated, auth.isLoading, auth.error, auth.signinRedirect]);
+  }, [auth]);
 
   if (auth.isAuthenticated) {
     return <Suspense fallback={<AppPlaceholder />}>{children}</Suspense>;

--- a/client/src/app/hooks/table-controls/active-item/useActiveItemEffects.ts
+++ b/client/src/app/hooks/table-controls/active-item/useActiveItemEffects.ts
@@ -37,5 +37,5 @@ export const useActiveItemEffects = <TItem>({
     if (!isLoading && activeItemId && !activeItem) {
       clearActiveItem();
     }
-  }, [isLoading, activeItemId, activeItem]); // TODO fix the exhaustive-deps lint warning here without affecting behavior
+  }, [isLoading, activeItemId, activeItem, clearActiveItem]);
 };

--- a/client/src/app/hooks/useUrlParams.ts
+++ b/client/src/app/hooks/useUrlParams.ts
@@ -111,8 +111,8 @@ export const useUrlParams = <
   }
 
   React.useEffect(() => {
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- setParams and defaultValue are stable per-mount; including them causes render loops
     if (allParamsEmpty) setParams(defaultValue);
-    // Leaving this rule enabled results in a cascade of unnecessary useCallbacks:
   }, [allParamsEmpty]);
 
   return [params, setParams];

--- a/client/src/app/hooks/useUrlParams.ts
+++ b/client/src/app/hooks/useUrlParams.ts
@@ -110,8 +110,8 @@ export const useUrlParams = <
     params = allParamsEmpty ? defaultValue : deserialize(serializedParams);
   }
 
+  // eslint-disable-next-line @eslint-react/exhaustive-deps -- setParams and defaultValue are stable per-mount; including them causes render loops
   React.useEffect(() => {
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- setParams and defaultValue are stable per-mount; including them causes render loops
     if (allParamsEmpty) setParams(defaultValue);
   }, [allParamsEmpty]);
 

--- a/client/src/app/hooks/useUrlParams.ts
+++ b/client/src/app/hooks/useUrlParams.ts
@@ -110,10 +110,11 @@ export const useUrlParams = <
     params = allParamsEmpty ? defaultValue : deserialize(serializedParams);
   }
 
-  // eslint-disable-next-line @eslint-react/exhaustive-deps -- setParams and defaultValue are stable per-mount; including them causes render loops
+  /* eslint-disable @eslint-react/exhaustive-deps -- setParams and defaultValue are stable per-mount; including them causes render loops */
   React.useEffect(() => {
     if (allParamsEmpty) setParams(defaultValue);
   }, [allParamsEmpty]);
+  /* eslint-enable @eslint-react/exhaustive-deps */
 
   return [params, setParams];
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,7 +43,6 @@ export default defineConfig([
       "@eslint-react/no-unnecessary-use-prefix": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "@eslint-react/static-components": "off",
-      "@eslint-react/exhaustive-deps": "off",
       "@eslint-react/no-nested-component-definitions": "off",
       "@tanstack/query/prefer-query-options": "off",
       "@tanstack/query/exhaustive-deps": "off",


### PR DESCRIPTION
## Summary
- Remove the `@eslint-react/exhaustive-deps` override from ESLint config
- Simplify `OidcProvider` effect to depend on `auth` object directly
- Add `clearActiveItem` to `useActiveItemEffects` dependency array (also removes the TODO comment)
- Suppress `useUrlParams` deps warning with justification (adding deps causes render loops)

## Test plan
- [x] `npm run lint` passes with 0 warnings

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Summary by Sourcery

Enable the @eslint-react/exhaustive-deps rule and update React hooks to satisfy the stricter dependency checks without changing runtime behavior.

Enhancements:
- Adjust OidcProvider effect to depend on the auth object directly.
- Update useActiveItemEffects hook dependencies to include clearActiveItem for exhaustive-deps compliance.
- Document and suppress the exhaustive-deps warning in useUrlParams where adding dependencies would cause render loops.

Build:
- Remove the @eslint-react/exhaustive-deps override from the ESLint configuration to enforce the rule.