### PR TITLE
feat(csaf-visualizer): integrated CSAF VEX visualizer

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,8 @@
     "@tanstack/react-query-devtools": "^5.61.0",
     "axios": "^1.16.0",
     "dayjs": "^1.11.18",
+    "echarts": "^6.1.0",
+    "echarts-for-react": "^3.0.6",
     "file-saver": "^2.0.5",
     "oidc-client-ts": "^3.3.0",
     "packageurl-js": "^2.0.1",

--- a/client/src/app/pages/advisory-details/advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/advisory-details.tsx
@@ -43,6 +43,7 @@ import {
   useFetchAdvisoryById,
 } from "@app/queries/advisories";
 
+import { CsafAdvisoryTabs } from "./csaf-advisory-tabs";
 import { Overview } from "./overview";
 import { VulnerabilitiesByAdvisory } from "./vulnerabilities-by-advisory";
 import { DocumentMetadata } from "@app/components/DocumentMetadata";
@@ -177,47 +178,53 @@ export const AdvisoryDetails: React.FC = () => {
           </SplitItem>
         </Split>
       </PageSection>
-      <PageSection>
-        <Tabs
-          mountOnEnter
-          {...getTabsProps()}
-          aria-label="Tabs that contain the Advisory information"
-          role="region"
-        >
-          <Tab
-            {...getTabProps("info")}
-            title={<TabTitleText>Info</TabTitleText>}
-            tabContentRef={infoTabRef}
-          />
-          <Tab
-            {...getTabProps("vulnerabilities")}
-            title={<TabTitleText>Vulnerabilities</TabTitleText>}
-            tabContentRef={vulnerabilitiesTabRef}
-          />
-        </Tabs>
-      </PageSection>
-      <PageSection>
-        <TabContent
-          {...getTabContentProps("info")}
-          ref={infoTabRef}
-          aria-label="Information of the Advisory"
-        >
-          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
-            {advisory && <Overview advisory={advisory} />}
-          </LoadingWrapper>
-        </TabContent>
-        <TabContent
-          {...getTabContentProps("vulnerabilities")}
-          ref={vulnerabilitiesTabRef}
-          aria-label="Vulnerabilities within the Advisory"
-        >
-          <VulnerabilitiesByAdvisory
-            isFetching={isFetching}
-            fetchError={fetchError}
-            vulnerabilities={advisory?.vulnerabilities || []}
-          />
-        </TabContent>
-      </PageSection>
+      {advisory?.labels.type === "csaf" ? (
+        <CsafAdvisoryTabs advisoryId={advisoryId} />
+      ) : (
+        <>
+          <PageSection>
+            <Tabs
+              mountOnEnter
+              {...getTabsProps()}
+              aria-label="Tabs that contain the Advisory information"
+              role="region"
+            >
+              <Tab
+                {...getTabProps("info")}
+                title={<TabTitleText>Info</TabTitleText>}
+                tabContentRef={infoTabRef}
+              />
+              <Tab
+                {...getTabProps("vulnerabilities")}
+                title={<TabTitleText>Vulnerabilities</TabTitleText>}
+                tabContentRef={vulnerabilitiesTabRef}
+              />
+            </Tabs>
+          </PageSection>
+          <PageSection>
+            <TabContent
+              {...getTabContentProps("info")}
+              ref={infoTabRef}
+              aria-label="Information of the Advisory"
+            >
+              <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+                {advisory && <Overview advisory={advisory} />}
+              </LoadingWrapper>
+            </TabContent>
+            <TabContent
+              {...getTabContentProps("vulnerabilities")}
+              ref={vulnerabilitiesTabRef}
+              aria-label="Vulnerabilities within the Advisory"
+            >
+              <VulnerabilitiesByAdvisory
+                isFetching={isFetching}
+                fetchError={fetchError}
+                vulnerabilities={advisory?.vulnerabilities || []}
+              />
+            </TabContent>
+          </PageSection>
+        </>
+      )}
 
       <ConfirmDialog
         {...advisoryDeleteDialogProps(advisory)}

--- a/client/src/app/pages/advisory-details/csaf-advisory-tabs.tsx
+++ b/client/src/app/pages/advisory-details/csaf-advisory-tabs.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+
+import {
+  PageSection,
+  Tab,
+  TabContent,
+  Tabs,
+  TabTitleText,
+} from "@patternfly/react-core";
+
+import { LoadingWrapper } from "@app/components/LoadingWrapper";
+import { useTabControls } from "@app/hooks/tab-controls";
+import { useFetchCsafSource } from "@app/queries/advisories";
+
+import { DocumentOverview } from "../csaf-visualizer/components/DocumentOverview";
+import { ProductsTable } from "../csaf-visualizer/components/ProductsTable";
+import { RelationshipTree } from "../csaf-visualizer/components/RelationshipTree";
+import { SourceView } from "../csaf-visualizer/components/SourceView";
+import { VulnerabilitySection } from "../csaf-visualizer/components/VulnerabilitySection";
+
+interface CsafAdvisoryTabsProps {
+  advisoryId: string;
+}
+
+/** Tab container for CSAF advisory visualization with 5 purpose-built tabs. */
+export const CsafAdvisoryTabs: React.FC<CsafAdvisoryTabsProps> = ({
+  advisoryId,
+}) => {
+  const { csafDocument, isFetching, fetchError } =
+    useFetchCsafSource(advisoryId);
+
+  const hasRelationships =
+    (csafDocument?.product_tree?.relationships?.length ?? 0) > 0;
+
+  const tabKeys = React.useMemo(() => {
+    const keys: string[] = [
+      "overview",
+      "vulnerabilities",
+      "product-tree",
+      ...(hasRelationships ? ["relationship-tree"] : []),
+      "source",
+    ];
+    return keys;
+  }, [hasRelationships]);
+
+  const {
+    propHelpers: { getTabsProps, getTabProps, getTabContentProps },
+  } = useTabControls({
+    persistenceKeyPrefix: "ad",
+    persistTo: "urlParams",
+    tabKeys,
+  });
+
+  const overviewRef = React.createRef<HTMLElement>();
+  const vulnerabilitiesRef = React.createRef<HTMLElement>();
+  const productTreeRef = React.createRef<HTMLElement>();
+  const relationshipTreeRef = React.createRef<HTMLElement>();
+  const sourceRef = React.createRef<HTMLElement>();
+
+  return (
+    <>
+      <PageSection>
+        <Tabs
+          mountOnEnter
+          {...getTabsProps()}
+          aria-label="CSAF advisory visualization tabs"
+          role="region"
+        >
+          <Tab
+            {...getTabProps("overview")}
+            title={<TabTitleText>Overview</TabTitleText>}
+            tabContentRef={overviewRef}
+          />
+          <Tab
+            {...getTabProps("vulnerabilities")}
+            title={<TabTitleText>Vulnerabilities</TabTitleText>}
+            tabContentRef={vulnerabilitiesRef}
+          />
+          <Tab
+            {...getTabProps("product-tree")}
+            title={<TabTitleText>Product Tree</TabTitleText>}
+            tabContentRef={productTreeRef}
+          />
+          {hasRelationships && (
+            <Tab
+              {...getTabProps("relationship-tree")}
+              title={<TabTitleText>Relationship Tree</TabTitleText>}
+              tabContentRef={relationshipTreeRef}
+            />
+          )}
+          <Tab
+            {...getTabProps("source")}
+            title={<TabTitleText>Source</TabTitleText>}
+            tabContentRef={sourceRef}
+          />
+        </Tabs>
+      </PageSection>
+      <PageSection>
+        <TabContent
+          {...getTabContentProps("overview")}
+          ref={overviewRef}
+          aria-label="CSAF document overview"
+        >
+          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+            {csafDocument && <DocumentOverview csafDocument={csafDocument} />}
+          </LoadingWrapper>
+        </TabContent>
+        <TabContent
+          {...getTabContentProps("vulnerabilities")}
+          ref={vulnerabilitiesRef}
+          aria-label="CSAF vulnerabilities"
+        >
+          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+            {csafDocument && (
+              <VulnerabilitySection csafDocument={csafDocument} />
+            )}
+          </LoadingWrapper>
+        </TabContent>
+        <TabContent
+          {...getTabContentProps("product-tree")}
+          ref={productTreeRef}
+          aria-label="CSAF product tree"
+        >
+          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+            {csafDocument && <ProductsTable csafDocument={csafDocument} />}
+          </LoadingWrapper>
+        </TabContent>
+        {hasRelationships && (
+          <TabContent
+            {...getTabContentProps("relationship-tree")}
+            ref={relationshipTreeRef}
+            aria-label="CSAF relationship tree"
+          >
+            <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+              {csafDocument && <RelationshipTree csafDocument={csafDocument} />}
+            </LoadingWrapper>
+          </TabContent>
+        )}
+        <TabContent
+          {...getTabContentProps("source")}
+          ref={sourceRef}
+          aria-label="CSAF source document"
+        >
+          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+            {csafDocument && <SourceView csafDocument={csafDocument} />}
+          </LoadingWrapper>
+        </TabContent>
+      </PageSection>
+    </>
+  );
+};

--- a/client/src/app/pages/csaf-visualizer/components/DocumentOverview.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/DocumentOverview.tsx
@@ -1,0 +1,10 @@
+import type React from "react";
+
+import type { CsafDocument } from "../types";
+
+interface DocumentOverviewProps {
+  csafDocument: CsafDocument;
+}
+
+/** Placeholder for the CSAF Overview tab — replaced by TC-4602. */
+export const DocumentOverview: React.FC<DocumentOverviewProps> = () => <></>;

--- a/client/src/app/pages/csaf-visualizer/components/DocumentOverview.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/DocumentOverview.tsx
@@ -1,4 +1,29 @@
-import type React from "react";
+import React from "react";
+
+import { ChartDonut } from "@patternfly/react-charts/victory";
+
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Content,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Grid,
+  GridItem,
+  Label,
+  List,
+  ListItem,
+  Stack,
+  StackItem,
+} from "@patternfly/react-core";
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+
+import { severityList } from "@app/api/model-utils";
+import type { ExtendedSeverity } from "@app/api/models";
+import { formatDate } from "@app/utils/utils";
 
 import type { CsafDocument } from "../types";
 
@@ -6,5 +31,371 @@ interface DocumentOverviewProps {
   csafDocument: CsafDocument;
 }
 
-/** Placeholder for the CSAF Overview tab — replaced by TC-4602. */
-export const DocumentOverview: React.FC<DocumentOverviewProps> = () => <></>;
+const severityColorMap: Record<string, string> = {
+  critical: "red",
+  important: "orange",
+  high: "orange",
+  moderate: "gold",
+  medium: "gold",
+  low: "blue",
+};
+
+const remediationLabels: Record<string, string> = {
+  vendor_fix: "Vendor Fix",
+  workaround: "Workaround",
+  mitigation: "Mitigation",
+  no_fix_planned: "No Fix Planned",
+  none_available: "None Available",
+};
+
+/** CSAF Overview tab showing metadata, impact summary, remediation status, references, and revision history. */
+export const DocumentOverview: React.FC<DocumentOverviewProps> = ({
+  csafDocument,
+}) => {
+  const { document: doc, vulnerabilities } = csafDocument;
+
+  const severityCounts = React.useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const vuln of vulnerabilities) {
+      const severity =
+        vuln.scores?.[0]?.cvss_v3?.baseSeverity?.toLowerCase() ?? "unknown";
+      counts[severity] = (counts[severity] ?? 0) + 1;
+    }
+    return counts;
+  }, [vulnerabilities]);
+
+  const remediationCounts = React.useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const vuln of vulnerabilities) {
+      for (const rem of vuln.remediations ?? []) {
+        counts[rem.category] = (counts[rem.category] ?? 0) + 1;
+      }
+    }
+    return counts;
+  }, [vulnerabilities]);
+
+  const donutData = React.useMemo(() => {
+    return Object.entries(remediationCounts).map(([category, count]) => ({
+      label: remediationLabels[category] ?? category,
+      count,
+    }));
+  }, [remediationCounts]);
+
+  const totalRemediations = donutData.reduce(
+    (sum, item) => sum + item.count,
+    0,
+  );
+
+  const severityBarData = React.useMemo(() => {
+    return Object.entries(severityCounts)
+      .map(([severity, count]) => {
+        const key = severity as ExtendedSeverity;
+        const props = severityList[key];
+        return {
+          severity,
+          count,
+          label: props?.name ?? severity,
+          color: props?.color.var ?? "#888",
+        };
+      })
+      .sort((a, b) => b.count - a.count);
+  }, [severityCounts]);
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Grid hasGutter>
+          <GridItem md={4}>
+            <Card isFullHeight>
+              <CardTitle>Document</CardTitle>
+              <CardBody>
+                <DescriptionList>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Title</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {doc.title}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Category</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {doc.category}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  {doc.aggregate_severity && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Severity</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <Label
+                          color={
+                            (severityColorMap[
+                              doc.aggregate_severity.text.toLowerCase()
+                            ] as "red" | "orange" | "gold" | "blue") ?? "grey"
+                          }
+                        >
+                          {doc.aggregate_severity.text}
+                        </Label>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
+                  {doc.distribution?.tlp && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>TLP</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <Label>{doc.distribution.tlp.label}</Label>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>CSAF Version</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {doc.csaf_version}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                </DescriptionList>
+              </CardBody>
+            </Card>
+          </GridItem>
+          <GridItem md={4}>
+            <Card isFullHeight>
+              <CardTitle>Publisher</CardTitle>
+              <CardBody>
+                <DescriptionList>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Name</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {doc.publisher.name}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Category</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {doc.publisher.category}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  {doc.publisher.contact_details && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Contact Details</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {doc.publisher.contact_details}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
+                  {doc.publisher.issuing_authority && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>
+                        Issuing Authority
+                      </DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {doc.publisher.issuing_authority}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
+                </DescriptionList>
+              </CardBody>
+            </Card>
+          </GridItem>
+          <GridItem md={4}>
+            <Card isFullHeight>
+              <CardTitle>Tracking</CardTitle>
+              <CardBody>
+                <DescriptionList>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>ID</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {doc.tracking.id}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Status</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {doc.tracking.status}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Version</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {doc.tracking.version}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>
+                      Initial Release Date
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {formatDate(doc.tracking.initial_release_date)}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>
+                      Current Release Date
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {formatDate(doc.tracking.current_release_date)}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  {doc.tracking.generator && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Generator</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {doc.tracking.generator.engine.name}{" "}
+                        {doc.tracking.generator.engine.version}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
+                </DescriptionList>
+              </CardBody>
+            </Card>
+          </GridItem>
+        </Grid>
+      </StackItem>
+
+      <StackItem>
+        <Grid hasGutter>
+          <GridItem md={6}>
+            <Card>
+              <CardTitle>Impact Summary</CardTitle>
+              <CardBody>
+                {severityBarData.length > 0 ? (
+                  <DescriptionList isHorizontal>
+                    {severityBarData.map(
+                      ({ severity, count, label, color }) => (
+                        <DescriptionListGroup key={severity}>
+                          <DescriptionListTerm>{label}</DescriptionListTerm>
+                          <DescriptionListDescription>
+                            <div
+                              style={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 8,
+                              }}
+                            >
+                              <div
+                                style={{
+                                  width: `${Math.max(20, (count / vulnerabilities.length) * 200)}px`,
+                                  height: 16,
+                                  backgroundColor: color,
+                                  borderRadius: 2,
+                                }}
+                              />
+                              <span>{count}</span>
+                            </div>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                      ),
+                    )}
+                  </DescriptionList>
+                ) : (
+                  <Content component="p">
+                    No vulnerability data available
+                  </Content>
+                )}
+              </CardBody>
+            </Card>
+          </GridItem>
+          <GridItem md={6}>
+            <Card>
+              <CardTitle>Remediation Status</CardTitle>
+              <CardBody>
+                {donutData.length > 0 ? (
+                  <div style={{ height: "230px", maxWidth: "350px" }}>
+                    <ChartDonut
+                      constrainToVisibleArea
+                      legendOrientation="vertical"
+                      legendPosition="right"
+                      padding={{
+                        bottom: 20,
+                        left: 20,
+                        right: 140,
+                        top: 20,
+                      }}
+                      title={`${totalRemediations}`}
+                      subTitle="Total remediations"
+                      width={350}
+                      legendData={donutData.map(({ label, count }) => ({
+                        name: `${label}: ${count}`,
+                      }))}
+                      data={donutData.map(({ label, count }) => ({
+                        x: label,
+                        y: count,
+                      }))}
+                      labels={({ datum }) => `${datum.x}: ${datum.y}`}
+                    />
+                  </div>
+                ) : (
+                  <Content component="p">No remediation data available</Content>
+                )}
+              </CardBody>
+            </Card>
+          </GridItem>
+        </Grid>
+      </StackItem>
+
+      {doc.references && doc.references.length > 0 && (
+        <StackItem>
+          <Card>
+            <CardTitle>References</CardTitle>
+            <CardBody>
+              <List isPlain>
+                {doc.references.map((ref, index) => (
+                  <ListItem key={index}>
+                    <a href={ref.url} target="_blank" rel="noopener noreferrer">
+                      {ref.summary} <ExternalLinkAltIcon />
+                    </a>
+                  </ListItem>
+                ))}
+              </List>
+            </CardBody>
+          </Card>
+        </StackItem>
+      )}
+
+      {doc.tracking.revision_history.length > 0 && (
+        <StackItem>
+          <Card>
+            <CardTitle>Revision History</CardTitle>
+            <CardBody>
+              <DescriptionList isHorizontal>
+                {[...doc.tracking.revision_history]
+                  .sort(
+                    (a, b) =>
+                      new Date(b.date).getTime() - new Date(a.date).getTime(),
+                  )
+                  .map((rev) => (
+                    <DescriptionListGroup key={rev.number}>
+                      <DescriptionListTerm>
+                        v{rev.number} — {formatDate(rev.date)}
+                      </DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {rev.summary}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  ))}
+              </DescriptionList>
+            </CardBody>
+          </Card>
+        </StackItem>
+      )}
+
+      {doc.notes && doc.notes.length > 0 && (
+        <StackItem>
+          <Card>
+            <CardTitle>Notes</CardTitle>
+            <CardBody>
+              <Stack hasGutter>
+                {doc.notes.map((note, index) => (
+                  <StackItem key={index}>
+                    {note.title && (
+                      <Content component="h4">{note.title}</Content>
+                    )}
+                    <Content component="p">{note.text}</Content>
+                  </StackItem>
+                ))}
+              </Stack>
+            </CardBody>
+          </Card>
+        </StackItem>
+      )}
+    </Stack>
+  );
+};

--- a/client/src/app/pages/csaf-visualizer/components/ProductsTable.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/ProductsTable.tsx
@@ -1,10 +1,149 @@
-import type React from "react";
+import React from "react";
 
-import type { CsafDocument } from "../types";
+import ReactECharts from "echarts-for-react";
+
+import {
+  Flex,
+  FlexItem,
+  Label,
+  Stack,
+  StackItem,
+} from "@patternfly/react-core";
+
+import type { Branch, CsafDocument } from "../types";
 
 interface ProductsTableProps {
   csafDocument: CsafDocument;
 }
 
-/** Placeholder for the CSAF Product Tree tab — replaced by TC-4604. */
-export const ProductsTable: React.FC<ProductsTableProps> = () => <></>;
+const categoryColors: Record<string, string> = {
+  vendor: "#0066CC",
+  product_family: "#009596",
+  product_name: "#3E8635",
+  product_version: "#6A6E73",
+  product_version_range: "#6753AC",
+  architecture: "#EC7A08",
+  language: "#C9190B",
+};
+
+interface TreeNode {
+  name: string;
+  children?: TreeNode[];
+  collapsed?: boolean;
+  itemStyle?: { color: string };
+}
+
+/** Counts descendant leaf nodes in a branch. */
+function countLeaves(branch: Branch): number {
+  if (!branch.branches || branch.branches.length === 0) return 1;
+  return branch.branches.reduce((sum, child) => sum + countLeaves(child), 0);
+}
+
+/** Converts a CSAF Branch into an ECharts tree node. */
+function branchToTreeNode(branch: Branch): TreeNode {
+  const node: TreeNode = {
+    name: branch.product?.name ?? branch.name,
+    itemStyle: { color: categoryColors[branch.category] ?? "#6A6E73" },
+  };
+
+  if (branch.branches && branch.branches.length > 0) {
+    node.children = branch.branches.map(branchToTreeNode);
+    if (countLeaves(branch) > 40) {
+      node.collapsed = true;
+    }
+  }
+
+  return node;
+}
+
+/** Interactive ECharts tree visualization of the CSAF product hierarchy. */
+export const ProductsTable: React.FC<ProductsTableProps> = ({
+  csafDocument,
+}) => {
+  const treeData = React.useMemo(() => {
+    return csafDocument.product_tree.branches.map(branchToTreeNode);
+  }, [csafDocument.product_tree.branches]);
+
+  const leafCount = React.useMemo(() => {
+    return csafDocument.product_tree.branches.reduce(
+      (sum, branch) => sum + countLeaves(branch),
+      0,
+    );
+  }, [csafDocument.product_tree.branches]);
+
+  const chartHeight = Math.max(400, leafCount * 25);
+
+  const option = React.useMemo(
+    () => ({
+      tooltip: { trigger: "item" as const },
+      series: [
+        {
+          type: "tree" as const,
+          data: treeData,
+          orient: "LR",
+          roam: true,
+          initialTreeDepth: 2,
+          symbolSize: 8,
+          label: {
+            fontSize: 11,
+          },
+          leaves: {
+            label: {
+              position: "right" as const,
+              verticalAlign: "middle" as const,
+              align: "left" as const,
+            },
+          },
+          emphasis: {
+            focus: "descendant" as const,
+          },
+          expandAndCollapse: true,
+          animationDuration: 300,
+          animationDurationUpdate: 300,
+        },
+      ],
+    }),
+    [treeData],
+  );
+
+  const usedCategories = React.useMemo(() => {
+    const categories = new Set<string>();
+    function walk(branches: Branch[]) {
+      for (const branch of branches) {
+        categories.add(branch.category);
+        if (branch.branches) walk(branch.branches);
+      }
+    }
+    walk(csafDocument.product_tree.branches);
+    return Array.from(categories);
+  }, [csafDocument.product_tree.branches]);
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Flex spaceItems={{ default: "spaceItemsSm" }}>
+          {usedCategories.map((category) => (
+            <FlexItem key={category}>
+              <Label
+                style={{
+                  backgroundColor: categoryColors[category] ?? "#6A6E73",
+                  color: "#fff",
+                }}
+              >
+                {category.replace(/_/g, " ")}
+              </Label>
+            </FlexItem>
+          ))}
+        </Flex>
+      </StackItem>
+      <StackItem>
+        <ReactECharts
+          option={option}
+          style={{ height: `${chartHeight}px`, width: "100%" }}
+          notMerge
+          lazyUpdate
+        />
+      </StackItem>
+    </Stack>
+  );
+};

--- a/client/src/app/pages/csaf-visualizer/components/ProductsTable.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/ProductsTable.tsx
@@ -1,0 +1,10 @@
+import type React from "react";
+
+import type { CsafDocument } from "../types";
+
+interface ProductsTableProps {
+  csafDocument: CsafDocument;
+}
+
+/** Placeholder for the CSAF Product Tree tab — replaced by TC-4604. */
+export const ProductsTable: React.FC<ProductsTableProps> = () => <></>;

--- a/client/src/app/pages/csaf-visualizer/components/RelationshipTree.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/RelationshipTree.tsx
@@ -1,0 +1,10 @@
+import type React from "react";
+
+import type { CsafDocument } from "../types";
+
+interface RelationshipTreeProps {
+  csafDocument: CsafDocument;
+}
+
+/** Placeholder for the CSAF Relationship Tree tab — replaced by TC-4604. */
+export const RelationshipTree: React.FC<RelationshipTreeProps> = () => <></>;

--- a/client/src/app/pages/csaf-visualizer/components/RelationshipTree.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/RelationshipTree.tsx
@@ -1,10 +1,190 @@
-import type React from "react";
+import React from "react";
+
+import ReactECharts from "echarts-for-react";
+
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Flex,
+  FlexItem,
+  Label,
+  Stack,
+  StackItem,
+} from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
 
 import type { CsafDocument } from "../types";
+import { collectProducts } from "../utils";
 
 interface RelationshipTreeProps {
   csafDocument: CsafDocument;
 }
 
-/** Placeholder for the CSAF Relationship Tree tab — replaced by TC-4604. */
-export const RelationshipTree: React.FC<RelationshipTreeProps> = () => <></>;
+const categoryStyles: Record<
+  string,
+  { color: string; lineType: string; label: string }
+> = {
+  default_component_of: {
+    color: "#C9190B",
+    lineType: "solid",
+    label: "Default Component Of",
+  },
+  external_component_of: {
+    color: "#0066CC",
+    lineType: "solid",
+    label: "External Component Of",
+  },
+  installed_on: {
+    color: "#3E8635",
+    lineType: "dashed",
+    label: "Installed On",
+  },
+  installed_with: {
+    color: "#6753AC",
+    lineType: "dotted",
+    label: "Installed With",
+  },
+  optional_component_of: {
+    color: "#EC7A08",
+    lineType: "dashed",
+    label: "Optional Component Of",
+  },
+};
+
+interface TreeNode {
+  name: string;
+  children?: TreeNode[];
+  lineStyle?: { color: string; type: string };
+}
+
+/** Interactive ECharts tree showing product relationships grouped by target product. */
+export const RelationshipTree: React.FC<RelationshipTreeProps> = ({
+  csafDocument,
+}) => {
+  const relationships = csafDocument.product_tree.relationships;
+
+  const productMap = React.useMemo(
+    () => collectProducts(csafDocument.product_tree.branches),
+    [csafDocument.product_tree.branches],
+  );
+
+  const treeData = React.useMemo(() => {
+    if (!relationships || relationships.length === 0) return [];
+
+    const grouped = new Map<string, TreeNode[]>();
+    for (const rel of relationships) {
+      const targetId = rel.relates_to_product_reference;
+      const targetName = productMap.get(targetId) ?? targetId;
+      const style =
+        categoryStyles[rel.category] ?? categoryStyles.default_component_of;
+
+      const child: TreeNode = {
+        name: productMap.get(rel.product_reference) ?? rel.product_reference,
+        lineStyle: { color: style.color, type: style.lineType },
+      };
+
+      if (!grouped.has(targetName)) {
+        grouped.set(targetName, []);
+      }
+      grouped.get(targetName)!.push(child);
+    }
+
+    return Array.from(grouped.entries()).map(
+      ([name, children]) => ({ name, children }) as TreeNode,
+    );
+  }, [relationships, productMap]);
+
+  const usedCategories = React.useMemo(() => {
+    if (!relationships) return [];
+    const categories = new Set<string>();
+    for (const rel of relationships) {
+      categories.add(rel.category);
+    }
+    return Array.from(categories);
+  }, [relationships]);
+
+  if (!relationships || relationships.length === 0) {
+    return (
+      <EmptyState
+        headingLevel="h4"
+        icon={CubesIcon}
+        titleText="No relationships found"
+        variant={EmptyStateVariant.sm}
+      >
+        <EmptyStateBody>
+          This advisory does not contain product relationship information.
+        </EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  const nodeCount = treeData.reduce(
+    (sum, node) => sum + 1 + (node.children?.length ?? 0),
+    0,
+  );
+  const chartHeight = Math.max(400, nodeCount * 25);
+
+  const option = {
+    tooltip: { trigger: "item" as const },
+    series: [
+      {
+        type: "tree" as const,
+        data: treeData,
+        orient: "LR",
+        roam: true,
+        initialTreeDepth: 3,
+        symbolSize: 8,
+        label: {
+          fontSize: 11,
+        },
+        leaves: {
+          label: {
+            position: "right" as const,
+            verticalAlign: "middle" as const,
+            align: "left" as const,
+          },
+        },
+        emphasis: {
+          focus: "descendant" as const,
+        },
+        expandAndCollapse: true,
+        animationDuration: 300,
+        animationDurationUpdate: 300,
+      },
+    ],
+  };
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Flex spaceItems={{ default: "spaceItemsSm" }}>
+          {usedCategories.map((category) => {
+            const style = categoryStyles[category];
+            if (!style) return null;
+            return (
+              <FlexItem key={category}>
+                <Label
+                  style={{
+                    backgroundColor: style.color,
+                    color: "#fff",
+                  }}
+                >
+                  {style.label}
+                </Label>
+              </FlexItem>
+            );
+          })}
+        </Flex>
+      </StackItem>
+      <StackItem>
+        <ReactECharts
+          option={option}
+          style={{ height: `${chartHeight}px`, width: "100%" }}
+          notMerge
+          lazyUpdate
+        />
+      </StackItem>
+    </Stack>
+  );
+};

--- a/client/src/app/pages/csaf-visualizer/components/SourceView.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/SourceView.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import {
+  CodeBlock,
+  CodeBlockCode,
+  Content,
+  Stack,
+  StackItem,
+} from "@patternfly/react-core";
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+
+import type { CsafDocument } from "../types";
+
+interface SourceViewProps {
+  csafDocument: CsafDocument;
+}
+
+/** Displays the raw CSAF JSON with a link to the original advisory. */
+export const SourceView: React.FC<SourceViewProps> = ({ csafDocument }) => {
+  const selfRef = csafDocument.document.references?.find(
+    (ref) => ref.category === "self",
+  );
+
+  return (
+    <Stack hasGutter>
+      {selfRef && (
+        <StackItem>
+          <Content>
+            <a href={selfRef.url} target="_blank" rel="noopener noreferrer">
+              {selfRef.summary || "View original advisory"}{" "}
+              <ExternalLinkAltIcon />
+            </a>
+          </Content>
+        </StackItem>
+      )}
+      <StackItem>
+        <CodeBlock>
+          <CodeBlockCode>{JSON.stringify(csafDocument, null, 2)}</CodeBlockCode>
+        </CodeBlock>
+      </StackItem>
+    </Stack>
+  );
+};

--- a/client/src/app/pages/csaf-visualizer/components/VulnerabilitySection.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/VulnerabilitySection.tsx
@@ -1,0 +1,12 @@
+import type React from "react";
+
+import type { CsafDocument } from "../types";
+
+interface VulnerabilitySectionProps {
+  csafDocument: CsafDocument;
+}
+
+/** Placeholder for the CSAF Vulnerabilities tab — replaced by TC-4603. */
+export const VulnerabilitySection: React.FC<VulnerabilitySectionProps> = () => (
+  <></>
+);

--- a/client/src/app/pages/csaf-visualizer/components/VulnerabilitySection.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/VulnerabilitySection.tsx
@@ -1,12 +1,453 @@
-import type React from "react";
+import React from "react";
+import { generatePath, Link } from "react-router-dom";
 
-import type { CsafDocument } from "../types";
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Content,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Divider,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  ExpandableSection,
+  Flex,
+  FlexItem,
+  Label,
+  List,
+  ListItem,
+  Stack,
+  StackItem,
+} from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+
+import { extendedSeverityFromSeverity } from "@app/api/models";
+import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
+import { Paths } from "@app/Routes";
+import { formatDate } from "@app/utils/utils";
+
+import type { CsafDocument, Vulnerability } from "../types";
+import { collectProducts } from "../utils";
 
 interface VulnerabilitySectionProps {
   csafDocument: CsafDocument;
 }
 
-/** Placeholder for the CSAF Vulnerabilities tab — replaced by TC-4603. */
-export const VulnerabilitySection: React.FC<VulnerabilitySectionProps> = () => (
-  <></>
-);
+const remediationLabels: Record<string, string> = {
+  vendor_fix: "Vendor Fix",
+  workaround: "Workaround",
+  mitigation: "Mitigation",
+  no_fix_planned: "No Fix Planned",
+  none_available: "None Available",
+};
+
+const URL_REGEX = /(https?:\/\/[^\s<]+)/g;
+
+/** Renders text with URLs auto-linkified. */
+const LinkifiedText: React.FC<{ text: string }> = ({ text }) => {
+  const parts = text.split(URL_REGEX);
+  return (
+    <>
+      {parts.map((part, i) =>
+        URL_REGEX.test(part) ? (
+          <a key={i} href={part} target="_blank" rel="noopener noreferrer">
+            {part}
+          </a>
+        ) : (
+          <React.Fragment key={i}>{part}</React.Fragment>
+        ),
+      )}
+    </>
+  );
+};
+
+/** Displays affected product IDs resolved to names, with a "+N more" toggle. */
+const ProductList: React.FC<{
+  productIds: string[];
+  productMap: Map<string, string>;
+  label: string;
+}> = ({ productIds, productMap, label }) => {
+  const [expanded, setExpanded] = React.useState(false);
+  const INITIAL_SHOW = 5;
+
+  if (productIds.length === 0) return null;
+
+  const visible = expanded ? productIds : productIds.slice(0, INITIAL_SHOW);
+  const remaining = productIds.length - INITIAL_SHOW;
+
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>
+        {label} ({productIds.length})
+      </DescriptionListTerm>
+      <DescriptionListDescription>
+        <List isPlain>
+          {visible.map((id) => (
+            <ListItem key={id}>{productMap.get(id) ?? id}</ListItem>
+          ))}
+        </List>
+        {remaining > 0 && (
+          <Content
+            component="small"
+            style={{ cursor: "pointer" }}
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded ? "Show less" : `+${remaining} more`}
+          </Content>
+        )}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+/** Renders a single vulnerability card with CVSS, products, remediations, and references. */
+const VulnerabilityCard: React.FC<{
+  vulnerability: Vulnerability;
+  productMap: Map<string, string>;
+}> = ({ vulnerability, productMap }) => {
+  const score = vulnerability.scores?.[0]?.cvss_v3;
+  const severity = extendedSeverityFromSeverity(
+    score?.baseSeverity?.toLowerCase() as
+      | "none"
+      | "low"
+      | "medium"
+      | "high"
+      | "critical"
+      | undefined,
+  );
+
+  return (
+    <Card>
+      <CardTitle>
+        <Flex
+          spaceItems={{ default: "spaceItemsMd" }}
+          alignItems={{ default: "alignItemsCenter" }}
+        >
+          <FlexItem>
+            <Link
+              to={generatePath(Paths.vulnerabilityDetails, {
+                vulnerabilityId: vulnerability.cve,
+              })}
+            >
+              {vulnerability.cve}
+            </Link>
+          </FlexItem>
+          <FlexItem>
+            <SeverityShieldAndText
+              value={severity}
+              score={score?.baseScore ?? null}
+              showLabel
+              showScore
+            />
+          </FlexItem>
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <Stack hasGutter>
+          <StackItem>
+            <Content component="p">
+              <strong>{vulnerability.title}</strong>
+            </Content>
+          </StackItem>
+
+          {vulnerability.cwe && (
+            <StackItem>
+              <Label color="blue" isCompact>
+                {vulnerability.cwe.id}: {vulnerability.cwe.name}
+              </Label>
+            </StackItem>
+          )}
+
+          <StackItem>
+            <DescriptionList isHorizontal isCompact>
+              {vulnerability.discovery_date && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Discovered</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {formatDate(vulnerability.discovery_date)}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {vulnerability.release_date && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Released</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {formatDate(vulnerability.release_date)}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+            </DescriptionList>
+          </StackItem>
+
+          {score && (
+            <StackItem>
+              <ExpandableSection toggleText="CVSS Details">
+                <DescriptionList isHorizontal isCompact>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Attack Vector</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {score.attackVector}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Attack Complexity</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {score.attackComplexity}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>
+                      Privileges Required
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {score.privilegesRequired}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>User Interaction</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {score.userInteraction}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Scope</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {score.scope}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Confidentiality</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {score.confidentialityImpact}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Integrity</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {score.integrityImpact}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Availability</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {score.availabilityImpact}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Vector String</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <code>{score.vectorString}</code>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                </DescriptionList>
+              </ExpandableSection>
+            </StackItem>
+          )}
+
+          {vulnerability.product_status && (
+            <StackItem>
+              <Divider />
+              <DescriptionList>
+                <ProductList
+                  productIds={vulnerability.product_status.known_affected ?? []}
+                  productMap={productMap}
+                  label="Affected"
+                />
+                <ProductList
+                  productIds={vulnerability.product_status.fixed ?? []}
+                  productMap={productMap}
+                  label="Fixed"
+                />
+                <ProductList
+                  productIds={
+                    vulnerability.product_status.known_not_affected ?? []
+                  }
+                  productMap={productMap}
+                  label="Not Affected"
+                />
+                <ProductList
+                  productIds={
+                    vulnerability.product_status.under_investigation ?? []
+                  }
+                  productMap={productMap}
+                  label="Under Investigation"
+                />
+              </DescriptionList>
+            </StackItem>
+          )}
+
+          {vulnerability.remediations &&
+            vulnerability.remediations.length > 0 && (
+              <StackItem>
+                <Divider />
+                <ExpandableSection toggleText="Remediations">
+                  <Stack hasGutter>
+                    {vulnerability.remediations.map((rem, i) => (
+                      <StackItem key={i}>
+                        <Card isCompact isFlat>
+                          <CardBody>
+                            <DescriptionList isHorizontal isCompact>
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                  Category
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  <Label isCompact>
+                                    {remediationLabels[rem.category] ??
+                                      rem.category}
+                                  </Label>
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                              <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                  Details
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                  <LinkifiedText text={rem.details} />
+                                </DescriptionListDescription>
+                              </DescriptionListGroup>
+                              {rem.date && (
+                                <DescriptionListGroup>
+                                  <DescriptionListTerm>
+                                    Date
+                                  </DescriptionListTerm>
+                                  <DescriptionListDescription>
+                                    {formatDate(rem.date)}
+                                  </DescriptionListDescription>
+                                </DescriptionListGroup>
+                              )}
+                              {rem.url && (
+                                <DescriptionListGroup>
+                                  <DescriptionListTerm>URL</DescriptionListTerm>
+                                  <DescriptionListDescription>
+                                    <a
+                                      href={rem.url}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                    >
+                                      {rem.url} <ExternalLinkAltIcon />
+                                    </a>
+                                  </DescriptionListDescription>
+                                </DescriptionListGroup>
+                              )}
+                            </DescriptionList>
+                            {rem.product_ids && rem.product_ids.length > 0 && (
+                              <ExpandableSection
+                                toggleText={`Affected products (${rem.product_ids.length})`}
+                              >
+                                <List isPlain>
+                                  {rem.product_ids.map((id) => (
+                                    <ListItem key={id}>
+                                      {productMap.get(id) ?? id}
+                                    </ListItem>
+                                  ))}
+                                </List>
+                              </ExpandableSection>
+                            )}
+                          </CardBody>
+                        </Card>
+                      </StackItem>
+                    ))}
+                  </Stack>
+                </ExpandableSection>
+              </StackItem>
+            )}
+
+          {vulnerability.references && vulnerability.references.length > 0 && (
+            <StackItem>
+              <Divider />
+              <Content component="h4">References</Content>
+              <List isPlain>
+                {vulnerability.references.map((ref, i) => (
+                  <ListItem key={i}>
+                    <a href={ref.url} target="_blank" rel="noopener noreferrer">
+                      {ref.summary} <ExternalLinkAltIcon />
+                    </a>
+                  </ListItem>
+                ))}
+              </List>
+            </StackItem>
+          )}
+
+          {vulnerability.threats && vulnerability.threats.length > 0 && (
+            <StackItem>
+              <Divider />
+              <Content component="h4">Threats</Content>
+              <DescriptionList isCompact>
+                {vulnerability.threats.map((threat, i) => (
+                  <DescriptionListGroup key={i}>
+                    <DescriptionListTerm>{threat.category}</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <LinkifiedText text={threat.details} />
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                ))}
+              </DescriptionList>
+            </StackItem>
+          )}
+
+          {vulnerability.notes && vulnerability.notes.length > 0 && (
+            <StackItem>
+              <Divider />
+              <Content component="h4">Notes</Content>
+              {vulnerability.notes.map((note, i) => (
+                <Content key={i} component="p">
+                  {note.title && <strong>{note.title}: </strong>}
+                  {note.text}
+                </Content>
+              ))}
+            </StackItem>
+          )}
+        </Stack>
+      </CardBody>
+    </Card>
+  );
+};
+
+/** CSAF Vulnerabilities tab displaying per-CVE cards sorted by severity. */
+export const VulnerabilitySection: React.FC<VulnerabilitySectionProps> = ({
+  csafDocument,
+}) => {
+  const productMap = React.useMemo(
+    () => collectProducts(csafDocument.product_tree.branches),
+    [csafDocument.product_tree.branches],
+  );
+
+  const sortedVulnerabilities = React.useMemo(() => {
+    return [...csafDocument.vulnerabilities].sort(
+      (a, b) =>
+        (b.scores?.[0]?.cvss_v3?.baseScore ?? 0) -
+        (a.scores?.[0]?.cvss_v3?.baseScore ?? 0),
+    );
+  }, [csafDocument.vulnerabilities]);
+
+  if (sortedVulnerabilities.length === 0) {
+    return (
+      <EmptyState
+        headingLevel="h4"
+        icon={CubesIcon}
+        titleText="No vulnerabilities found"
+        variant={EmptyStateVariant.sm}
+      >
+        <EmptyStateBody>
+          This advisory does not contain any vulnerability information.
+        </EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <Stack hasGutter>
+      {sortedVulnerabilities.map((vuln) => (
+        <StackItem key={vuln.cve}>
+          <VulnerabilityCard vulnerability={vuln} productMap={productMap} />
+        </StackItem>
+      ))}
+    </Stack>
+  );
+};

--- a/client/src/app/pages/csaf-visualizer/index.ts
+++ b/client/src/app/pages/csaf-visualizer/index.ts
@@ -1,0 +1,25 @@
+export type {
+  Branch,
+  CsafDocument,
+  CvssV3,
+  DocumentMeta,
+  Note,
+  Product,
+  ProductStatus,
+  ProductTree,
+  Publisher,
+  Reference,
+  Relationship,
+  Remediation,
+  RevisionEntry,
+  Score,
+  Threat,
+  Tracking,
+  Vulnerability,
+} from "./types";
+
+export {
+  collectProducts,
+  collectProductNodes,
+  collectRelationshipProducts,
+} from "./utils";

--- a/client/src/app/pages/csaf-visualizer/types.ts
+++ b/client/src/app/pages/csaf-visualizer/types.ts
@@ -1,0 +1,165 @@
+/** Top-level CSAF 2.0 document structure. */
+export interface CsafDocument {
+  document: DocumentMeta;
+  product_tree: ProductTree;
+  vulnerabilities: Vulnerability[];
+}
+
+/** CSAF document metadata including title, publisher, tracking, and distribution info. */
+export interface DocumentMeta {
+  aggregate_severity?: { namespace: string; text: string };
+  category: string;
+  csaf_version: string;
+  distribution?: {
+    text: string;
+    tlp?: { label: string; url: string };
+  };
+  lang?: string;
+  notes?: Note[];
+  publisher: Publisher;
+  references?: Reference[];
+  title: string;
+  tracking: Tracking;
+}
+
+/** Publisher information for the CSAF document. */
+export interface Publisher {
+  category: string;
+  contact_details?: string;
+  issuing_authority?: string;
+  name: string;
+  namespace: string;
+}
+
+/** Document tracking metadata including version history. */
+export interface Tracking {
+  current_release_date: string;
+  generator?: {
+    date: string;
+    engine: { name: string; version: string };
+  };
+  id: string;
+  initial_release_date: string;
+  revision_history: RevisionEntry[];
+  status: string;
+  version: string;
+}
+
+/** A single entry in the document revision history. */
+export interface RevisionEntry {
+  date: string;
+  number: string;
+  summary: string;
+}
+
+/** A note attached to a document or vulnerability. */
+export interface Note {
+  category: string;
+  text: string;
+  title?: string;
+}
+
+/** A reference link with summary and URL. */
+export interface Reference {
+  category: string;
+  summary: string;
+  url: string;
+}
+
+/** Product tree containing branch hierarchy and product relationships. */
+export interface ProductTree {
+  branches: Branch[];
+  relationships?: Relationship[];
+}
+
+/** Recursive branch in the product tree hierarchy. */
+export interface Branch {
+  category: string;
+  name: string;
+  branches?: Branch[];
+  product?: Product;
+}
+
+/** A product leaf node with identification helpers. */
+export interface Product {
+  name: string;
+  product_id: string;
+  product_identification_helper?: {
+    cpe?: string;
+    purl?: string;
+  };
+}
+
+/** A relationship between two products in the product tree. */
+export interface Relationship {
+  category: string;
+  full_product_name: {
+    name: string;
+    product_id: string;
+  };
+  product_reference: string;
+  relates_to_product_reference: string;
+}
+
+/** A vulnerability entry with CVE, scores, remediations, and affected products. */
+export interface Vulnerability {
+  cve: string;
+  cwe?: { id: string; name: string };
+  discovery_date?: string;
+  ids?: { system_name: string; text: string }[];
+  notes?: Note[];
+  product_status?: ProductStatus;
+  references?: Reference[];
+  release_date?: string;
+  remediations?: Remediation[];
+  scores?: Score[];
+  threats?: Threat[];
+  title: string;
+}
+
+/** Product status categories for a vulnerability. */
+export interface ProductStatus {
+  fixed?: string[];
+  known_affected?: string[];
+  known_not_affected?: string[];
+  under_investigation?: string[];
+}
+
+/** A remediation action for a vulnerability. */
+export interface Remediation {
+  category: string;
+  date?: string;
+  details: string;
+  group_ids?: string[];
+  product_ids?: string[];
+  url?: string;
+}
+
+/** CVSS v3 scoring for a vulnerability. */
+export interface Score {
+  cvss_v3?: CvssV3;
+  products: string[];
+}
+
+/** CVSS v3 score breakdown. */
+export interface CvssV3 {
+  attackComplexity: string;
+  attackVector: string;
+  availabilityImpact: string;
+  baseScore: number;
+  baseSeverity: string;
+  confidentialityImpact: string;
+  integrityImpact: string;
+  privilegesRequired: string;
+  scope: string;
+  userInteraction: string;
+  vectorString: string;
+  version: string;
+}
+
+/** A threat entry describing the nature and impact of a vulnerability. */
+export interface Threat {
+  category: string;
+  details: string;
+  product_ids?: string[];
+}

--- a/client/src/app/pages/csaf-visualizer/utils.test.ts
+++ b/client/src/app/pages/csaf-visualizer/utils.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import { collectProducts, collectRelationshipProducts } from "./utils";
+import type { Branch, Relationship } from "./types";
+
+describe("collectProducts", () => {
+  /** Verifies that a 3-level nested branch tree is flattened into a product map. */
+  it("flattens a nested branch tree (3+ levels deep)", () => {
+    // Given a branch tree with vendor → family → product version
+    const branches: Branch[] = [
+      {
+        category: "vendor",
+        name: "Red Hat",
+        branches: [
+          {
+            category: "product_family",
+            name: "Red Hat Enterprise Linux",
+            branches: [
+              {
+                category: "product_version",
+                name: "RHEL 8",
+                product: {
+                  name: "Red Hat Enterprise Linux 8",
+                  product_id: "rhel-8",
+                },
+              },
+              {
+                category: "product_version",
+                name: "RHEL 9",
+                product: {
+                  name: "Red Hat Enterprise Linux 9",
+                  product_id: "rhel-9",
+                },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        category: "vendor",
+        name: "Fedora",
+        product: {
+          name: "Fedora 40",
+          product_id: "fedora-40",
+        },
+      },
+    ];
+
+    // When collecting products
+    const result = collectProducts(branches);
+
+    // Then all leaf products are in the map
+    expect(result.size).toBe(3);
+    expect(result.get("rhel-8")).toBe("Red Hat Enterprise Linux 8");
+    expect(result.get("rhel-9")).toBe("Red Hat Enterprise Linux 9");
+    expect(result.get("fedora-40")).toBe("Fedora 40");
+  });
+
+  /** Verifies that an empty branch array returns an empty map. */
+  it("returns an empty map for empty branches", () => {
+    const result = collectProducts([]);
+    expect(result.size).toBe(0);
+  });
+
+  /** Verifies that undefined branches return an empty map. */
+  it("returns an empty map for undefined branches", () => {
+    const result = collectProducts(undefined);
+    expect(result.size).toBe(0);
+  });
+
+  /** Verifies that branches without product leaves are skipped. */
+  it("handles branches with no product leaves", () => {
+    const branches: Branch[] = [
+      {
+        category: "vendor",
+        name: "Empty Vendor",
+        branches: [
+          {
+            category: "product_family",
+            name: "Empty Family",
+          },
+        ],
+      },
+    ];
+
+    const result = collectProducts(branches);
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("collectRelationshipProducts", () => {
+  /** Verifies that relationships are mapped to resolved product names. */
+  it("maps relationship references to product names", () => {
+    // Given relationships and a product map
+    const relationships: Relationship[] = [
+      {
+        category: "default_component_of",
+        product_reference: "openssl-1.1",
+        relates_to_product_reference: "rhel-8",
+        full_product_name: {
+          name: "OpenSSL 1.1 as component of RHEL 8",
+          product_id: "openssl-in-rhel8",
+        },
+      },
+    ];
+
+    const productMap = new Map<string, string>([
+      ["openssl-1.1", "OpenSSL 1.1.1k"],
+      ["rhel-8", "Red Hat Enterprise Linux 8"],
+    ]);
+
+    // When collecting relationship products
+    const result = collectRelationshipProducts(relationships, productMap);
+
+    // Then references are resolved to names
+    expect(result).toHaveLength(1);
+    expect(result[0].productReferenceName).toBe("OpenSSL 1.1.1k");
+    expect(result[0].relatesToProductReferenceName).toBe(
+      "Red Hat Enterprise Linux 8",
+    );
+    expect(result[0].category).toBe("default_component_of");
+    expect(result[0].fullProductName).toBe(
+      "OpenSSL 1.1 as component of RHEL 8",
+    );
+  });
+
+  /** Verifies graceful degradation when product references are not in the map. */
+  it("falls back to raw IDs for missing product references", () => {
+    // Given a relationship with references not in the product map
+    const relationships: Relationship[] = [
+      {
+        category: "installed_on",
+        product_reference: "unknown-component",
+        relates_to_product_reference: "unknown-target",
+        full_product_name: {
+          name: "Unknown Component on Unknown Target",
+          product_id: "unknown-combo",
+        },
+      },
+    ];
+
+    const productMap = new Map<string, string>();
+
+    // When collecting relationship products
+    const result = collectRelationshipProducts(relationships, productMap);
+
+    // Then raw IDs are used as fallback names
+    expect(result).toHaveLength(1);
+    expect(result[0].productReferenceName).toBe("unknown-component");
+    expect(result[0].relatesToProductReferenceName).toBe("unknown-target");
+  });
+
+  /** Verifies that undefined relationships return an empty array. */
+  it("returns empty array for undefined relationships", () => {
+    const result = collectRelationshipProducts(
+      undefined,
+      new Map<string, string>(),
+    );
+    expect(result).toHaveLength(0);
+  });
+});

--- a/client/src/app/pages/csaf-visualizer/utils.ts
+++ b/client/src/app/pages/csaf-visualizer/utils.ts
@@ -1,0 +1,76 @@
+import type { Branch, Product, ProductTree, Relationship } from "./types";
+
+/** Flattens the recursive branch tree into a map of product_id to product name. */
+export function collectProducts(
+  branches: Branch[] | undefined,
+): Map<string, string> {
+  const products = new Map<string, string>();
+
+  function walk(branchList: Branch[]) {
+    for (const branch of branchList) {
+      if (branch.product) {
+        products.set(branch.product.product_id, branch.product.name);
+      }
+      if (branch.branches) {
+        walk(branch.branches);
+      }
+    }
+  }
+
+  if (branches) {
+    walk(branches);
+  }
+
+  return products;
+}
+
+/** Collects all product leaf nodes from a branch tree. */
+export function collectProductNodes(branches: Branch[] | undefined): Product[] {
+  const products: Product[] = [];
+
+  function walk(branchList: Branch[]) {
+    for (const branch of branchList) {
+      if (branch.product) {
+        products.push(branch.product);
+      }
+      if (branch.branches) {
+        walk(branch.branches);
+      }
+    }
+  }
+
+  if (branches) {
+    walk(branches);
+  }
+
+  return products;
+}
+
+/** Maps relationship references to resolved product names using the product map. */
+export function collectRelationshipProducts(
+  relationships: Relationship[] | undefined,
+  productMap: Map<string, string>,
+): {
+  productReference: string;
+  productReferenceName: string;
+  relatesToProductReference: string;
+  relatesToProductReferenceName: string;
+  category: string;
+  fullProductName: string;
+}[] {
+  if (!relationships) {
+    return [];
+  }
+
+  return relationships.map((rel) => ({
+    productReference: rel.product_reference,
+    productReferenceName:
+      productMap.get(rel.product_reference) ?? rel.product_reference,
+    relatesToProductReference: rel.relates_to_product_reference,
+    relatesToProductReferenceName:
+      productMap.get(rel.relates_to_product_reference) ??
+      rel.relates_to_product_reference,
+    category: rel.category,
+    fullProductName: rel.full_product_name.name,
+  }));
+}

--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -19,6 +19,8 @@ import {
   updateAdvisoryLabels,
 } from "@app/client";
 
+import type { CsafDocument } from "@app/pages/csaf-visualizer";
+
 import { uploadAdvisory } from "@app/api/rest";
 import {
   labelRequestParamsQuery,
@@ -125,6 +127,27 @@ export const useDeleteAdvisoryMutation = (
       await queryClient.invalidateQueries({ queryKey: [AdvisoriesQueryKey] });
     },
   });
+};
+
+/** Fetches and parses the raw advisory source document as a typed CSAF document. */
+export const useFetchCsafSource = (id: string) => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: [AdvisoriesQueryKey, id, "csaf-source"],
+    queryFn: async () => {
+      const response = await downloadAdvisory({ client, path: { key: id } });
+      const rawData = response.data;
+      const parsed =
+        typeof rawData === "string" ? JSON.parse(rawData) : rawData;
+      return parsed as CsafDocument;
+    },
+    enabled: !!id,
+  });
+
+  return {
+    csafDocument: data,
+    isFetching: isLoading,
+    fetchError: error as AxiosError | null,
+  };
 };
 
 export const useFetchAdvisorySourceById = (id: string) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,8 @@
         "@tanstack/react-query-devtools": "^5.61.0",
         "axios": "^1.16.0",
         "dayjs": "^1.11.18",
+        "echarts": "^6.1.0",
+        "echarts-for-react": "^3.0.6",
         "file-saver": "^2.0.5",
         "oidc-client-ts": "^3.3.0",
         "packageurl-js": "^2.0.1",
@@ -6200,6 +6202,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/echarts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.1.0"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6888,7 +6920,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -11458,6 +11489,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -13605,6 +13642,21 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "server": {
       "name": "@trustify-ui/server",


### PR DESCRIPTION
## Summary
- **TC-4601**: Add CSAF tab container with advisory type detection (`labels.type === "csaf"`), `useFetchCsafSource` query hook, Source tab with raw JSON display, and placeholder stubs for remaining tabs
- **TC-4602**: Implement CSAF Overview tab with document metadata cards, impact summary chart, remediation status donut chart, references, revision history, and notes
- **TC-4603**: Implement CSAF Vulnerabilities tab with per-CVE cards sorted by CVSS score, expandable CVSS breakdown, affected products with "+N more" toggle, remediations with linkified URLs, and empty state
- **TC-4604**: Implement Product Tree (ECharts interactive tree with color-coded categories, auto-collapse for large subtrees) and Relationship Tree (ECharts tree grouped by target product with color-coded relationship types)

## Test plan
- [x] `npm run lint -w client` passes
- [x] `npm run format -w client` passes  
- [x] `npm run build -w client` succeeds
- [x] All 31 unit tests pass (7 test files)
- [ ] Manual: Navigate to CSAF advisory → 5 CSAF tabs appear (Overview, Vulnerabilities, Product Tree, Relationship Tree, Source)
- [ ] Manual: Navigate to non-CSAF advisory → standard 2 tabs appear (no regression)
- [ ] Manual: Source tab shows formatted JSON with self-reference link
- [ ] Manual: Overview tab shows metadata, charts, references
- [ ] Manual: Vulnerabilities tab shows sorted CVE cards with CVSS details
- [ ] Manual: Product Tree shows interactive ECharts tree
- [ ] Manual: Relationship Tree tab hidden when no relationships exist

Implements [TC-4601](https://redhat.atlassian.net/browse/TC-4601), [TC-4602](https://redhat.atlassian.net/browse/TC-4602), [TC-4603](https://redhat.atlassian.net/browse/TC-4603), [TC-4604](https://redhat.atlassian.net/browse/TC-4604)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4601]: https://redhat.atlassian.net/browse/TC-4601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add a CSAF-specific advisory visualization experience with dedicated tabs, leveraging parsed CSAF source data and new charting dependencies.

New Features:
- Introduce CSAF advisory tab layout that replaces the standard info/vulnerabilities view for advisories labeled as CSAF, with Overview, Vulnerabilities, Product Tree, optional Relationship Tree, and Source tabs.
- Add a CSAF document overview view that surfaces document metadata, severity and remediation summaries, references, revision history, and notes.
- Add a CSAF vulnerabilities view showing per-CVE cards with CVSS details, affected product status, remediations, references, threats, and notes.
- Add interactive CSAF product and relationship tree visualizations using ECharts to explore product hierarchies and relationships.
- Add a CSAF source view that displays the raw CSAF JSON along with a self-reference link when available.
- Introduce a React Query hook to download and parse advisory content as a typed CSAF document and a shared CSAF type/utility module.

Build:
- Add echarts and echarts-for-react dependencies for interactive CSAF tree visualizations.

Tests:
- Add unit tests for CSAF visualizer utilities.