### PR TITLE
feat(advisory): add CSAF 2.0 types, query hook, and ECharts dependency

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,8 @@
     "@tanstack/react-query-devtools": "^5.61.0",
     "axios": "^1.16.0",
     "dayjs": "^1.11.18",
+    "echarts": "^5.6.0",
+    "echarts-for-react": "^3.0.2",
     "file-saver": "^2.0.5",
     "oidc-client-ts": "^3.3.0",
     "packageurl-js": "^2.0.1",

--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -18,6 +18,7 @@ import {
   listAdvisoryLabels,
   updateAdvisoryLabels,
 } from "@app/client";
+import type { CsafDocument } from "@app/types/csaf";
 
 import { uploadAdvisory } from "@app/api/rest";
 import {
@@ -136,6 +137,26 @@ export const useFetchAdvisorySourceById = (id: string) => {
 
   return {
     source: data,
+    isFetching: isLoading,
+    fetchError: error as AxiosError | null,
+  };
+};
+
+/** Fetches the raw CSAF JSON document and parses it into a typed CsafDocument. */
+export const useFetchAdvisoryCsafById = (id: string) => {
+  const { data, isLoading, error } = useQuery<CsafDocument>({
+    queryKey: [AdvisoriesQueryKey, id, "csaf"],
+    queryFn: async () => {
+      const response = await downloadAdvisory({ client, path: { key: id } });
+      const blob = response.data as Blob;
+      const text = await blob.text();
+      return JSON.parse(text) as CsafDocument;
+    },
+    enabled: !!id,
+  });
+
+  return {
+    csafDocument: data,
     isFetching: isLoading,
     fetchError: error as AxiosError | null,
   };

--- a/client/src/app/types/csaf.ts
+++ b/client/src/app/types/csaf.ts
@@ -1,0 +1,290 @@
+/** CSAF 2.0 VEX document type definitions per the OASIS CSAF JSON schema. */
+
+/** Top-level CSAF document container. */
+export interface CsafDocument {
+  document: CsafDocumentMetadata;
+  product_tree?: CsafProductTree;
+  vulnerabilities?: CsafVulnerability[];
+}
+
+/** Document-level metadata section. */
+export interface CsafDocumentMetadata {
+  category: string;
+  csaf_version: string;
+  title: string;
+  publisher: CsafPublisher;
+  tracking: CsafTracking;
+  notes?: CsafNote[];
+  references?: CsafReference[];
+  distribution?: CsafDistribution;
+  aggregate_severity?: CsafAggregateSeverity;
+  lang?: string;
+  source_lang?: string;
+}
+
+/** Document publisher information. */
+export interface CsafPublisher {
+  category: string;
+  name: string;
+  namespace: string;
+  contact_details?: string;
+  issuing_authority?: string;
+}
+
+/** Document tracking metadata including revision history. */
+export interface CsafTracking {
+  current_release_date: string;
+  id: string;
+  initial_release_date: string;
+  revision_history: CsafRevision[];
+  status: string;
+  version: string;
+  generator?: CsafGenerator;
+  aliases?: string[];
+}
+
+/** Document version revision entry. */
+export interface CsafRevision {
+  date: string;
+  number: string;
+  summary: string;
+}
+
+/** Tool that generated the CSAF document. */
+export interface CsafGenerator {
+  engine: CsafGeneratorEngine;
+  date?: string;
+}
+
+/** Generator engine identification. */
+export interface CsafGeneratorEngine {
+  name: string;
+  version?: string;
+}
+
+/** Document-level note. */
+export interface CsafNote {
+  category: string;
+  text: string;
+  audience?: string;
+  title?: string;
+}
+
+/** External reference link. */
+export interface CsafReference {
+  url: string;
+  summary?: string;
+  category?: string;
+}
+
+/** TLP distribution information. */
+export interface CsafDistribution {
+  text?: string;
+  tlp?: CsafTlp;
+}
+
+/** Traffic Light Protocol classification. */
+export interface CsafTlp {
+  label: string;
+  url?: string;
+}
+
+/** Aggregate severity for the entire document. */
+export interface CsafAggregateSeverity {
+  text: string;
+  namespace?: string;
+}
+
+/** Product tree describing the vendor/product/version hierarchy. */
+export interface CsafProductTree {
+  branches?: CsafBranch[];
+  full_product_names?: CsafFullProductName[];
+  relationships?: CsafRelationship[];
+  product_groups?: CsafProductGroup[];
+}
+
+/** Recursive branch in the product tree hierarchy. */
+export interface CsafBranch {
+  category: string;
+  name: string;
+  branches?: CsafBranch[];
+  product?: CsafFullProductName;
+}
+
+/** A uniquely identifiable product with an ID and display name. */
+export interface CsafFullProductName {
+  name: string;
+  product_id: string;
+  product_identification_helper?: CsafProductIdentificationHelper;
+}
+
+/** Helper data for identifying a product (CPE, PURL, etc.). */
+export interface CsafProductIdentificationHelper {
+  cpe?: string;
+  purl?: string;
+  hashes?: CsafHash[];
+  model_numbers?: string[];
+  serial_numbers?: string[];
+  skus?: string[];
+  x_generic_uris?: CsafGenericUri[];
+}
+
+/** Cryptographic hash for product identification. */
+export interface CsafHash {
+  file_hashes: CsafFileHash[];
+  filename: string;
+}
+
+/** Individual file hash entry. */
+export interface CsafFileHash {
+  algorithm: string;
+  value: string;
+}
+
+/** Generic URI reference. */
+export interface CsafGenericUri {
+  namespace: string;
+  uri: string;
+}
+
+/** Relationship between two products. */
+export interface CsafRelationship {
+  category: string;
+  full_product_name: CsafFullProductName;
+  product_reference: string;
+  relates_to_product_reference: string;
+}
+
+/** Named group of product IDs. */
+export interface CsafProductGroup {
+  group_id: string;
+  product_ids: string[];
+  summary?: string;
+}
+
+/** Vulnerability entry in a CSAF document. */
+export interface CsafVulnerability {
+  cve?: string;
+  cwe?: CsafCwe;
+  title?: string;
+  notes?: CsafNote[];
+  references?: CsafReference[];
+  discovery_date?: string;
+  release_date?: string;
+  scores?: CsafScore[];
+  product_status?: CsafProductStatus;
+  remediations?: CsafRemediation[];
+  threats?: CsafThreat[];
+  acknowledgments?: CsafAcknowledgment[];
+  involvements?: CsafInvolvement[];
+  ids?: CsafVulnerabilityId[];
+}
+
+/** CWE weakness classification. */
+export interface CsafCwe {
+  id: string;
+  name: string;
+}
+
+/** CVSS scoring data for a set of products. */
+export interface CsafScore {
+  products: string[];
+  cvss_v3?: CsafCvssV3;
+  cvss_v2?: CsafCvssV2;
+}
+
+/** CVSS v3.x score details. */
+export interface CsafCvssV3 {
+  version: string;
+  vectorString: string;
+  baseScore: number;
+  baseSeverity: string;
+  attackVector?: string;
+  attackComplexity?: string;
+  privilegesRequired?: string;
+  userInteraction?: string;
+  scope?: string;
+  confidentialityImpact?: string;
+  integrityImpact?: string;
+  availabilityImpact?: string;
+  exploitCodeMaturity?: string;
+  remediationLevel?: string;
+  reportConfidence?: string;
+  temporalScore?: number;
+  temporalSeverity?: string;
+  environmentalScore?: number;
+  environmentalSeverity?: string;
+}
+
+/** CVSS v2 score details. */
+export interface CsafCvssV2 {
+  version: string;
+  vectorString: string;
+  baseScore: number;
+  accessVector?: string;
+  accessComplexity?: string;
+  authentication?: string;
+  confidentialityImpact?: string;
+  integrityImpact?: string;
+  availabilityImpact?: string;
+}
+
+/** Product status categories per vulnerability. */
+export interface CsafProductStatus {
+  fixed?: string[];
+  known_affected?: string[];
+  known_not_affected?: string[];
+  first_affected?: string[];
+  first_fixed?: string[];
+  last_affected?: string[];
+  recommended?: string[];
+  under_investigation?: string[];
+}
+
+/** Remediation action for affected products. */
+export interface CsafRemediation {
+  category: string;
+  details: string;
+  product_ids?: string[];
+  group_ids?: string[];
+  url?: string;
+  date?: string;
+  entitlements?: string[];
+  restart_required?: CsafRestartRequired;
+}
+
+/** Restart requirement for a remediation. */
+export interface CsafRestartRequired {
+  category: string;
+  details?: string;
+}
+
+/** Threat information for affected products. */
+export interface CsafThreat {
+  category: string;
+  details: string;
+  product_ids?: string[];
+  group_ids?: string[];
+  date?: string;
+}
+
+/** Acknowledgment of contributors or reporters. */
+export interface CsafAcknowledgment {
+  names?: string[];
+  organization?: string;
+  summary?: string;
+  urls?: string[];
+}
+
+/** Involvement of a party in vulnerability handling. */
+export interface CsafInvolvement {
+  party: string;
+  status: string;
+  summary?: string;
+}
+
+/** Alternative vulnerability identifier. */
+export interface CsafVulnerabilityId {
+  system_name: string;
+  text: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,8 @@
         "@tanstack/react-query-devtools": "^5.61.0",
         "axios": "^1.16.0",
         "dayjs": "^1.11.18",
+        "echarts": "^5.6.0",
+        "echarts-for-react": "^3.0.2",
         "file-saver": "^2.0.5",
         "oidc-client-ts": "^3.3.0",
         "packageurl-js": "^2.0.1",
@@ -6200,6 +6202,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6888,7 +6920,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -11458,6 +11489,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -13605,6 +13642,21 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "server": {
       "name": "@trustify-ui/server",


### PR DESCRIPTION
## Summary
- Define TypeScript interfaces for the full CSAF 2.0 VEX document structure (`CsafDocument`, `CsafVulnerability`, `CsafProductTree`, `CsafBranch`, `CsafRelationship`, etc.)
- Add `useFetchAdvisoryCsafById` query hook that fetches raw CSAF JSON via `downloadAdvisory` endpoint and parses `Blob` into typed `CsafDocument`
- Add `echarts` and `echarts-for-react` dependencies to client workspace

## Test plan
- [x] `npm run build -w client` succeeds
- [x] All 24 unit tests pass
- [x] Biome check passes
- [x] TypeScript compilation verifies CSAF type correctness

Implements [TC-4618](https://redhat.atlassian.net/browse/TC-4618)

Assisted-by: Claude Code

[TC-4618]: https://redhat.atlassian.net/browse/TC-4618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce CSAF 2.0 VEX document support in the client, including typed models and a query hook for fetching advisory CSAF data.

New Features:
- Add a React Query hook to fetch and parse CSAF JSON for an advisory into a typed CsafDocument.
- Define TypeScript interfaces representing the CSAF 2.0 VEX document structure used by advisories.

Enhancements:
- Integrate ECharts dependencies into the client workspace to enable future CSAF-related visualizations.

Build:
- Add echarts and echarts-for-react runtime dependencies to the client package configuration.