### PR TITLE
feat(advisory): implement CSAF Product Tree tab with ECharts tree visualization

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,8 @@
     "@tanstack/react-query-devtools": "^5.61.0",
     "axios": "^1.16.0",
     "dayjs": "^1.11.18",
+    "echarts": "^5.6.0",
+    "echarts-for-react": "^3.0.2",
     "file-saver": "^2.0.5",
     "oidc-client-ts": "^3.3.0",
     "packageurl-js": "^2.0.1",

--- a/client/src/app/pages/advisory-details/advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/advisory-details.tsx
@@ -43,9 +43,11 @@ import {
   useFetchAdvisoryById,
 } from "@app/queries/advisories";
 
+import { DocumentMetadata } from "@app/components/DocumentMetadata";
+
+import { CsafAdvisoryDetails } from "./csaf-advisory-details";
 import { Overview } from "./overview";
 import { VulnerabilitiesByAdvisory } from "./vulnerabilities-by-advisory";
-import { DocumentMetadata } from "@app/components/DocumentMetadata";
 
 export const AdvisoryDetails: React.FC = () => {
   const navigate = useNavigate();
@@ -87,11 +89,13 @@ export const AdvisoryDetails: React.FC = () => {
   const { mutate: deleteAdvisory, isPending: isDeleting } =
     useDeleteAdvisoryMutation(onDeleteAdvisorySuccess, onDeleteAdvisoryError);
 
-  // Tabs
+  const isCsaf = advisory?.labels.type === "csaf";
+
+  // Tabs (default non-CSAF layout)
   const {
     propHelpers: { getTabsProps, getTabProps, getTabContentProps },
   } = useTabControls({
-    persistenceKeyPrefix: "ad", // ad="advisory details"
+    persistenceKeyPrefix: "ad",
     persistTo: "urlParams",
     tabKeys: ["info", "vulnerabilities"],
   });
@@ -177,47 +181,54 @@ export const AdvisoryDetails: React.FC = () => {
           </SplitItem>
         </Split>
       </PageSection>
-      <PageSection>
-        <Tabs
-          mountOnEnter
-          {...getTabsProps()}
-          aria-label="Tabs that contain the Advisory information"
-          role="region"
-        >
-          <Tab
-            {...getTabProps("info")}
-            title={<TabTitleText>Info</TabTitleText>}
-            tabContentRef={infoTabRef}
-          />
-          <Tab
-            {...getTabProps("vulnerabilities")}
-            title={<TabTitleText>Vulnerabilities</TabTitleText>}
-            tabContentRef={vulnerabilitiesTabRef}
-          />
-        </Tabs>
-      </PageSection>
-      <PageSection>
-        <TabContent
-          {...getTabContentProps("info")}
-          ref={infoTabRef}
-          aria-label="Information of the Advisory"
-        >
-          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
-            {advisory && <Overview advisory={advisory} />}
-          </LoadingWrapper>
-        </TabContent>
-        <TabContent
-          {...getTabContentProps("vulnerabilities")}
-          ref={vulnerabilitiesTabRef}
-          aria-label="Vulnerabilities within the Advisory"
-        >
-          <VulnerabilitiesByAdvisory
-            isFetching={isFetching}
-            fetchError={fetchError}
-            vulnerabilities={advisory?.vulnerabilities || []}
-          />
-        </TabContent>
-      </PageSection>
+
+      {isCsaf ? (
+        <CsafAdvisoryDetails advisoryId={advisoryId} />
+      ) : (
+        <>
+          <PageSection>
+            <Tabs
+              mountOnEnter
+              {...getTabsProps()}
+              aria-label="Tabs that contain the Advisory information"
+              role="region"
+            >
+              <Tab
+                {...getTabProps("info")}
+                title={<TabTitleText>Info</TabTitleText>}
+                tabContentRef={infoTabRef}
+              />
+              <Tab
+                {...getTabProps("vulnerabilities")}
+                title={<TabTitleText>Vulnerabilities</TabTitleText>}
+                tabContentRef={vulnerabilitiesTabRef}
+              />
+            </Tabs>
+          </PageSection>
+          <PageSection>
+            <TabContent
+              {...getTabContentProps("info")}
+              ref={infoTabRef}
+              aria-label="Information of the Advisory"
+            >
+              <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+                {advisory && <Overview advisory={advisory} />}
+              </LoadingWrapper>
+            </TabContent>
+            <TabContent
+              {...getTabContentProps("vulnerabilities")}
+              ref={vulnerabilitiesTabRef}
+              aria-label="Vulnerabilities within the Advisory"
+            >
+              <VulnerabilitiesByAdvisory
+                isFetching={isFetching}
+                fetchError={fetchError}
+                vulnerabilities={advisory?.vulnerabilities || []}
+              />
+            </TabContent>
+          </PageSection>
+        </>
+      )}
 
       <ConfirmDialog
         {...advisoryDeleteDialogProps(advisory)}

--- a/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
@@ -17,6 +17,8 @@ import { LoadingWrapper } from "@app/components/LoadingWrapper";
 import { useTabControls } from "@app/hooks/tab-controls";
 import { useFetchAdvisoryCsafById } from "@app/queries/advisories";
 
+import { CsafProductTree } from "./csaf-product-tree";
+
 interface CsafAdvisoryDetailsProps {
   advisoryId: string;
 }
@@ -116,7 +118,7 @@ export const CsafAdvisoryDetails: React.FC<CsafAdvisoryDetailsProps> = ({
             ref={productTreeTabRef}
             aria-label="CSAF product tree"
           >
-            <ComingSoon label="Product Tree" />
+            {csafDocument && <CsafProductTree csafDocument={csafDocument} />}
           </TabContent>
           <TabContent
             {...getTabContentProps("relationship-tree")}

--- a/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
@@ -1,0 +1,139 @@
+/** CSAF-specific advisory details with 5-tab layout for VEX document visualization. */
+import React from "react";
+
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  PageSection,
+  Tab,
+  TabContent,
+  Tabs,
+  TabTitleText,
+} from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+
+import { LoadingWrapper } from "@app/components/LoadingWrapper";
+import { useTabControls } from "@app/hooks/tab-controls";
+import { useFetchAdvisoryCsafById } from "@app/queries/advisories";
+
+interface CsafAdvisoryDetailsProps {
+  advisoryId: string;
+}
+
+/** Placeholder for tabs not yet implemented. */
+const ComingSoon: React.FC<{ label: string }> = ({ label }) => (
+  <EmptyState
+    titleText={label}
+    headingLevel="h2"
+    icon={CubesIcon}
+    variant={EmptyStateVariant.sm}
+  >
+    <EmptyStateBody>This tab is under construction.</EmptyStateBody>
+  </EmptyState>
+);
+
+export const CsafAdvisoryDetails: React.FC<CsafAdvisoryDetailsProps> = ({
+  advisoryId,
+}) => {
+  const { csafDocument, isFetching, fetchError } =
+    useFetchAdvisoryCsafById(advisoryId);
+
+  const {
+    propHelpers: { getTabsProps, getTabProps, getTabContentProps },
+  } = useTabControls({
+    persistenceKeyPrefix: "cad",
+    persistTo: "urlParams",
+    tabKeys: [
+      "overview",
+      "vulnerabilities",
+      "product-tree",
+      "relationship-tree",
+      "source",
+    ],
+  });
+
+  const overviewTabRef = React.createRef<HTMLElement>();
+  const vulnerabilitiesTabRef = React.createRef<HTMLElement>();
+  const productTreeTabRef = React.createRef<HTMLElement>();
+  const relationshipTreeTabRef = React.createRef<HTMLElement>();
+  const sourceTabRef = React.createRef<HTMLElement>();
+
+  return (
+    <>
+      <PageSection>
+        <Tabs
+          mountOnEnter
+          {...getTabsProps()}
+          aria-label="CSAF advisory visualization tabs"
+          role="region"
+        >
+          <Tab
+            {...getTabProps("overview")}
+            title={<TabTitleText>Overview</TabTitleText>}
+            tabContentRef={overviewTabRef}
+          />
+          <Tab
+            {...getTabProps("vulnerabilities")}
+            title={<TabTitleText>Vulnerabilities</TabTitleText>}
+            tabContentRef={vulnerabilitiesTabRef}
+          />
+          <Tab
+            {...getTabProps("product-tree")}
+            title={<TabTitleText>Product Tree</TabTitleText>}
+            tabContentRef={productTreeTabRef}
+          />
+          <Tab
+            {...getTabProps("relationship-tree")}
+            title={<TabTitleText>Relationship Tree</TabTitleText>}
+            tabContentRef={relationshipTreeTabRef}
+          />
+          <Tab
+            {...getTabProps("source")}
+            title={<TabTitleText>Source</TabTitleText>}
+            tabContentRef={sourceTabRef}
+          />
+        </Tabs>
+      </PageSection>
+      <PageSection>
+        <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+          <TabContent
+            {...getTabContentProps("overview")}
+            ref={overviewTabRef}
+            aria-label="CSAF document overview"
+          >
+            <ComingSoon label="Overview" />
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("vulnerabilities")}
+            ref={vulnerabilitiesTabRef}
+            aria-label="CSAF vulnerabilities"
+          >
+            <ComingSoon label="Vulnerabilities" />
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("product-tree")}
+            ref={productTreeTabRef}
+            aria-label="CSAF product tree"
+          >
+            <ComingSoon label="Product Tree" />
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("relationship-tree")}
+            ref={relationshipTreeTabRef}
+            aria-label="CSAF relationship tree"
+          >
+            <ComingSoon label="Relationship Tree" />
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("source")}
+            ref={sourceTabRef}
+            aria-label="CSAF source document"
+          >
+            <ComingSoon label="Source" />
+          </TabContent>
+        </LoadingWrapper>
+      </PageSection>
+    </>
+  );
+};

--- a/client/src/app/pages/advisory-details/csaf-product-tree.tsx
+++ b/client/src/app/pages/advisory-details/csaf-product-tree.tsx
@@ -1,0 +1,142 @@
+/** CSAF Product Tree tab with ECharts interactive tree visualization. */
+import React from "react";
+
+import ReactECharts from "echarts-for-react";
+
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Flex,
+  FlexItem,
+} from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+
+import type { CsafDocument } from "@app/types/csaf";
+
+import {
+  BRANCH_CATEGORY_COLORS,
+  transformBranchesToTreeData,
+} from "./helpers/csaf-tree-helpers";
+
+interface CsafProductTreeProps {
+  csafDocument: CsafDocument;
+}
+
+/** Color-coded legend for branch categories. */
+const CategoryLegend: React.FC = () => {
+  const entries = Object.entries(BRANCH_CATEGORY_COLORS);
+  return (
+    <Flex
+      gap={{ default: "gapMd" }}
+      flexWrap={{ default: "wrap" }}
+      justifyContent={{ default: "justifyContentCenter" }}
+    >
+      {entries.map(([category, color]) => (
+        <FlexItem key={category}>
+          <Flex
+            gap={{ default: "gapXs" }}
+            alignItems={{ default: "alignItemsCenter" }}
+          >
+            <FlexItem>
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 12,
+                  height: 12,
+                  borderRadius: "50%",
+                  backgroundColor: color,
+                }}
+              />
+            </FlexItem>
+            <FlexItem>
+              <span style={{ fontSize: "var(--pf-t--global--font--size--sm)" }}>
+                {category.replace(/_/g, " ")}
+              </span>
+            </FlexItem>
+          </Flex>
+        </FlexItem>
+      ))}
+    </Flex>
+  );
+};
+
+export const CsafProductTree: React.FC<CsafProductTreeProps> = ({
+  csafDocument,
+}) => {
+  const branches = csafDocument.product_tree?.branches;
+
+  const treeData = React.useMemo(() => {
+    if (!branches || branches.length === 0) return null;
+    return transformBranchesToTreeData(branches);
+  }, [branches]);
+
+  if (!treeData) {
+    return (
+      <EmptyState
+        titleText="No product tree available"
+        headingLevel="h2"
+        icon={CubesIcon}
+        variant={EmptyStateVariant.sm}
+      >
+        <EmptyStateBody>
+          This advisory does not contain product tree data.
+        </EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  const option = {
+    tooltip: {
+      trigger: "item" as const,
+      triggerOn: "mousemove" as const,
+      formatter: (params: { data?: { name?: string; value?: string } }) => {
+        const category = params.data?.value;
+        return category
+          ? `${params.data?.name}<br/><em>${category.replace(/_/g, " ")}</em>`
+          : params.data?.name || "";
+      },
+    },
+    series: [
+      {
+        type: "tree" as const,
+        data: [treeData],
+        orient: "LR" as const,
+        roam: true,
+        initialTreeDepth: 2,
+        expandAndCollapse: true,
+        animationDuration: 550,
+        animationDurationUpdate: 750,
+        label: {
+          position: "left" as const,
+          verticalAlign: "middle" as const,
+          align: "right" as const,
+          fontSize: 11,
+        },
+        leaves: {
+          label: {
+            position: "right" as const,
+            verticalAlign: "middle" as const,
+            align: "left" as const,
+          },
+        },
+      },
+    ],
+  };
+
+  return (
+    <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+      <FlexItem>
+        <ReactECharts
+          option={option}
+          style={{ height: "600px", width: "100%" }}
+          notMerge
+          lazyUpdate
+        />
+      </FlexItem>
+      <FlexItem>
+        <CategoryLegend />
+      </FlexItem>
+    </Flex>
+  );
+};

--- a/client/src/app/pages/advisory-details/helpers/csaf-tree-helpers.ts
+++ b/client/src/app/pages/advisory-details/helpers/csaf-tree-helpers.ts
@@ -1,0 +1,64 @@
+/** Helpers for transforming CSAF branch data into ECharts tree format. */
+import type { CsafBranch } from "@app/types/csaf";
+
+/** ECharts tree node data shape. */
+export interface EChartsTreeNode {
+  name: string;
+  value?: string;
+  collapsed?: boolean;
+  itemStyle?: { color: string };
+  children?: EChartsTreeNode[];
+}
+
+const AUTO_COLLAPSE_THRESHOLD = 40;
+
+/** Color mapping for CSAF branch categories. */
+export const BRANCH_CATEGORY_COLORS: Record<string, string> = {
+  vendor: "#0066CC",
+  product_family: "#009596",
+  product_name: "#4CB140",
+  product_version: "#EC7A08",
+  product_version_range: "#6753AC",
+  architecture: "#8A8D90",
+  language: "#C9190B",
+  legacy: "#F4C145",
+  patch_level: "#38812F",
+  service_pack: "#2B9AF3",
+};
+
+/** Counts leaf nodes in a CSAF branch subtree. */
+function countLeaves(branch: CsafBranch): number {
+  if (!branch.branches || branch.branches.length === 0) {
+    return 1;
+  }
+  return branch.branches.reduce((sum, child) => sum + countLeaves(child), 0);
+}
+
+/** Transforms a single CSAF branch into an ECharts tree node. */
+function transformBranch(branch: CsafBranch): EChartsTreeNode {
+  const leafCount = countLeaves(branch);
+  const node: EChartsTreeNode = {
+    name: branch.name,
+    value: branch.category,
+    itemStyle: {
+      color: BRANCH_CATEGORY_COLORS[branch.category] || "#8A8D90",
+    },
+    collapsed: leafCount > AUTO_COLLAPSE_THRESHOLD,
+  };
+
+  if (branch.branches && branch.branches.length > 0) {
+    node.children = branch.branches.map(transformBranch);
+  }
+
+  return node;
+}
+
+/** Transforms CSAF branches array into ECharts tree data with a virtual root. */
+export function transformBranchesToTreeData(
+  branches: CsafBranch[],
+): EChartsTreeNode {
+  return {
+    name: "Product Tree",
+    children: branches.map(transformBranch),
+  };
+}

--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -18,6 +18,7 @@ import {
   listAdvisoryLabels,
   updateAdvisoryLabels,
 } from "@app/client";
+import type { CsafDocument } from "@app/types/csaf";
 
 import { uploadAdvisory } from "@app/api/rest";
 import {
@@ -136,6 +137,26 @@ export const useFetchAdvisorySourceById = (id: string) => {
 
   return {
     source: data,
+    isFetching: isLoading,
+    fetchError: error as AxiosError | null,
+  };
+};
+
+/** Fetches the raw CSAF JSON document and parses it into a typed CsafDocument. */
+export const useFetchAdvisoryCsafById = (id: string) => {
+  const { data, isLoading, error } = useQuery<CsafDocument>({
+    queryKey: [AdvisoriesQueryKey, id, "csaf"],
+    queryFn: async () => {
+      const response = await downloadAdvisory({ client, path: { key: id } });
+      const blob = response.data as Blob;
+      const text = await blob.text();
+      return JSON.parse(text) as CsafDocument;
+    },
+    enabled: !!id,
+  });
+
+  return {
+    csafDocument: data,
     isFetching: isLoading,
     fetchError: error as AxiosError | null,
   };

--- a/client/src/app/types/csaf.ts
+++ b/client/src/app/types/csaf.ts
@@ -1,0 +1,290 @@
+/** CSAF 2.0 VEX document type definitions per the OASIS CSAF JSON schema. */
+
+/** Top-level CSAF document container. */
+export interface CsafDocument {
+  document: CsafDocumentMetadata;
+  product_tree?: CsafProductTree;
+  vulnerabilities?: CsafVulnerability[];
+}
+
+/** Document-level metadata section. */
+export interface CsafDocumentMetadata {
+  category: string;
+  csaf_version: string;
+  title: string;
+  publisher: CsafPublisher;
+  tracking: CsafTracking;
+  notes?: CsafNote[];
+  references?: CsafReference[];
+  distribution?: CsafDistribution;
+  aggregate_severity?: CsafAggregateSeverity;
+  lang?: string;
+  source_lang?: string;
+}
+
+/** Document publisher information. */
+export interface CsafPublisher {
+  category: string;
+  name: string;
+  namespace: string;
+  contact_details?: string;
+  issuing_authority?: string;
+}
+
+/** Document tracking metadata including revision history. */
+export interface CsafTracking {
+  current_release_date: string;
+  id: string;
+  initial_release_date: string;
+  revision_history: CsafRevision[];
+  status: string;
+  version: string;
+  generator?: CsafGenerator;
+  aliases?: string[];
+}
+
+/** Document version revision entry. */
+export interface CsafRevision {
+  date: string;
+  number: string;
+  summary: string;
+}
+
+/** Tool that generated the CSAF document. */
+export interface CsafGenerator {
+  engine: CsafGeneratorEngine;
+  date?: string;
+}
+
+/** Generator engine identification. */
+export interface CsafGeneratorEngine {
+  name: string;
+  version?: string;
+}
+
+/** Document-level note. */
+export interface CsafNote {
+  category: string;
+  text: string;
+  audience?: string;
+  title?: string;
+}
+
+/** External reference link. */
+export interface CsafReference {
+  url: string;
+  summary?: string;
+  category?: string;
+}
+
+/** TLP distribution information. */
+export interface CsafDistribution {
+  text?: string;
+  tlp?: CsafTlp;
+}
+
+/** Traffic Light Protocol classification. */
+export interface CsafTlp {
+  label: string;
+  url?: string;
+}
+
+/** Aggregate severity for the entire document. */
+export interface CsafAggregateSeverity {
+  text: string;
+  namespace?: string;
+}
+
+/** Product tree describing the vendor/product/version hierarchy. */
+export interface CsafProductTree {
+  branches?: CsafBranch[];
+  full_product_names?: CsafFullProductName[];
+  relationships?: CsafRelationship[];
+  product_groups?: CsafProductGroup[];
+}
+
+/** Recursive branch in the product tree hierarchy. */
+export interface CsafBranch {
+  category: string;
+  name: string;
+  branches?: CsafBranch[];
+  product?: CsafFullProductName;
+}
+
+/** A uniquely identifiable product with an ID and display name. */
+export interface CsafFullProductName {
+  name: string;
+  product_id: string;
+  product_identification_helper?: CsafProductIdentificationHelper;
+}
+
+/** Helper data for identifying a product (CPE, PURL, etc.). */
+export interface CsafProductIdentificationHelper {
+  cpe?: string;
+  purl?: string;
+  hashes?: CsafHash[];
+  model_numbers?: string[];
+  serial_numbers?: string[];
+  skus?: string[];
+  x_generic_uris?: CsafGenericUri[];
+}
+
+/** Cryptographic hash for product identification. */
+export interface CsafHash {
+  file_hashes: CsafFileHash[];
+  filename: string;
+}
+
+/** Individual file hash entry. */
+export interface CsafFileHash {
+  algorithm: string;
+  value: string;
+}
+
+/** Generic URI reference. */
+export interface CsafGenericUri {
+  namespace: string;
+  uri: string;
+}
+
+/** Relationship between two products. */
+export interface CsafRelationship {
+  category: string;
+  full_product_name: CsafFullProductName;
+  product_reference: string;
+  relates_to_product_reference: string;
+}
+
+/** Named group of product IDs. */
+export interface CsafProductGroup {
+  group_id: string;
+  product_ids: string[];
+  summary?: string;
+}
+
+/** Vulnerability entry in a CSAF document. */
+export interface CsafVulnerability {
+  cve?: string;
+  cwe?: CsafCwe;
+  title?: string;
+  notes?: CsafNote[];
+  references?: CsafReference[];
+  discovery_date?: string;
+  release_date?: string;
+  scores?: CsafScore[];
+  product_status?: CsafProductStatus;
+  remediations?: CsafRemediation[];
+  threats?: CsafThreat[];
+  acknowledgments?: CsafAcknowledgment[];
+  involvements?: CsafInvolvement[];
+  ids?: CsafVulnerabilityId[];
+}
+
+/** CWE weakness classification. */
+export interface CsafCwe {
+  id: string;
+  name: string;
+}
+
+/** CVSS scoring data for a set of products. */
+export interface CsafScore {
+  products: string[];
+  cvss_v3?: CsafCvssV3;
+  cvss_v2?: CsafCvssV2;
+}
+
+/** CVSS v3.x score details. */
+export interface CsafCvssV3 {
+  version: string;
+  vectorString: string;
+  baseScore: number;
+  baseSeverity: string;
+  attackVector?: string;
+  attackComplexity?: string;
+  privilegesRequired?: string;
+  userInteraction?: string;
+  scope?: string;
+  confidentialityImpact?: string;
+  integrityImpact?: string;
+  availabilityImpact?: string;
+  exploitCodeMaturity?: string;
+  remediationLevel?: string;
+  reportConfidence?: string;
+  temporalScore?: number;
+  temporalSeverity?: string;
+  environmentalScore?: number;
+  environmentalSeverity?: string;
+}
+
+/** CVSS v2 score details. */
+export interface CsafCvssV2 {
+  version: string;
+  vectorString: string;
+  baseScore: number;
+  accessVector?: string;
+  accessComplexity?: string;
+  authentication?: string;
+  confidentialityImpact?: string;
+  integrityImpact?: string;
+  availabilityImpact?: string;
+}
+
+/** Product status categories per vulnerability. */
+export interface CsafProductStatus {
+  fixed?: string[];
+  known_affected?: string[];
+  known_not_affected?: string[];
+  first_affected?: string[];
+  first_fixed?: string[];
+  last_affected?: string[];
+  recommended?: string[];
+  under_investigation?: string[];
+}
+
+/** Remediation action for affected products. */
+export interface CsafRemediation {
+  category: string;
+  details: string;
+  product_ids?: string[];
+  group_ids?: string[];
+  url?: string;
+  date?: string;
+  entitlements?: string[];
+  restart_required?: CsafRestartRequired;
+}
+
+/** Restart requirement for a remediation. */
+export interface CsafRestartRequired {
+  category: string;
+  details?: string;
+}
+
+/** Threat information for affected products. */
+export interface CsafThreat {
+  category: string;
+  details: string;
+  product_ids?: string[];
+  group_ids?: string[];
+  date?: string;
+}
+
+/** Acknowledgment of contributors or reporters. */
+export interface CsafAcknowledgment {
+  names?: string[];
+  organization?: string;
+  summary?: string;
+  urls?: string[];
+}
+
+/** Involvement of a party in vulnerability handling. */
+export interface CsafInvolvement {
+  party: string;
+  status: string;
+  summary?: string;
+}
+
+/** Alternative vulnerability identifier. */
+export interface CsafVulnerabilityId {
+  system_name: string;
+  text: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,8 @@
         "@tanstack/react-query-devtools": "^5.61.0",
         "axios": "^1.16.0",
         "dayjs": "^1.11.18",
+        "echarts": "^5.6.0",
+        "echarts-for-react": "^3.0.2",
         "file-saver": "^2.0.5",
         "oidc-client-ts": "^3.3.0",
         "packageurl-js": "^2.0.1",
@@ -6200,6 +6202,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6888,7 +6920,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -11458,6 +11489,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -13605,6 +13642,21 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "server": {
       "name": "@trustify-ui/server",


### PR DESCRIPTION
## Summary
- Add interactive ECharts tree rendering of CSAF `product_tree.branches` hierarchy (vendor → product family → product name → product version)
- Left-to-right tree layout with click to expand/collapse, scroll to zoom, drag to pan
- Color-coded nodes by branch category (vendor, product_name, product_version, etc.) with legend
- Auto-collapse subtrees with >40 leaves for performance
- Empty state when no product tree data exists
- `React.useMemo` for data transformation performance
- Helper module `csaf-tree-helpers.ts` for reuse by Relationship Tree tab

## Test plan
- [x] Build succeeds (`npm run build -w client`)
- [x] All 24 unit tests pass
- [x] Biome/lint passes
- [x] Tree renders with correct hierarchy from branch data
- [x] Empty state displays when no product tree

Implements [TC-4622](https://redhat.atlassian.net/browse/TC-4622)

Assisted-by: Claude Code

[TC-4622]: https://redhat.atlassian.net/browse/TC-4622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add CSAF-specific advisory details view with a product tree visualization and supporting CSAF data types and query.

New Features:
- Introduce a CSAF-specific advisory details layout with dedicated tabs for overview, vulnerabilities, product tree, relationship tree, and source.
- Render CSAF product_tree branches as an interactive ECharts tree with zoom, pan, expand/collapse behavior, and a category color legend.
- Add a React Query hook to download and parse the raw CSAF JSON document for use in CSAF visualizations.

Enhancements:
- Add strongly typed CSAF 2.0 VEX TypeScript interfaces for documents, product trees, and vulnerabilities.
- Wire advisory details page to switch between the existing view and the CSAF-specific tabbed view based on advisory type.

Build:
- Add ECharts and echarts-for-react as new client-side dependencies.