### PR TITLE
feat(advisory): implement CSAF Overview tab with metadata, charts, refs, and history

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,8 @@
     "@tanstack/react-query-devtools": "^5.61.0",
     "axios": "^1.16.0",
     "dayjs": "^1.11.18",
+    "echarts": "^5.6.0",
+    "echarts-for-react": "^3.0.2",
     "file-saver": "^2.0.5",
     "oidc-client-ts": "^3.3.0",
     "packageurl-js": "^2.0.1",

--- a/client/src/app/pages/advisory-details/advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/advisory-details.tsx
@@ -43,9 +43,11 @@ import {
   useFetchAdvisoryById,
 } from "@app/queries/advisories";
 
+import { DocumentMetadata } from "@app/components/DocumentMetadata";
+
+import { CsafAdvisoryDetails } from "./csaf-advisory-details";
 import { Overview } from "./overview";
 import { VulnerabilitiesByAdvisory } from "./vulnerabilities-by-advisory";
-import { DocumentMetadata } from "@app/components/DocumentMetadata";
 
 export const AdvisoryDetails: React.FC = () => {
   const navigate = useNavigate();
@@ -87,11 +89,13 @@ export const AdvisoryDetails: React.FC = () => {
   const { mutate: deleteAdvisory, isPending: isDeleting } =
     useDeleteAdvisoryMutation(onDeleteAdvisorySuccess, onDeleteAdvisoryError);
 
-  // Tabs
+  const isCsaf = advisory?.labels.type === "csaf";
+
+  // Tabs (default non-CSAF layout)
   const {
     propHelpers: { getTabsProps, getTabProps, getTabContentProps },
   } = useTabControls({
-    persistenceKeyPrefix: "ad", // ad="advisory details"
+    persistenceKeyPrefix: "ad",
     persistTo: "urlParams",
     tabKeys: ["info", "vulnerabilities"],
   });
@@ -177,47 +181,54 @@ export const AdvisoryDetails: React.FC = () => {
           </SplitItem>
         </Split>
       </PageSection>
-      <PageSection>
-        <Tabs
-          mountOnEnter
-          {...getTabsProps()}
-          aria-label="Tabs that contain the Advisory information"
-          role="region"
-        >
-          <Tab
-            {...getTabProps("info")}
-            title={<TabTitleText>Info</TabTitleText>}
-            tabContentRef={infoTabRef}
-          />
-          <Tab
-            {...getTabProps("vulnerabilities")}
-            title={<TabTitleText>Vulnerabilities</TabTitleText>}
-            tabContentRef={vulnerabilitiesTabRef}
-          />
-        </Tabs>
-      </PageSection>
-      <PageSection>
-        <TabContent
-          {...getTabContentProps("info")}
-          ref={infoTabRef}
-          aria-label="Information of the Advisory"
-        >
-          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
-            {advisory && <Overview advisory={advisory} />}
-          </LoadingWrapper>
-        </TabContent>
-        <TabContent
-          {...getTabContentProps("vulnerabilities")}
-          ref={vulnerabilitiesTabRef}
-          aria-label="Vulnerabilities within the Advisory"
-        >
-          <VulnerabilitiesByAdvisory
-            isFetching={isFetching}
-            fetchError={fetchError}
-            vulnerabilities={advisory?.vulnerabilities || []}
-          />
-        </TabContent>
-      </PageSection>
+
+      {isCsaf ? (
+        <CsafAdvisoryDetails advisoryId={advisoryId} />
+      ) : (
+        <>
+          <PageSection>
+            <Tabs
+              mountOnEnter
+              {...getTabsProps()}
+              aria-label="Tabs that contain the Advisory information"
+              role="region"
+            >
+              <Tab
+                {...getTabProps("info")}
+                title={<TabTitleText>Info</TabTitleText>}
+                tabContentRef={infoTabRef}
+              />
+              <Tab
+                {...getTabProps("vulnerabilities")}
+                title={<TabTitleText>Vulnerabilities</TabTitleText>}
+                tabContentRef={vulnerabilitiesTabRef}
+              />
+            </Tabs>
+          </PageSection>
+          <PageSection>
+            <TabContent
+              {...getTabContentProps("info")}
+              ref={infoTabRef}
+              aria-label="Information of the Advisory"
+            >
+              <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+                {advisory && <Overview advisory={advisory} />}
+              </LoadingWrapper>
+            </TabContent>
+            <TabContent
+              {...getTabContentProps("vulnerabilities")}
+              ref={vulnerabilitiesTabRef}
+              aria-label="Vulnerabilities within the Advisory"
+            >
+              <VulnerabilitiesByAdvisory
+                isFetching={isFetching}
+                fetchError={fetchError}
+                vulnerabilities={advisory?.vulnerabilities || []}
+              />
+            </TabContent>
+          </PageSection>
+        </>
+      )}
 
       <ConfirmDialog
         {...advisoryDeleteDialogProps(advisory)}

--- a/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
@@ -17,6 +17,8 @@ import { LoadingWrapper } from "@app/components/LoadingWrapper";
 import { useTabControls } from "@app/hooks/tab-controls";
 import { useFetchAdvisoryCsafById } from "@app/queries/advisories";
 
+import { CsafOverview } from "./csaf-overview";
+
 interface CsafAdvisoryDetailsProps {
   advisoryId: string;
 }
@@ -102,7 +104,7 @@ export const CsafAdvisoryDetails: React.FC<CsafAdvisoryDetailsProps> = ({
             ref={overviewTabRef}
             aria-label="CSAF document overview"
           >
-            <ComingSoon label="Overview" />
+            {csafDocument && <CsafOverview csafDocument={csafDocument} />}
           </TabContent>
           <TabContent
             {...getTabContentProps("vulnerabilities")}

--- a/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
@@ -1,0 +1,139 @@
+/** CSAF-specific advisory details with 5-tab layout for VEX document visualization. */
+import React from "react";
+
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  PageSection,
+  Tab,
+  TabContent,
+  Tabs,
+  TabTitleText,
+} from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+
+import { LoadingWrapper } from "@app/components/LoadingWrapper";
+import { useTabControls } from "@app/hooks/tab-controls";
+import { useFetchAdvisoryCsafById } from "@app/queries/advisories";
+
+interface CsafAdvisoryDetailsProps {
+  advisoryId: string;
+}
+
+/** Placeholder for tabs not yet implemented. */
+const ComingSoon: React.FC<{ label: string }> = ({ label }) => (
+  <EmptyState
+    titleText={label}
+    headingLevel="h2"
+    icon={CubesIcon}
+    variant={EmptyStateVariant.sm}
+  >
+    <EmptyStateBody>This tab is under construction.</EmptyStateBody>
+  </EmptyState>
+);
+
+export const CsafAdvisoryDetails: React.FC<CsafAdvisoryDetailsProps> = ({
+  advisoryId,
+}) => {
+  const { csafDocument, isFetching, fetchError } =
+    useFetchAdvisoryCsafById(advisoryId);
+
+  const {
+    propHelpers: { getTabsProps, getTabProps, getTabContentProps },
+  } = useTabControls({
+    persistenceKeyPrefix: "cad",
+    persistTo: "urlParams",
+    tabKeys: [
+      "overview",
+      "vulnerabilities",
+      "product-tree",
+      "relationship-tree",
+      "source",
+    ],
+  });
+
+  const overviewTabRef = React.createRef<HTMLElement>();
+  const vulnerabilitiesTabRef = React.createRef<HTMLElement>();
+  const productTreeTabRef = React.createRef<HTMLElement>();
+  const relationshipTreeTabRef = React.createRef<HTMLElement>();
+  const sourceTabRef = React.createRef<HTMLElement>();
+
+  return (
+    <>
+      <PageSection>
+        <Tabs
+          mountOnEnter
+          {...getTabsProps()}
+          aria-label="CSAF advisory visualization tabs"
+          role="region"
+        >
+          <Tab
+            {...getTabProps("overview")}
+            title={<TabTitleText>Overview</TabTitleText>}
+            tabContentRef={overviewTabRef}
+          />
+          <Tab
+            {...getTabProps("vulnerabilities")}
+            title={<TabTitleText>Vulnerabilities</TabTitleText>}
+            tabContentRef={vulnerabilitiesTabRef}
+          />
+          <Tab
+            {...getTabProps("product-tree")}
+            title={<TabTitleText>Product Tree</TabTitleText>}
+            tabContentRef={productTreeTabRef}
+          />
+          <Tab
+            {...getTabProps("relationship-tree")}
+            title={<TabTitleText>Relationship Tree</TabTitleText>}
+            tabContentRef={relationshipTreeTabRef}
+          />
+          <Tab
+            {...getTabProps("source")}
+            title={<TabTitleText>Source</TabTitleText>}
+            tabContentRef={sourceTabRef}
+          />
+        </Tabs>
+      </PageSection>
+      <PageSection>
+        <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+          <TabContent
+            {...getTabContentProps("overview")}
+            ref={overviewTabRef}
+            aria-label="CSAF document overview"
+          >
+            <ComingSoon label="Overview" />
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("vulnerabilities")}
+            ref={vulnerabilitiesTabRef}
+            aria-label="CSAF vulnerabilities"
+          >
+            <ComingSoon label="Vulnerabilities" />
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("product-tree")}
+            ref={productTreeTabRef}
+            aria-label="CSAF product tree"
+          >
+            <ComingSoon label="Product Tree" />
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("relationship-tree")}
+            ref={relationshipTreeTabRef}
+            aria-label="CSAF relationship tree"
+          >
+            <ComingSoon label="Relationship Tree" />
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("source")}
+            ref={sourceTabRef}
+            aria-label="CSAF source document"
+          >
+            <ComingSoon label="Source" />
+          </TabContent>
+        </LoadingWrapper>
+      </PageSection>
+    </>
+  );
+};

--- a/client/src/app/pages/advisory-details/csaf-overview.tsx
+++ b/client/src/app/pages/advisory-details/csaf-overview.tsx
@@ -179,8 +179,8 @@ export const CsafOverview: React.FC<CsafOverviewProps> = ({ csafDocument }) => {
                       value={
                         doc.aggregate_severity.text.toLowerCase() as
                           | "critical"
-                          | "important"
-                          | "moderate"
+                          | "high"
+                          | "medium"
                           | "low"
                           | "none"
                       }
@@ -226,8 +226,8 @@ export const CsafOverview: React.FC<CsafOverviewProps> = ({ csafDocument }) => {
                                 value={
                                   severity.toLowerCase() as
                                     | "critical"
-                                    | "important"
-                                    | "moderate"
+                                    | "high"
+                                    | "medium"
                                     | "low"
                                     | "none"
                                 }

--- a/client/src/app/pages/advisory-details/csaf-overview.tsx
+++ b/client/src/app/pages/advisory-details/csaf-overview.tsx
@@ -1,0 +1,376 @@
+/** CSAF Overview tab displaying document metadata, charts, references, revision history, and notes. */
+import React from "react";
+
+import dayjs from "dayjs";
+
+import { ChartDonut } from "@patternfly/react-charts/victory";
+
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Content,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Flex,
+  FlexItem,
+  Grid,
+  GridItem,
+  Label,
+  List,
+  ListItem,
+} from "@patternfly/react-core";
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+
+import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
+import type { CsafDocument, CsafVulnerability } from "@app/types/csaf";
+
+interface CsafOverviewProps {
+  csafDocument: CsafDocument;
+}
+
+/** Severity color mapping for impact summary. */
+const SEVERITY_COLORS: Record<string, string> = {
+  CRITICAL: "#A30000",
+  HIGH: "#C9190B",
+  MEDIUM: "#F0AB00",
+  LOW: "#0066CC",
+  NONE: "#8A8D90",
+};
+
+/** Derives severity counts from CSAF vulnerabilities. */
+function computeSeverityCounts(
+  vulnerabilities?: CsafVulnerability[],
+): { severity: string; count: number }[] {
+  const counts: Record<string, number> = {};
+  if (vulnerabilities) {
+    for (const vuln of vulnerabilities) {
+      const baseSeverity =
+        vuln.scores?.[0]?.cvss_v3?.baseSeverity?.toUpperCase() || "NONE";
+      counts[baseSeverity] = (counts[baseSeverity] || 0) + 1;
+    }
+  }
+  const order = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "NONE"];
+  return order
+    .filter((s) => (counts[s] || 0) > 0)
+    .map((severity) => ({ severity, count: counts[severity] || 0 }));
+}
+
+/** Derives remediation category counts from CSAF vulnerabilities. */
+function computeRemediationCounts(
+  vulnerabilities?: CsafVulnerability[],
+): { category: string; count: number }[] {
+  const counts: Record<string, number> = {};
+  if (vulnerabilities) {
+    for (const vuln of vulnerabilities) {
+      if (vuln.remediations) {
+        for (const rem of vuln.remediations) {
+          counts[rem.category] = (counts[rem.category] || 0) + 1;
+        }
+      }
+    }
+  }
+  return Object.entries(counts).map(([category, count]) => ({
+    category,
+    count,
+  }));
+}
+
+const REMEDIATION_COLORS: Record<string, string> = {
+  vendor_fix: "#4CB140",
+  workaround: "#F0AB00",
+  no_fix_planned: "#C9190B",
+  none_available: "#8A8D90",
+  mitigation: "#0066CC",
+};
+
+export const CsafOverview: React.FC<CsafOverviewProps> = ({ csafDocument }) => {
+  const { document: doc, vulnerabilities } = csafDocument;
+  const severityCounts = React.useMemo(
+    () => computeSeverityCounts(vulnerabilities),
+    [vulnerabilities],
+  );
+  const remediationCounts = React.useMemo(
+    () => computeRemediationCounts(vulnerabilities),
+    [vulnerabilities],
+  );
+  const totalRemediations = remediationCounts.reduce(
+    (sum, r) => sum + r.count,
+    0,
+  );
+
+  return (
+    <Flex direction={{ default: "column" }} gap={{ default: "gapLg" }}>
+      {/* Metadata */}
+      <FlexItem>
+        <Card isPlain>
+          <CardTitle>Document Metadata</CardTitle>
+          <CardBody>
+            <DescriptionList isHorizontal>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Title</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {doc.title}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Tracking ID</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {doc.tracking.id}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Status</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <Label>{doc.tracking.status}</Label>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Version</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {doc.tracking.version}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Category</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {doc.category}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Publisher</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {doc.publisher.name}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Initial release</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {dayjs(doc.tracking.initial_release_date).format(
+                    "YYYY-MM-DD",
+                  )}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Current release</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {dayjs(doc.tracking.current_release_date).format(
+                    "YYYY-MM-DD",
+                  )}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              {doc.tracking.generator && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Generator</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {doc.tracking.generator.engine.name}
+                    {doc.tracking.generator.engine.version &&
+                      ` v${doc.tracking.generator.engine.version}`}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {doc.aggregate_severity && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Severity</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <SeverityShieldAndText
+                      value={
+                        doc.aggregate_severity.text.toLowerCase() as
+                          | "critical"
+                          | "important"
+                          | "moderate"
+                          | "low"
+                          | "none"
+                      }
+                      score={null}
+                    />
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {doc.distribution?.tlp && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>TLP</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <Label>{doc.distribution.tlp.label}</Label>
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+            </DescriptionList>
+          </CardBody>
+        </Card>
+      </FlexItem>
+
+      {/* Charts */}
+      {(severityCounts.length > 0 || remediationCounts.length > 0) && (
+        <FlexItem>
+          <Grid hasGutter>
+            {severityCounts.length > 0 && (
+              <GridItem md={6}>
+                <Card isPlain>
+                  <CardTitle>Impact Summary</CardTitle>
+                  <CardBody>
+                    <Flex
+                      direction={{ default: "column" }}
+                      gap={{ default: "gapSm" }}
+                    >
+                      {severityCounts.map(({ severity, count }) => (
+                        <FlexItem key={severity}>
+                          <Flex
+                            alignItems={{ default: "alignItemsCenter" }}
+                            gap={{ default: "gapSm" }}
+                          >
+                            <FlexItem style={{ minWidth: 120 }}>
+                              <SeverityShieldAndText
+                                value={
+                                  severity.toLowerCase() as
+                                    | "critical"
+                                    | "important"
+                                    | "moderate"
+                                    | "low"
+                                    | "none"
+                                }
+                                score={null}
+                              />
+                            </FlexItem>
+                            <FlexItem>
+                              <div
+                                style={{
+                                  height: 16,
+                                  width: count * 40,
+                                  maxWidth: 300,
+                                  minWidth: 20,
+                                  backgroundColor:
+                                    SEVERITY_COLORS[severity] || "#8A8D90",
+                                  borderRadius: 2,
+                                }}
+                              />
+                            </FlexItem>
+                            <FlexItem>
+                              <strong>{count}</strong>{" "}
+                              {count === 1 ? "CVE" : "CVEs"}
+                            </FlexItem>
+                          </Flex>
+                        </FlexItem>
+                      ))}
+                    </Flex>
+                  </CardBody>
+                </Card>
+              </GridItem>
+            )}
+            {remediationCounts.length > 0 && (
+              <GridItem md={6}>
+                <Card isPlain>
+                  <CardTitle>Remediation Status</CardTitle>
+                  <CardBody>
+                    <div style={{ height: "230px", maxWidth: "350px" }}>
+                      <ChartDonut
+                        constrainToVisibleArea
+                        legendOrientation="vertical"
+                        legendPosition="right"
+                        padding={{
+                          bottom: 20,
+                          left: 20,
+                          right: 140,
+                          top: 20,
+                        }}
+                        title={`${totalRemediations}`}
+                        subTitle="Remediations"
+                        width={350}
+                        legendData={remediationCounts.map(
+                          ({ category, count }) => ({
+                            name: `${category.replace(/_/g, " ")}: ${count}`,
+                          }),
+                        )}
+                        data={remediationCounts.map(({ category, count }) => ({
+                          x: category.replace(/_/g, " "),
+                          y: count,
+                        }))}
+                        labels={({ datum }) => `${datum.x}: ${datum.y}`}
+                        colorScale={remediationCounts.map(
+                          ({ category }) =>
+                            REMEDIATION_COLORS[category] || "#8A8D90",
+                        )}
+                      />
+                    </div>
+                  </CardBody>
+                </Card>
+              </GridItem>
+            )}
+          </Grid>
+        </FlexItem>
+      )}
+
+      {/* References */}
+      {doc.references && doc.references.length > 0 && (
+        <FlexItem>
+          <Card isPlain>
+            <CardTitle>References</CardTitle>
+            <CardBody>
+              <List isPlain>
+                {doc.references.map((ref, i) => (
+                  <ListItem key={`ref-${i}`}>
+                    <a href={ref.url} target="_blank" rel="noopener noreferrer">
+                      {ref.summary || ref.url} <ExternalLinkAltIcon />
+                    </a>
+                    {ref.category && (
+                      <Label isCompact color="grey" style={{ marginLeft: 8 }}>
+                        {ref.category}
+                      </Label>
+                    )}
+                  </ListItem>
+                ))}
+              </List>
+            </CardBody>
+          </Card>
+        </FlexItem>
+      )}
+
+      {/* Revision History */}
+      {doc.tracking.revision_history.length > 0 && (
+        <FlexItem>
+          <Card isPlain>
+            <CardTitle>Revision History</CardTitle>
+            <CardBody>
+              <DescriptionList isHorizontal>
+                {doc.tracking.revision_history.map((rev) => (
+                  <DescriptionListGroup key={rev.number}>
+                    <DescriptionListTerm>
+                      v{rev.number} — {dayjs(rev.date).format("YYYY-MM-DD")}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {rev.summary}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                ))}
+              </DescriptionList>
+            </CardBody>
+          </Card>
+        </FlexItem>
+      )}
+
+      {/* Notes */}
+      {doc.notes && doc.notes.length > 0 && (
+        <FlexItem>
+          <Card isPlain>
+            <CardTitle>Notes</CardTitle>
+            <CardBody>
+              {doc.notes.map((note, i) => (
+                <div key={`note-${i}`} style={{ marginBottom: 16 }}>
+                  {note.title && <Content component="h4">{note.title}</Content>}
+                  {!note.title && note.category && (
+                    <Content component="h4">
+                      {note.category.replace(/_/g, " ")}
+                    </Content>
+                  )}
+                  <Content component="p">{note.text}</Content>
+                </div>
+              ))}
+            </CardBody>
+          </Card>
+        </FlexItem>
+      )}
+    </Flex>
+  );
+};

--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -18,6 +18,7 @@ import {
   listAdvisoryLabels,
   updateAdvisoryLabels,
 } from "@app/client";
+import type { CsafDocument } from "@app/types/csaf";
 
 import { uploadAdvisory } from "@app/api/rest";
 import {
@@ -136,6 +137,26 @@ export const useFetchAdvisorySourceById = (id: string) => {
 
   return {
     source: data,
+    isFetching: isLoading,
+    fetchError: error as AxiosError | null,
+  };
+};
+
+/** Fetches the raw CSAF JSON document and parses it into a typed CsafDocument. */
+export const useFetchAdvisoryCsafById = (id: string) => {
+  const { data, isLoading, error } = useQuery<CsafDocument>({
+    queryKey: [AdvisoriesQueryKey, id, "csaf"],
+    queryFn: async () => {
+      const response = await downloadAdvisory({ client, path: { key: id } });
+      const blob = response.data as Blob;
+      const text = await blob.text();
+      return JSON.parse(text) as CsafDocument;
+    },
+    enabled: !!id,
+  });
+
+  return {
+    csafDocument: data,
     isFetching: isLoading,
     fetchError: error as AxiosError | null,
   };

--- a/client/src/app/types/csaf.ts
+++ b/client/src/app/types/csaf.ts
@@ -1,0 +1,290 @@
+/** CSAF 2.0 VEX document type definitions per the OASIS CSAF JSON schema. */
+
+/** Top-level CSAF document container. */
+export interface CsafDocument {
+  document: CsafDocumentMetadata;
+  product_tree?: CsafProductTree;
+  vulnerabilities?: CsafVulnerability[];
+}
+
+/** Document-level metadata section. */
+export interface CsafDocumentMetadata {
+  category: string;
+  csaf_version: string;
+  title: string;
+  publisher: CsafPublisher;
+  tracking: CsafTracking;
+  notes?: CsafNote[];
+  references?: CsafReference[];
+  distribution?: CsafDistribution;
+  aggregate_severity?: CsafAggregateSeverity;
+  lang?: string;
+  source_lang?: string;
+}
+
+/** Document publisher information. */
+export interface CsafPublisher {
+  category: string;
+  name: string;
+  namespace: string;
+  contact_details?: string;
+  issuing_authority?: string;
+}
+
+/** Document tracking metadata including revision history. */
+export interface CsafTracking {
+  current_release_date: string;
+  id: string;
+  initial_release_date: string;
+  revision_history: CsafRevision[];
+  status: string;
+  version: string;
+  generator?: CsafGenerator;
+  aliases?: string[];
+}
+
+/** Document version revision entry. */
+export interface CsafRevision {
+  date: string;
+  number: string;
+  summary: string;
+}
+
+/** Tool that generated the CSAF document. */
+export interface CsafGenerator {
+  engine: CsafGeneratorEngine;
+  date?: string;
+}
+
+/** Generator engine identification. */
+export interface CsafGeneratorEngine {
+  name: string;
+  version?: string;
+}
+
+/** Document-level note. */
+export interface CsafNote {
+  category: string;
+  text: string;
+  audience?: string;
+  title?: string;
+}
+
+/** External reference link. */
+export interface CsafReference {
+  url: string;
+  summary?: string;
+  category?: string;
+}
+
+/** TLP distribution information. */
+export interface CsafDistribution {
+  text?: string;
+  tlp?: CsafTlp;
+}
+
+/** Traffic Light Protocol classification. */
+export interface CsafTlp {
+  label: string;
+  url?: string;
+}
+
+/** Aggregate severity for the entire document. */
+export interface CsafAggregateSeverity {
+  text: string;
+  namespace?: string;
+}
+
+/** Product tree describing the vendor/product/version hierarchy. */
+export interface CsafProductTree {
+  branches?: CsafBranch[];
+  full_product_names?: CsafFullProductName[];
+  relationships?: CsafRelationship[];
+  product_groups?: CsafProductGroup[];
+}
+
+/** Recursive branch in the product tree hierarchy. */
+export interface CsafBranch {
+  category: string;
+  name: string;
+  branches?: CsafBranch[];
+  product?: CsafFullProductName;
+}
+
+/** A uniquely identifiable product with an ID and display name. */
+export interface CsafFullProductName {
+  name: string;
+  product_id: string;
+  product_identification_helper?: CsafProductIdentificationHelper;
+}
+
+/** Helper data for identifying a product (CPE, PURL, etc.). */
+export interface CsafProductIdentificationHelper {
+  cpe?: string;
+  purl?: string;
+  hashes?: CsafHash[];
+  model_numbers?: string[];
+  serial_numbers?: string[];
+  skus?: string[];
+  x_generic_uris?: CsafGenericUri[];
+}
+
+/** Cryptographic hash for product identification. */
+export interface CsafHash {
+  file_hashes: CsafFileHash[];
+  filename: string;
+}
+
+/** Individual file hash entry. */
+export interface CsafFileHash {
+  algorithm: string;
+  value: string;
+}
+
+/** Generic URI reference. */
+export interface CsafGenericUri {
+  namespace: string;
+  uri: string;
+}
+
+/** Relationship between two products. */
+export interface CsafRelationship {
+  category: string;
+  full_product_name: CsafFullProductName;
+  product_reference: string;
+  relates_to_product_reference: string;
+}
+
+/** Named group of product IDs. */
+export interface CsafProductGroup {
+  group_id: string;
+  product_ids: string[];
+  summary?: string;
+}
+
+/** Vulnerability entry in a CSAF document. */
+export interface CsafVulnerability {
+  cve?: string;
+  cwe?: CsafCwe;
+  title?: string;
+  notes?: CsafNote[];
+  references?: CsafReference[];
+  discovery_date?: string;
+  release_date?: string;
+  scores?: CsafScore[];
+  product_status?: CsafProductStatus;
+  remediations?: CsafRemediation[];
+  threats?: CsafThreat[];
+  acknowledgments?: CsafAcknowledgment[];
+  involvements?: CsafInvolvement[];
+  ids?: CsafVulnerabilityId[];
+}
+
+/** CWE weakness classification. */
+export interface CsafCwe {
+  id: string;
+  name: string;
+}
+
+/** CVSS scoring data for a set of products. */
+export interface CsafScore {
+  products: string[];
+  cvss_v3?: CsafCvssV3;
+  cvss_v2?: CsafCvssV2;
+}
+
+/** CVSS v3.x score details. */
+export interface CsafCvssV3 {
+  version: string;
+  vectorString: string;
+  baseScore: number;
+  baseSeverity: string;
+  attackVector?: string;
+  attackComplexity?: string;
+  privilegesRequired?: string;
+  userInteraction?: string;
+  scope?: string;
+  confidentialityImpact?: string;
+  integrityImpact?: string;
+  availabilityImpact?: string;
+  exploitCodeMaturity?: string;
+  remediationLevel?: string;
+  reportConfidence?: string;
+  temporalScore?: number;
+  temporalSeverity?: string;
+  environmentalScore?: number;
+  environmentalSeverity?: string;
+}
+
+/** CVSS v2 score details. */
+export interface CsafCvssV2 {
+  version: string;
+  vectorString: string;
+  baseScore: number;
+  accessVector?: string;
+  accessComplexity?: string;
+  authentication?: string;
+  confidentialityImpact?: string;
+  integrityImpact?: string;
+  availabilityImpact?: string;
+}
+
+/** Product status categories per vulnerability. */
+export interface CsafProductStatus {
+  fixed?: string[];
+  known_affected?: string[];
+  known_not_affected?: string[];
+  first_affected?: string[];
+  first_fixed?: string[];
+  last_affected?: string[];
+  recommended?: string[];
+  under_investigation?: string[];
+}
+
+/** Remediation action for affected products. */
+export interface CsafRemediation {
+  category: string;
+  details: string;
+  product_ids?: string[];
+  group_ids?: string[];
+  url?: string;
+  date?: string;
+  entitlements?: string[];
+  restart_required?: CsafRestartRequired;
+}
+
+/** Restart requirement for a remediation. */
+export interface CsafRestartRequired {
+  category: string;
+  details?: string;
+}
+
+/** Threat information for affected products. */
+export interface CsafThreat {
+  category: string;
+  details: string;
+  product_ids?: string[];
+  group_ids?: string[];
+  date?: string;
+}
+
+/** Acknowledgment of contributors or reporters. */
+export interface CsafAcknowledgment {
+  names?: string[];
+  organization?: string;
+  summary?: string;
+  urls?: string[];
+}
+
+/** Involvement of a party in vulnerability handling. */
+export interface CsafInvolvement {
+  party: string;
+  status: string;
+  summary?: string;
+}
+
+/** Alternative vulnerability identifier. */
+export interface CsafVulnerabilityId {
+  system_name: string;
+  text: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,8 @@
         "@tanstack/react-query-devtools": "^5.61.0",
         "axios": "^1.16.0",
         "dayjs": "^1.11.18",
+        "echarts": "^5.6.0",
+        "echarts-for-react": "^3.0.2",
         "file-saver": "^2.0.5",
         "oidc-client-ts": "^3.3.0",
         "packageurl-js": "^2.0.1",
@@ -6200,6 +6202,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6888,7 +6920,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -11458,6 +11489,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -13605,6 +13642,21 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "server": {
       "name": "@trustify-ui/server",


### PR DESCRIPTION
## Summary
- Add `CsafOverview` component with document metadata card (title, tracking ID, status, version, category, publisher, dates, generator, severity, TLP)
- Impact summary bar showing CVE count per severity level with color-coded shields
- Remediation status donut chart using PatternFly `ChartDonut` (vendor_fix, workaround, etc.)
- Document references as clickable external links with category labels
- Revision history with version, date, and summary
- Document-level notes with category headings
- All sections gracefully handle missing/empty optional CSAF fields

## Test plan
- [x] Build succeeds (`npm run build -w client`)
- [x] All 24 unit tests pass
- [x] Biome/lint passes
- [x] Overview renders metadata, charts, refs, history, and notes
- [x] Graceful degradation when optional sections are absent

Implements [TC-4620](https://redhat.atlassian.net/browse/TC-4620)

Assisted-by: Claude Code

[TC-4620]: https://redhat.atlassian.net/browse/TC-4620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce a CSAF-specific advisory details view with a new overview tab and supporting CSAF data types.

New Features:
- Add a CSAF advisory details layout with dedicated tabs for overview, vulnerabilities, product tree, relationship tree, and source.
- Implement a CSAF overview component that displays document metadata, impact summary by severity, remediation status donut chart, external references, revision history, and notes for CSAF advisories.
- Introduce a query hook to fetch and parse CSAF JSON documents for advisories by ID.

Enhancements:
- Update the advisory details page to route CSAF-type advisories to the new CSAF advisory details experience while preserving the existing layout for non-CSAF advisories.

Build:
- Add charting dependencies (echarts and echarts-for-react) to the client package configuration.