### PR TITLE
feat(advisory): implement CSAF Vulnerabilities tab with per-CVE cards

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,8 @@
     "@tanstack/react-query-devtools": "^5.61.0",
     "axios": "^1.16.0",
     "dayjs": "^1.11.18",
+    "echarts": "^5.6.0",
+    "echarts-for-react": "^3.0.2",
     "file-saver": "^2.0.5",
     "oidc-client-ts": "^3.3.0",
     "packageurl-js": "^2.0.1",

--- a/client/src/app/pages/advisory-details/advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/advisory-details.tsx
@@ -43,9 +43,11 @@ import {
   useFetchAdvisoryById,
 } from "@app/queries/advisories";
 
+import { DocumentMetadata } from "@app/components/DocumentMetadata";
+
+import { CsafAdvisoryDetails } from "./csaf-advisory-details";
 import { Overview } from "./overview";
 import { VulnerabilitiesByAdvisory } from "./vulnerabilities-by-advisory";
-import { DocumentMetadata } from "@app/components/DocumentMetadata";
 
 export const AdvisoryDetails: React.FC = () => {
   const navigate = useNavigate();
@@ -87,11 +89,13 @@ export const AdvisoryDetails: React.FC = () => {
   const { mutate: deleteAdvisory, isPending: isDeleting } =
     useDeleteAdvisoryMutation(onDeleteAdvisorySuccess, onDeleteAdvisoryError);
 
-  // Tabs
+  const isCsaf = advisory?.labels.type === "csaf";
+
+  // Tabs (default non-CSAF layout)
   const {
     propHelpers: { getTabsProps, getTabProps, getTabContentProps },
   } = useTabControls({
-    persistenceKeyPrefix: "ad", // ad="advisory details"
+    persistenceKeyPrefix: "ad",
     persistTo: "urlParams",
     tabKeys: ["info", "vulnerabilities"],
   });
@@ -177,47 +181,54 @@ export const AdvisoryDetails: React.FC = () => {
           </SplitItem>
         </Split>
       </PageSection>
-      <PageSection>
-        <Tabs
-          mountOnEnter
-          {...getTabsProps()}
-          aria-label="Tabs that contain the Advisory information"
-          role="region"
-        >
-          <Tab
-            {...getTabProps("info")}
-            title={<TabTitleText>Info</TabTitleText>}
-            tabContentRef={infoTabRef}
-          />
-          <Tab
-            {...getTabProps("vulnerabilities")}
-            title={<TabTitleText>Vulnerabilities</TabTitleText>}
-            tabContentRef={vulnerabilitiesTabRef}
-          />
-        </Tabs>
-      </PageSection>
-      <PageSection>
-        <TabContent
-          {...getTabContentProps("info")}
-          ref={infoTabRef}
-          aria-label="Information of the Advisory"
-        >
-          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
-            {advisory && <Overview advisory={advisory} />}
-          </LoadingWrapper>
-        </TabContent>
-        <TabContent
-          {...getTabContentProps("vulnerabilities")}
-          ref={vulnerabilitiesTabRef}
-          aria-label="Vulnerabilities within the Advisory"
-        >
-          <VulnerabilitiesByAdvisory
-            isFetching={isFetching}
-            fetchError={fetchError}
-            vulnerabilities={advisory?.vulnerabilities || []}
-          />
-        </TabContent>
-      </PageSection>
+
+      {isCsaf ? (
+        <CsafAdvisoryDetails advisoryId={advisoryId} />
+      ) : (
+        <>
+          <PageSection>
+            <Tabs
+              mountOnEnter
+              {...getTabsProps()}
+              aria-label="Tabs that contain the Advisory information"
+              role="region"
+            >
+              <Tab
+                {...getTabProps("info")}
+                title={<TabTitleText>Info</TabTitleText>}
+                tabContentRef={infoTabRef}
+              />
+              <Tab
+                {...getTabProps("vulnerabilities")}
+                title={<TabTitleText>Vulnerabilities</TabTitleText>}
+                tabContentRef={vulnerabilitiesTabRef}
+              />
+            </Tabs>
+          </PageSection>
+          <PageSection>
+            <TabContent
+              {...getTabContentProps("info")}
+              ref={infoTabRef}
+              aria-label="Information of the Advisory"
+            >
+              <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+                {advisory && <Overview advisory={advisory} />}
+              </LoadingWrapper>
+            </TabContent>
+            <TabContent
+              {...getTabContentProps("vulnerabilities")}
+              ref={vulnerabilitiesTabRef}
+              aria-label="Vulnerabilities within the Advisory"
+            >
+              <VulnerabilitiesByAdvisory
+                isFetching={isFetching}
+                fetchError={fetchError}
+                vulnerabilities={advisory?.vulnerabilities || []}
+              />
+            </TabContent>
+          </PageSection>
+        </>
+      )}
 
       <ConfirmDialog
         {...advisoryDeleteDialogProps(advisory)}

--- a/client/src/app/pages/advisory-details/components/csaf-cvss-details.tsx
+++ b/client/src/app/pages/advisory-details/components/csaf-cvss-details.tsx
@@ -1,0 +1,51 @@
+/** Expandable CVSS v3 breakdown showing all scoring metrics. */
+import React from "react";
+
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  ExpandableSection,
+} from "@patternfly/react-core";
+
+import type { CsafCvssV3 } from "@app/types/csaf";
+
+interface CsafCvssDetailsProps {
+  cvss: CsafCvssV3;
+}
+
+export const CsafCvssDetails: React.FC<CsafCvssDetailsProps> = ({ cvss }) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+
+  const metrics: { label: string; value?: string }[] = [
+    { label: "Attack Vector", value: cvss.attackVector },
+    { label: "Attack Complexity", value: cvss.attackComplexity },
+    { label: "Privileges Required", value: cvss.privilegesRequired },
+    { label: "User Interaction", value: cvss.userInteraction },
+    { label: "Scope", value: cvss.scope },
+    { label: "Confidentiality Impact", value: cvss.confidentialityImpact },
+    { label: "Integrity Impact", value: cvss.integrityImpact },
+    { label: "Availability Impact", value: cvss.availabilityImpact },
+    { label: "Vector String", value: cvss.vectorString },
+  ];
+
+  return (
+    <ExpandableSection
+      toggleText={isExpanded ? "Hide CVSS details" : "Show CVSS details"}
+      onToggle={(_event, expanded) => setIsExpanded(expanded)}
+      isExpanded={isExpanded}
+    >
+      <DescriptionList isHorizontal isCompact>
+        {metrics
+          .filter((m) => m.value)
+          .map((m) => (
+            <DescriptionListGroup key={m.label}>
+              <DescriptionListTerm>{m.label}</DescriptionListTerm>
+              <DescriptionListDescription>{m.value}</DescriptionListDescription>
+            </DescriptionListGroup>
+          ))}
+      </DescriptionList>
+    </ExpandableSection>
+  );
+};

--- a/client/src/app/pages/advisory-details/components/csaf-remediations.tsx
+++ b/client/src/app/pages/advisory-details/components/csaf-remediations.tsx
@@ -1,0 +1,157 @@
+/** Remediations section grouped by category with expandable product lists. */
+import React from "react";
+
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  ExpandableSection,
+  Flex,
+  FlexItem,
+  Label,
+  List,
+  ListItem,
+} from "@patternfly/react-core";
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+
+import type { CsafFullProductName, CsafRemediation } from "@app/types/csaf";
+
+interface CsafRemediationsProps {
+  remediations: CsafRemediation[];
+  productNameMap: Map<string, string>;
+}
+
+/** Groups remediations by category. */
+function groupByCategory(
+  remediations: CsafRemediation[],
+): Map<string, CsafRemediation[]> {
+  const groups = new Map<string, CsafRemediation[]>();
+  for (const rem of remediations) {
+    const existing = groups.get(rem.category);
+    if (existing) {
+      existing.push(rem);
+    } else {
+      groups.set(rem.category, [rem]);
+    }
+  }
+  return groups;
+}
+
+/** Renders text with URLs converted to links. */
+const LinkifiedText: React.FC<{ text: string }> = ({ text }) => {
+  const urlRegex = /(https?:\/\/[^\s)]+)/g;
+  const parts = text.split(urlRegex);
+  return (
+    <>
+      {parts.map((part, i) =>
+        urlRegex.test(part) ? (
+          <a
+            key={`link-${i}`}
+            href={part}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {part} <ExternalLinkAltIcon />
+          </a>
+        ) : (
+          <span key={`text-${i}`}>{part}</span>
+        ),
+      )}
+    </>
+  );
+};
+
+/** Single remediation card within a category group. */
+const RemediationCard: React.FC<{
+  remediation: CsafRemediation;
+  productNameMap: Map<string, string>;
+}> = ({ remediation, productNameMap }) => {
+  const [showProducts, setShowProducts] = React.useState(false);
+  const productIds = remediation.product_ids || [];
+
+  return (
+    <Card isPlain isCompact>
+      <CardBody>
+        <Flex direction={{ default: "column" }} gap={{ default: "gapSm" }}>
+          <FlexItem>
+            <LinkifiedText text={remediation.details} />
+          </FlexItem>
+          {remediation.url && (
+            <FlexItem>
+              <a
+                href={remediation.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {remediation.url} <ExternalLinkAltIcon />
+              </a>
+            </FlexItem>
+          )}
+          {productIds.length > 0 && (
+            <FlexItem>
+              <ExpandableSection
+                toggleText={
+                  showProducts
+                    ? "Hide affected products"
+                    : `Show ${productIds.length} affected products`
+                }
+                onToggle={(_event, expanded) => setShowProducts(expanded)}
+                isExpanded={showProducts}
+              >
+                <List isPlain>
+                  {productIds.map((pid) => (
+                    <ListItem key={pid}>
+                      {productNameMap.get(pid) || pid}
+                    </ListItem>
+                  ))}
+                </List>
+              </ExpandableSection>
+            </FlexItem>
+          )}
+        </Flex>
+      </CardBody>
+    </Card>
+  );
+};
+
+export const CsafRemediations: React.FC<CsafRemediationsProps> = ({
+  remediations,
+  productNameMap,
+}) => {
+  const grouped = React.useMemo(
+    () => groupByCategory(remediations),
+    [remediations],
+  );
+
+  return (
+    <ExpandableSection toggleText="Remediations" isExpanded={false}>
+      <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+        {Array.from(grouped.entries()).map(([category, rems]) => (
+          <FlexItem key={category}>
+            <Card isPlain>
+              <CardTitle>
+                <Label isCompact>{category.replace(/_/g, " ")}</Label> (
+                {rems.length})
+              </CardTitle>
+              <CardBody>
+                <Flex
+                  direction={{ default: "column" }}
+                  gap={{ default: "gapSm" }}
+                >
+                  {rems.map((rem, i) => (
+                    <FlexItem key={`${category}-${i}`}>
+                      <RemediationCard
+                        remediation={rem}
+                        productNameMap={productNameMap}
+                      />
+                    </FlexItem>
+                  ))}
+                </Flex>
+              </CardBody>
+            </Card>
+          </FlexItem>
+        ))}
+      </Flex>
+    </ExpandableSection>
+  );
+};

--- a/client/src/app/pages/advisory-details/components/csaf-remediations.tsx
+++ b/client/src/app/pages/advisory-details/components/csaf-remediations.tsx
@@ -14,7 +14,7 @@ import {
 } from "@patternfly/react-core";
 import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
 
-import type { CsafFullProductName, CsafRemediation } from "@app/types/csaf";
+import type { CsafRemediation } from "@app/types/csaf";
 
 interface CsafRemediationsProps {
   remediations: CsafRemediation[];
@@ -124,7 +124,7 @@ export const CsafRemediations: React.FC<CsafRemediationsProps> = ({
   );
 
   return (
-    <ExpandableSection toggleText="Remediations" isExpanded={false}>
+    <ExpandableSection toggleText="Remediations">
       <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
         {Array.from(grouped.entries()).map(([category, rems]) => (
           <FlexItem key={category}>

--- a/client/src/app/pages/advisory-details/components/csaf-vulnerability-card.tsx
+++ b/client/src/app/pages/advisory-details/components/csaf-vulnerability-card.tsx
@@ -74,8 +74,8 @@ export const CsafVulnerabilityCard: React.FC<CsafVulnerabilityCardProps> = ({
                 value={
                   cvss.baseSeverity.toLowerCase() as
                     | "critical"
-                    | "important"
-                    | "moderate"
+                    | "high"
+                    | "medium"
                     | "low"
                     | "none"
                 }
@@ -132,10 +132,7 @@ export const CsafVulnerabilityCard: React.FC<CsafVulnerabilityCardProps> = ({
           {/* Affected Products */}
           {affectedProducts.length > 0 && (
             <FlexItem>
-              <ExpandableSection
-                toggleText="Affected Products"
-                isExpanded={false}
-              >
+              <ExpandableSection toggleText="Affected Products">
                 <List isPlain>
                   {visibleProducts.map((pid) => (
                     <ListItem key={pid}>
@@ -170,7 +167,7 @@ export const CsafVulnerabilityCard: React.FC<CsafVulnerabilityCardProps> = ({
           {/* References */}
           {vulnerability.references && vulnerability.references.length > 0 && (
             <FlexItem>
-              <ExpandableSection toggleText="References" isExpanded={false}>
+              <ExpandableSection toggleText="References">
                 <List isPlain>
                   {vulnerability.references.map((ref, i) => (
                     <ListItem key={`ref-${i}`}>

--- a/client/src/app/pages/advisory-details/components/csaf-vulnerability-card.tsx
+++ b/client/src/app/pages/advisory-details/components/csaf-vulnerability-card.tsx
@@ -1,0 +1,194 @@
+/** Individual CVE card with severity, CVSS breakdown, products, remediations, and references. */
+import React from "react";
+import { Link } from "react-router-dom";
+
+import dayjs from "dayjs";
+
+import {
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Content,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  ExpandableSection,
+  Flex,
+  FlexItem,
+  List,
+  ListItem,
+} from "@patternfly/react-core";
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+
+import { Paths } from "@app/Routes";
+import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
+import type { CsafVulnerability } from "@app/types/csaf";
+
+import { CsafCvssDetails } from "./csaf-cvss-details";
+import { CsafRemediations } from "./csaf-remediations";
+
+interface CsafVulnerabilityCardProps {
+  vulnerability: CsafVulnerability;
+  productNameMap: Map<string, string>;
+}
+
+const INITIAL_PRODUCTS_SHOWN = 5;
+
+export const CsafVulnerabilityCard: React.FC<CsafVulnerabilityCardProps> = ({
+  vulnerability,
+  productNameMap,
+}) => {
+  const [showAllProducts, setShowAllProducts] = React.useState(false);
+  const cvss = vulnerability.scores?.[0]?.cvss_v3;
+  const affectedProducts = vulnerability.product_status?.known_affected || [];
+  const visibleProducts = showAllProducts
+    ? affectedProducts
+    : affectedProducts.slice(0, INITIAL_PRODUCTS_SHOWN);
+  const hiddenCount = affectedProducts.length - INITIAL_PRODUCTS_SHOWN;
+
+  return (
+    <Card>
+      <CardHeader>
+        <Flex
+          alignItems={{ default: "alignItemsCenter" }}
+          gap={{ default: "gapMd" }}
+          flexWrap={{ default: "wrap" }}
+        >
+          {vulnerability.cve && (
+            <FlexItem>
+              <Link
+                to={Paths.vulnerabilityDetails.replace(
+                  ":vulnerabilityId",
+                  vulnerability.cve,
+                )}
+              >
+                <strong>{vulnerability.cve}</strong>
+              </Link>
+            </FlexItem>
+          )}
+          {cvss && (
+            <FlexItem>
+              <SeverityShieldAndText
+                value={
+                  cvss.baseSeverity.toLowerCase() as
+                    | "critical"
+                    | "important"
+                    | "moderate"
+                    | "low"
+                    | "none"
+                }
+                score={cvss.baseScore}
+              />
+            </FlexItem>
+          )}
+          {vulnerability.title && (
+            <FlexItem>
+              <Content component="small">{vulnerability.title}</Content>
+            </FlexItem>
+          )}
+        </Flex>
+      </CardHeader>
+      <CardBody>
+        <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+          {/* Metadata */}
+          <FlexItem>
+            <DescriptionList isHorizontal isCompact>
+              {vulnerability.cwe && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>CWE</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {vulnerability.cwe.id} — {vulnerability.cwe.name}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {vulnerability.discovery_date && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Discovered</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {dayjs(vulnerability.discovery_date).format("YYYY-MM-DD")}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {vulnerability.release_date && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Released</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {dayjs(vulnerability.release_date).format("YYYY-MM-DD")}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+            </DescriptionList>
+          </FlexItem>
+
+          {/* CVSS Details */}
+          {cvss && (
+            <FlexItem>
+              <CsafCvssDetails cvss={cvss} />
+            </FlexItem>
+          )}
+
+          {/* Affected Products */}
+          {affectedProducts.length > 0 && (
+            <FlexItem>
+              <ExpandableSection
+                toggleText="Affected Products"
+                isExpanded={false}
+              >
+                <List isPlain>
+                  {visibleProducts.map((pid) => (
+                    <ListItem key={pid}>
+                      {productNameMap.get(pid) || pid}
+                    </ListItem>
+                  ))}
+                </List>
+                {hiddenCount > 0 && !showAllProducts && (
+                  <Button
+                    variant="link"
+                    isInline
+                    onClick={() => setShowAllProducts(true)}
+                  >
+                    +{hiddenCount} more
+                  </Button>
+                )}
+              </ExpandableSection>
+            </FlexItem>
+          )}
+
+          {/* Remediations */}
+          {vulnerability.remediations &&
+            vulnerability.remediations.length > 0 && (
+              <FlexItem>
+                <CsafRemediations
+                  remediations={vulnerability.remediations}
+                  productNameMap={productNameMap}
+                />
+              </FlexItem>
+            )}
+
+          {/* References */}
+          {vulnerability.references && vulnerability.references.length > 0 && (
+            <FlexItem>
+              <ExpandableSection toggleText="References" isExpanded={false}>
+                <List isPlain>
+                  {vulnerability.references.map((ref, i) => (
+                    <ListItem key={`ref-${i}`}>
+                      <a
+                        href={ref.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {ref.summary || ref.url} <ExternalLinkAltIcon />
+                      </a>
+                    </ListItem>
+                  ))}
+                </List>
+              </ExpandableSection>
+            </FlexItem>
+          )}
+        </Flex>
+      </CardBody>
+    </Card>
+  );
+};

--- a/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
@@ -17,6 +17,8 @@ import { LoadingWrapper } from "@app/components/LoadingWrapper";
 import { useTabControls } from "@app/hooks/tab-controls";
 import { useFetchAdvisoryCsafById } from "@app/queries/advisories";
 
+import { CsafVulnerabilities } from "./csaf-vulnerabilities";
+
 interface CsafAdvisoryDetailsProps {
   advisoryId: string;
 }
@@ -109,7 +111,9 @@ export const CsafAdvisoryDetails: React.FC<CsafAdvisoryDetailsProps> = ({
             ref={vulnerabilitiesTabRef}
             aria-label="CSAF vulnerabilities"
           >
-            <ComingSoon label="Vulnerabilities" />
+            {csafDocument && (
+              <CsafVulnerabilities csafDocument={csafDocument} />
+            )}
           </TabContent>
           <TabContent
             {...getTabContentProps("product-tree")}

--- a/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
@@ -1,0 +1,139 @@
+/** CSAF-specific advisory details with 5-tab layout for VEX document visualization. */
+import React from "react";
+
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  PageSection,
+  Tab,
+  TabContent,
+  Tabs,
+  TabTitleText,
+} from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+
+import { LoadingWrapper } from "@app/components/LoadingWrapper";
+import { useTabControls } from "@app/hooks/tab-controls";
+import { useFetchAdvisoryCsafById } from "@app/queries/advisories";
+
+interface CsafAdvisoryDetailsProps {
+  advisoryId: string;
+}
+
+/** Placeholder for tabs not yet implemented. */
+const ComingSoon: React.FC<{ label: string }> = ({ label }) => (
+  <EmptyState
+    titleText={label}
+    headingLevel="h2"
+    icon={CubesIcon}
+    variant={EmptyStateVariant.sm}
+  >
+    <EmptyStateBody>This tab is under construction.</EmptyStateBody>
+  </EmptyState>
+);
+
+export const CsafAdvisoryDetails: React.FC<CsafAdvisoryDetailsProps> = ({
+  advisoryId,
+}) => {
+  const { csafDocument, isFetching, fetchError } =
+    useFetchAdvisoryCsafById(advisoryId);
+
+  const {
+    propHelpers: { getTabsProps, getTabProps, getTabContentProps },
+  } = useTabControls({
+    persistenceKeyPrefix: "cad",
+    persistTo: "urlParams",
+    tabKeys: [
+      "overview",
+      "vulnerabilities",
+      "product-tree",
+      "relationship-tree",
+      "source",
+    ],
+  });
+
+  const overviewTabRef = React.createRef<HTMLElement>();
+  const vulnerabilitiesTabRef = React.createRef<HTMLElement>();
+  const productTreeTabRef = React.createRef<HTMLElement>();
+  const relationshipTreeTabRef = React.createRef<HTMLElement>();
+  const sourceTabRef = React.createRef<HTMLElement>();
+
+  return (
+    <>
+      <PageSection>
+        <Tabs
+          mountOnEnter
+          {...getTabsProps()}
+          aria-label="CSAF advisory visualization tabs"
+          role="region"
+        >
+          <Tab
+            {...getTabProps("overview")}
+            title={<TabTitleText>Overview</TabTitleText>}
+            tabContentRef={overviewTabRef}
+          />
+          <Tab
+            {...getTabProps("vulnerabilities")}
+            title={<TabTitleText>Vulnerabilities</TabTitleText>}
+            tabContentRef={vulnerabilitiesTabRef}
+          />
+          <Tab
+            {...getTabProps("product-tree")}
+            title={<TabTitleText>Product Tree</TabTitleText>}
+            tabContentRef={productTreeTabRef}
+          />
+          <Tab
+            {...getTabProps("relationship-tree")}
+            title={<TabTitleText>Relationship Tree</TabTitleText>}
+            tabContentRef={relationshipTreeTabRef}
+          />
+          <Tab
+            {...getTabProps("source")}
+            title={<TabTitleText>Source</TabTitleText>}
+            tabContentRef={sourceTabRef}
+          />
+        </Tabs>
+      </PageSection>
+      <PageSection>
+        <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+          <TabContent
+            {...getTabContentProps("overview")}
+            ref={overviewTabRef}
+            aria-label="CSAF document overview"
+          >
+            <ComingSoon label="Overview" />
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("vulnerabilities")}
+            ref={vulnerabilitiesTabRef}
+            aria-label="CSAF vulnerabilities"
+          >
+            <ComingSoon label="Vulnerabilities" />
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("product-tree")}
+            ref={productTreeTabRef}
+            aria-label="CSAF product tree"
+          >
+            <ComingSoon label="Product Tree" />
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("relationship-tree")}
+            ref={relationshipTreeTabRef}
+            aria-label="CSAF relationship tree"
+          >
+            <ComingSoon label="Relationship Tree" />
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("source")}
+            ref={sourceTabRef}
+            aria-label="CSAF source document"
+          >
+            <ComingSoon label="Source" />
+          </TabContent>
+        </LoadingWrapper>
+      </PageSection>
+    </>
+  );
+};

--- a/client/src/app/pages/advisory-details/csaf-vulnerabilities.tsx
+++ b/client/src/app/pages/advisory-details/csaf-vulnerabilities.tsx
@@ -1,0 +1,94 @@
+/** CSAF Vulnerabilities tab rendering per-CVE cards sorted by severity. */
+import React from "react";
+
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Flex,
+  FlexItem,
+} from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+
+import type { CsafDocument, CsafVulnerability } from "@app/types/csaf";
+
+import { CsafVulnerabilityCard } from "./components/csaf-vulnerability-card";
+
+interface CsafVulnerabilitiesProps {
+  csafDocument: CsafDocument;
+}
+
+const SEVERITY_ORDER: Record<string, number> = {
+  CRITICAL: 0,
+  HIGH: 1,
+  MEDIUM: 2,
+  LOW: 3,
+  NONE: 4,
+};
+
+/** Sorts vulnerabilities by CVSS severity, critical first. */
+function sortBySeverity(
+  vulnerabilities: CsafVulnerability[],
+): CsafVulnerability[] {
+  return [...vulnerabilities].sort((a, b) => {
+    const aSev = a.scores?.[0]?.cvss_v3?.baseSeverity?.toUpperCase() || "NONE";
+    const bSev = b.scores?.[0]?.cvss_v3?.baseSeverity?.toUpperCase() || "NONE";
+    return (SEVERITY_ORDER[aSev] ?? 5) - (SEVERITY_ORDER[bSev] ?? 5);
+  });
+}
+
+/** Builds product ID to display name map from full_product_names. */
+function buildProductNameMap(csafDocument: CsafDocument): Map<string, string> {
+  const map = new Map<string, string>();
+  const products = csafDocument.product_tree?.full_product_names;
+  if (products) {
+    for (const p of products) {
+      map.set(p.product_id, p.name);
+    }
+  }
+  return map;
+}
+
+export const CsafVulnerabilities: React.FC<CsafVulnerabilitiesProps> = ({
+  csafDocument,
+}) => {
+  const vulnerabilities = csafDocument.vulnerabilities;
+
+  const sorted = React.useMemo(
+    () => (vulnerabilities ? sortBySeverity(vulnerabilities) : []),
+    [vulnerabilities],
+  );
+
+  const productNameMap = React.useMemo(
+    () => buildProductNameMap(csafDocument),
+    [csafDocument],
+  );
+
+  if (sorted.length === 0) {
+    return (
+      <EmptyState
+        titleText="No vulnerabilities"
+        headingLevel="h2"
+        icon={CubesIcon}
+        variant={EmptyStateVariant.sm}
+      >
+        <EmptyStateBody>
+          This advisory does not contain vulnerability data.
+        </EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+      {sorted.map((vuln, i) => (
+        <FlexItem key={vuln.cve || `vuln-${i}`}>
+          <CsafVulnerabilityCard
+            vulnerability={vuln}
+            productNameMap={productNameMap}
+          />
+        </FlexItem>
+      ))}
+    </Flex>
+  );
+};

--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -18,6 +18,7 @@ import {
   listAdvisoryLabels,
   updateAdvisoryLabels,
 } from "@app/client";
+import type { CsafDocument } from "@app/types/csaf";
 
 import { uploadAdvisory } from "@app/api/rest";
 import {
@@ -136,6 +137,26 @@ export const useFetchAdvisorySourceById = (id: string) => {
 
   return {
     source: data,
+    isFetching: isLoading,
+    fetchError: error as AxiosError | null,
+  };
+};
+
+/** Fetches the raw CSAF JSON document and parses it into a typed CsafDocument. */
+export const useFetchAdvisoryCsafById = (id: string) => {
+  const { data, isLoading, error } = useQuery<CsafDocument>({
+    queryKey: [AdvisoriesQueryKey, id, "csaf"],
+    queryFn: async () => {
+      const response = await downloadAdvisory({ client, path: { key: id } });
+      const blob = response.data as Blob;
+      const text = await blob.text();
+      return JSON.parse(text) as CsafDocument;
+    },
+    enabled: !!id,
+  });
+
+  return {
+    csafDocument: data,
     isFetching: isLoading,
     fetchError: error as AxiosError | null,
   };

--- a/client/src/app/types/csaf.ts
+++ b/client/src/app/types/csaf.ts
@@ -1,0 +1,290 @@
+/** CSAF 2.0 VEX document type definitions per the OASIS CSAF JSON schema. */
+
+/** Top-level CSAF document container. */
+export interface CsafDocument {
+  document: CsafDocumentMetadata;
+  product_tree?: CsafProductTree;
+  vulnerabilities?: CsafVulnerability[];
+}
+
+/** Document-level metadata section. */
+export interface CsafDocumentMetadata {
+  category: string;
+  csaf_version: string;
+  title: string;
+  publisher: CsafPublisher;
+  tracking: CsafTracking;
+  notes?: CsafNote[];
+  references?: CsafReference[];
+  distribution?: CsafDistribution;
+  aggregate_severity?: CsafAggregateSeverity;
+  lang?: string;
+  source_lang?: string;
+}
+
+/** Document publisher information. */
+export interface CsafPublisher {
+  category: string;
+  name: string;
+  namespace: string;
+  contact_details?: string;
+  issuing_authority?: string;
+}
+
+/** Document tracking metadata including revision history. */
+export interface CsafTracking {
+  current_release_date: string;
+  id: string;
+  initial_release_date: string;
+  revision_history: CsafRevision[];
+  status: string;
+  version: string;
+  generator?: CsafGenerator;
+  aliases?: string[];
+}
+
+/** Document version revision entry. */
+export interface CsafRevision {
+  date: string;
+  number: string;
+  summary: string;
+}
+
+/** Tool that generated the CSAF document. */
+export interface CsafGenerator {
+  engine: CsafGeneratorEngine;
+  date?: string;
+}
+
+/** Generator engine identification. */
+export interface CsafGeneratorEngine {
+  name: string;
+  version?: string;
+}
+
+/** Document-level note. */
+export interface CsafNote {
+  category: string;
+  text: string;
+  audience?: string;
+  title?: string;
+}
+
+/** External reference link. */
+export interface CsafReference {
+  url: string;
+  summary?: string;
+  category?: string;
+}
+
+/** TLP distribution information. */
+export interface CsafDistribution {
+  text?: string;
+  tlp?: CsafTlp;
+}
+
+/** Traffic Light Protocol classification. */
+export interface CsafTlp {
+  label: string;
+  url?: string;
+}
+
+/** Aggregate severity for the entire document. */
+export interface CsafAggregateSeverity {
+  text: string;
+  namespace?: string;
+}
+
+/** Product tree describing the vendor/product/version hierarchy. */
+export interface CsafProductTree {
+  branches?: CsafBranch[];
+  full_product_names?: CsafFullProductName[];
+  relationships?: CsafRelationship[];
+  product_groups?: CsafProductGroup[];
+}
+
+/** Recursive branch in the product tree hierarchy. */
+export interface CsafBranch {
+  category: string;
+  name: string;
+  branches?: CsafBranch[];
+  product?: CsafFullProductName;
+}
+
+/** A uniquely identifiable product with an ID and display name. */
+export interface CsafFullProductName {
+  name: string;
+  product_id: string;
+  product_identification_helper?: CsafProductIdentificationHelper;
+}
+
+/** Helper data for identifying a product (CPE, PURL, etc.). */
+export interface CsafProductIdentificationHelper {
+  cpe?: string;
+  purl?: string;
+  hashes?: CsafHash[];
+  model_numbers?: string[];
+  serial_numbers?: string[];
+  skus?: string[];
+  x_generic_uris?: CsafGenericUri[];
+}
+
+/** Cryptographic hash for product identification. */
+export interface CsafHash {
+  file_hashes: CsafFileHash[];
+  filename: string;
+}
+
+/** Individual file hash entry. */
+export interface CsafFileHash {
+  algorithm: string;
+  value: string;
+}
+
+/** Generic URI reference. */
+export interface CsafGenericUri {
+  namespace: string;
+  uri: string;
+}
+
+/** Relationship between two products. */
+export interface CsafRelationship {
+  category: string;
+  full_product_name: CsafFullProductName;
+  product_reference: string;
+  relates_to_product_reference: string;
+}
+
+/** Named group of product IDs. */
+export interface CsafProductGroup {
+  group_id: string;
+  product_ids: string[];
+  summary?: string;
+}
+
+/** Vulnerability entry in a CSAF document. */
+export interface CsafVulnerability {
+  cve?: string;
+  cwe?: CsafCwe;
+  title?: string;
+  notes?: CsafNote[];
+  references?: CsafReference[];
+  discovery_date?: string;
+  release_date?: string;
+  scores?: CsafScore[];
+  product_status?: CsafProductStatus;
+  remediations?: CsafRemediation[];
+  threats?: CsafThreat[];
+  acknowledgments?: CsafAcknowledgment[];
+  involvements?: CsafInvolvement[];
+  ids?: CsafVulnerabilityId[];
+}
+
+/** CWE weakness classification. */
+export interface CsafCwe {
+  id: string;
+  name: string;
+}
+
+/** CVSS scoring data for a set of products. */
+export interface CsafScore {
+  products: string[];
+  cvss_v3?: CsafCvssV3;
+  cvss_v2?: CsafCvssV2;
+}
+
+/** CVSS v3.x score details. */
+export interface CsafCvssV3 {
+  version: string;
+  vectorString: string;
+  baseScore: number;
+  baseSeverity: string;
+  attackVector?: string;
+  attackComplexity?: string;
+  privilegesRequired?: string;
+  userInteraction?: string;
+  scope?: string;
+  confidentialityImpact?: string;
+  integrityImpact?: string;
+  availabilityImpact?: string;
+  exploitCodeMaturity?: string;
+  remediationLevel?: string;
+  reportConfidence?: string;
+  temporalScore?: number;
+  temporalSeverity?: string;
+  environmentalScore?: number;
+  environmentalSeverity?: string;
+}
+
+/** CVSS v2 score details. */
+export interface CsafCvssV2 {
+  version: string;
+  vectorString: string;
+  baseScore: number;
+  accessVector?: string;
+  accessComplexity?: string;
+  authentication?: string;
+  confidentialityImpact?: string;
+  integrityImpact?: string;
+  availabilityImpact?: string;
+}
+
+/** Product status categories per vulnerability. */
+export interface CsafProductStatus {
+  fixed?: string[];
+  known_affected?: string[];
+  known_not_affected?: string[];
+  first_affected?: string[];
+  first_fixed?: string[];
+  last_affected?: string[];
+  recommended?: string[];
+  under_investigation?: string[];
+}
+
+/** Remediation action for affected products. */
+export interface CsafRemediation {
+  category: string;
+  details: string;
+  product_ids?: string[];
+  group_ids?: string[];
+  url?: string;
+  date?: string;
+  entitlements?: string[];
+  restart_required?: CsafRestartRequired;
+}
+
+/** Restart requirement for a remediation. */
+export interface CsafRestartRequired {
+  category: string;
+  details?: string;
+}
+
+/** Threat information for affected products. */
+export interface CsafThreat {
+  category: string;
+  details: string;
+  product_ids?: string[];
+  group_ids?: string[];
+  date?: string;
+}
+
+/** Acknowledgment of contributors or reporters. */
+export interface CsafAcknowledgment {
+  names?: string[];
+  organization?: string;
+  summary?: string;
+  urls?: string[];
+}
+
+/** Involvement of a party in vulnerability handling. */
+export interface CsafInvolvement {
+  party: string;
+  status: string;
+  summary?: string;
+}
+
+/** Alternative vulnerability identifier. */
+export interface CsafVulnerabilityId {
+  system_name: string;
+  text: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,8 @@
         "@tanstack/react-query-devtools": "^5.61.0",
         "axios": "^1.16.0",
         "dayjs": "^1.11.18",
+        "echarts": "^5.6.0",
+        "echarts-for-react": "^3.0.2",
         "file-saver": "^2.0.5",
         "oidc-client-ts": "^3.3.0",
         "packageurl-js": "^2.0.1",
@@ -6200,6 +6202,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6888,7 +6920,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -11458,6 +11489,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -13605,6 +13642,21 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "server": {
       "name": "@trustify-ui/server",


### PR DESCRIPTION
## Summary
- Add `CsafVulnerabilities` tab rendering per-CVE cards sorted by severity (critical first)
- `CsafVulnerabilityCard` — CVE ID linked to vulnerability details, severity shield, title, CWE, dates
- `CsafCvssDetails` — expandable CVSS v3 breakdown (attack vector, complexity, privileges, etc.)
- `CsafRemediations` — grouped by category (vendor_fix, workaround, etc.) with linkified URLs and expandable product lists
- Affected products show first 5 with "+N more" toggle, IDs resolved to display names
- References rendered as external links
- All sections handle missing/empty optional fields gracefully

## Test plan
- [x] Build succeeds (`npm run build -w client`)
- [x] All 24 unit tests pass
- [x] Biome/lint passes
- [x] Vulnerability cards sort by severity
- [x] CVSS expandable section shows metrics
- [x] Remediations grouped by category
- [x] Empty state when no vulnerabilities

Implements [TC-4621](https://redhat.atlassian.net/browse/TC-4621)

Assisted-by: Claude Code

[TC-4621]: https://redhat.atlassian.net/browse/TC-4621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Introduce CSAF-specific advisory details view with a dedicated vulnerabilities tab and per-CVE cards for CSAF advisories.

New Features:
- Add CSAF-aware advisory details layout that switches to a CSAF visualization when the advisory is labeled as CSAF.
- Provide a CSAF Vulnerabilities tab that lists vulnerabilities as individual CVE cards with severity, CVSS details, affected products, remediations, and references.
- Add typed CSAF 2.0 data model and a query hook to fetch and parse raw CSAF JSON documents.

Enhancements:
- Integrate CSAF document loading into advisory details while preserving the existing non-CSAF tab layout.
- Introduce reusable components for CSAF CVSS breakdowns and remediation grouping with linkified URLs and expandable product lists.

Build:
- Add echarts and echarts-for-react dependencies for future CSAF visualizations.