### PR TITLE
feat(advisory): CSAF VEX Visualizer — all tabs combined [TC-4612]

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,8 @@
     "@tanstack/react-query-devtools": "^5.61.0",
     "axios": "^1.16.0",
     "dayjs": "^1.11.18",
+    "echarts": "^5.6.0",
+    "echarts-for-react": "^3.0.2",
     "file-saver": "^2.0.5",
     "oidc-client-ts": "^3.3.0",
     "packageurl-js": "^2.0.1",

--- a/client/src/app/pages/advisory-details/advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/advisory-details.tsx
@@ -43,9 +43,11 @@ import {
   useFetchAdvisoryById,
 } from "@app/queries/advisories";
 
+import { DocumentMetadata } from "@app/components/DocumentMetadata";
+
+import { CsafAdvisoryDetails } from "./csaf-advisory-details";
 import { Overview } from "./overview";
 import { VulnerabilitiesByAdvisory } from "./vulnerabilities-by-advisory";
-import { DocumentMetadata } from "@app/components/DocumentMetadata";
 
 export const AdvisoryDetails: React.FC = () => {
   const navigate = useNavigate();
@@ -87,11 +89,13 @@ export const AdvisoryDetails: React.FC = () => {
   const { mutate: deleteAdvisory, isPending: isDeleting } =
     useDeleteAdvisoryMutation(onDeleteAdvisorySuccess, onDeleteAdvisoryError);
 
-  // Tabs
+  const isCsaf = advisory?.labels.type === "csaf";
+
+  // Tabs (default non-CSAF layout)
   const {
     propHelpers: { getTabsProps, getTabProps, getTabContentProps },
   } = useTabControls({
-    persistenceKeyPrefix: "ad", // ad="advisory details"
+    persistenceKeyPrefix: "ad",
     persistTo: "urlParams",
     tabKeys: ["info", "vulnerabilities"],
   });
@@ -177,47 +181,54 @@ export const AdvisoryDetails: React.FC = () => {
           </SplitItem>
         </Split>
       </PageSection>
-      <PageSection>
-        <Tabs
-          mountOnEnter
-          {...getTabsProps()}
-          aria-label="Tabs that contain the Advisory information"
-          role="region"
-        >
-          <Tab
-            {...getTabProps("info")}
-            title={<TabTitleText>Info</TabTitleText>}
-            tabContentRef={infoTabRef}
-          />
-          <Tab
-            {...getTabProps("vulnerabilities")}
-            title={<TabTitleText>Vulnerabilities</TabTitleText>}
-            tabContentRef={vulnerabilitiesTabRef}
-          />
-        </Tabs>
-      </PageSection>
-      <PageSection>
-        <TabContent
-          {...getTabContentProps("info")}
-          ref={infoTabRef}
-          aria-label="Information of the Advisory"
-        >
-          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
-            {advisory && <Overview advisory={advisory} />}
-          </LoadingWrapper>
-        </TabContent>
-        <TabContent
-          {...getTabContentProps("vulnerabilities")}
-          ref={vulnerabilitiesTabRef}
-          aria-label="Vulnerabilities within the Advisory"
-        >
-          <VulnerabilitiesByAdvisory
-            isFetching={isFetching}
-            fetchError={fetchError}
-            vulnerabilities={advisory?.vulnerabilities || []}
-          />
-        </TabContent>
-      </PageSection>
+
+      {isCsaf ? (
+        <CsafAdvisoryDetails advisoryId={advisoryId} />
+      ) : (
+        <>
+          <PageSection>
+            <Tabs
+              mountOnEnter
+              {...getTabsProps()}
+              aria-label="Tabs that contain the Advisory information"
+              role="region"
+            >
+              <Tab
+                {...getTabProps("info")}
+                title={<TabTitleText>Info</TabTitleText>}
+                tabContentRef={infoTabRef}
+              />
+              <Tab
+                {...getTabProps("vulnerabilities")}
+                title={<TabTitleText>Vulnerabilities</TabTitleText>}
+                tabContentRef={vulnerabilitiesTabRef}
+              />
+            </Tabs>
+          </PageSection>
+          <PageSection>
+            <TabContent
+              {...getTabContentProps("info")}
+              ref={infoTabRef}
+              aria-label="Information of the Advisory"
+            >
+              <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+                {advisory && <Overview advisory={advisory} />}
+              </LoadingWrapper>
+            </TabContent>
+            <TabContent
+              {...getTabContentProps("vulnerabilities")}
+              ref={vulnerabilitiesTabRef}
+              aria-label="Vulnerabilities within the Advisory"
+            >
+              <VulnerabilitiesByAdvisory
+                isFetching={isFetching}
+                fetchError={fetchError}
+                vulnerabilities={advisory?.vulnerabilities || []}
+              />
+            </TabContent>
+          </PageSection>
+        </>
+      )}
 
       <ConfirmDialog
         {...advisoryDeleteDialogProps(advisory)}

--- a/client/src/app/pages/advisory-details/advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/advisory-details.tsx
@@ -14,7 +14,6 @@ import {
   DropdownList,
   Flex,
   FlexItem,
-  Label,
   MenuToggle,
   type MenuToggleElement,
   PageSection,
@@ -44,6 +43,7 @@ import {
 } from "@app/queries/advisories";
 
 import { DocumentMetadata } from "@app/components/DocumentMetadata";
+import { LabelsAsList } from "@app/components/LabelsAsList";
 
 import { CsafAdvisoryDetails } from "./csaf-advisory-details";
 import { Overview } from "./overview";
@@ -123,13 +123,16 @@ export const AdvisoryDetails: React.FC = () => {
                   <Content component="h1">
                     {advisory?.document_id ?? advisoryId ?? ""}
                   </Content>
-                  <Content component="p">Advisory detail information</Content>
                 </Content>
               </FlexItem>
               <FlexItem>
-                {advisory?.labels.type && (
-                  <Label color="blue">{advisory?.labels.type}</Label>
-                )}
+                <LabelsAsList
+                  value={Object.fromEntries(
+                    Object.entries(advisory?.labels ?? {}).filter(
+                      ([k]) => k === "type" || k === "severity",
+                    ),
+                  )}
+                />
               </FlexItem>
             </Flex>
           </SplitItem>

--- a/client/src/app/pages/advisory-details/components/csaf-cvss-details.tsx
+++ b/client/src/app/pages/advisory-details/components/csaf-cvss-details.tsx
@@ -1,0 +1,51 @@
+/** Expandable CVSS v3 breakdown showing all scoring metrics. */
+import React from "react";
+
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  ExpandableSection,
+} from "@patternfly/react-core";
+
+import type { CsafCvssV3 } from "@app/types/csaf";
+
+interface CsafCvssDetailsProps {
+  cvss: CsafCvssV3;
+}
+
+export const CsafCvssDetails: React.FC<CsafCvssDetailsProps> = ({ cvss }) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+
+  const metrics: { label: string; value?: string }[] = [
+    { label: "Attack Vector", value: cvss.attackVector },
+    { label: "Attack Complexity", value: cvss.attackComplexity },
+    { label: "Privileges Required", value: cvss.privilegesRequired },
+    { label: "User Interaction", value: cvss.userInteraction },
+    { label: "Scope", value: cvss.scope },
+    { label: "Confidentiality Impact", value: cvss.confidentialityImpact },
+    { label: "Integrity Impact", value: cvss.integrityImpact },
+    { label: "Availability Impact", value: cvss.availabilityImpact },
+    { label: "Vector String", value: cvss.vectorString },
+  ];
+
+  return (
+    <ExpandableSection
+      toggleText={isExpanded ? "Hide CVSS details" : "Show CVSS details"}
+      onToggle={(_event, expanded) => setIsExpanded(expanded)}
+      isExpanded={isExpanded}
+    >
+      <DescriptionList isHorizontal isCompact>
+        {metrics
+          .filter((m) => m.value)
+          .map((m) => (
+            <DescriptionListGroup key={m.label}>
+              <DescriptionListTerm>{m.label}</DescriptionListTerm>
+              <DescriptionListDescription>{m.value}</DescriptionListDescription>
+            </DescriptionListGroup>
+          ))}
+      </DescriptionList>
+    </ExpandableSection>
+  );
+};

--- a/client/src/app/pages/advisory-details/components/csaf-cvss-details.tsx
+++ b/client/src/app/pages/advisory-details/components/csaf-cvss-details.tsx
@@ -16,26 +16,20 @@ interface CsafCvssDetailsProps {
 }
 
 export const CsafCvssDetails: React.FC<CsafCvssDetailsProps> = ({ cvss }) => {
-  const [isExpanded, setIsExpanded] = React.useState(false);
-
   const metrics: { label: string; value?: string }[] = [
-    { label: "Attack Vector", value: cvss.attackVector },
-    { label: "Attack Complexity", value: cvss.attackComplexity },
-    { label: "Privileges Required", value: cvss.privilegesRequired },
-    { label: "User Interaction", value: cvss.userInteraction },
+    { label: "Attack vector", value: cvss.attackVector },
+    { label: "Attack complexity", value: cvss.attackComplexity },
+    { label: "Privileges required", value: cvss.privilegesRequired },
+    { label: "User interaction", value: cvss.userInteraction },
     { label: "Scope", value: cvss.scope },
-    { label: "Confidentiality Impact", value: cvss.confidentialityImpact },
-    { label: "Integrity Impact", value: cvss.integrityImpact },
-    { label: "Availability Impact", value: cvss.availabilityImpact },
-    { label: "Vector String", value: cvss.vectorString },
+    { label: "Confidentiality", value: cvss.confidentialityImpact },
+    { label: "Integrity", value: cvss.integrityImpact },
+    { label: "Availability", value: cvss.availabilityImpact },
+    { label: "Vector string", value: cvss.vectorString },
   ];
 
   return (
-    <ExpandableSection
-      toggleText={isExpanded ? "Hide CVSS details" : "Show CVSS details"}
-      onToggle={(_event, expanded) => setIsExpanded(expanded)}
-      isExpanded={isExpanded}
-    >
+    <ExpandableSection toggleText="CVSS v3 details">
       <DescriptionList isHorizontal isCompact>
         {metrics
           .filter((m) => m.value)

--- a/client/src/app/pages/advisory-details/components/csaf-remediations.tsx
+++ b/client/src/app/pages/advisory-details/components/csaf-remediations.tsx
@@ -1,0 +1,157 @@
+/** Remediations section grouped by category with expandable product lists. */
+import React from "react";
+
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  ExpandableSection,
+  Flex,
+  FlexItem,
+  Label,
+  List,
+  ListItem,
+} from "@patternfly/react-core";
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+
+import type { CsafRemediation } from "@app/types/csaf";
+
+interface CsafRemediationsProps {
+  remediations: CsafRemediation[];
+  productNameMap: Map<string, string>;
+}
+
+/** Groups remediations by category. */
+function groupByCategory(
+  remediations: CsafRemediation[],
+): Map<string, CsafRemediation[]> {
+  const groups = new Map<string, CsafRemediation[]>();
+  for (const rem of remediations) {
+    const existing = groups.get(rem.category);
+    if (existing) {
+      existing.push(rem);
+    } else {
+      groups.set(rem.category, [rem]);
+    }
+  }
+  return groups;
+}
+
+/** Renders text with URLs converted to links. */
+const LinkifiedText: React.FC<{ text: string }> = ({ text }) => {
+  const urlRegex = /(https?:\/\/[^\s)]+)/g;
+  const parts = text.split(urlRegex);
+  return (
+    <>
+      {parts.map((part, i) =>
+        urlRegex.test(part) ? (
+          <a
+            key={`link-${i}`}
+            href={part}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {part} <ExternalLinkAltIcon />
+          </a>
+        ) : (
+          <span key={`text-${i}`}>{part}</span>
+        ),
+      )}
+    </>
+  );
+};
+
+/** Single remediation card within a category group. */
+const RemediationCard: React.FC<{
+  remediation: CsafRemediation;
+  productNameMap: Map<string, string>;
+}> = ({ remediation, productNameMap }) => {
+  const [showProducts, setShowProducts] = React.useState(false);
+  const productIds = remediation.product_ids || [];
+
+  return (
+    <Card isPlain isCompact>
+      <CardBody>
+        <Flex direction={{ default: "column" }} gap={{ default: "gapSm" }}>
+          <FlexItem>
+            <LinkifiedText text={remediation.details} />
+          </FlexItem>
+          {remediation.url && (
+            <FlexItem>
+              <a
+                href={remediation.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {remediation.url} <ExternalLinkAltIcon />
+              </a>
+            </FlexItem>
+          )}
+          {productIds.length > 0 && (
+            <FlexItem>
+              <ExpandableSection
+                toggleText={
+                  showProducts
+                    ? "Hide affected products"
+                    : `Show ${productIds.length} affected products`
+                }
+                onToggle={(_event, expanded) => setShowProducts(expanded)}
+                isExpanded={showProducts}
+              >
+                <List isPlain>
+                  {productIds.map((pid) => (
+                    <ListItem key={pid}>
+                      {productNameMap.get(pid) || pid}
+                    </ListItem>
+                  ))}
+                </List>
+              </ExpandableSection>
+            </FlexItem>
+          )}
+        </Flex>
+      </CardBody>
+    </Card>
+  );
+};
+
+export const CsafRemediations: React.FC<CsafRemediationsProps> = ({
+  remediations,
+  productNameMap,
+}) => {
+  const grouped = React.useMemo(
+    () => groupByCategory(remediations),
+    [remediations],
+  );
+
+  return (
+    <ExpandableSection toggleText="Remediations">
+      <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+        {Array.from(grouped.entries()).map(([category, rems]) => (
+          <FlexItem key={category}>
+            <Card isPlain>
+              <CardTitle>
+                <Label isCompact>{category.replace(/_/g, " ")}</Label> (
+                {rems.length})
+              </CardTitle>
+              <CardBody>
+                <Flex
+                  direction={{ default: "column" }}
+                  gap={{ default: "gapSm" }}
+                >
+                  {rems.map((rem, i) => (
+                    <FlexItem key={`${category}-${i}`}>
+                      <RemediationCard
+                        remediation={rem}
+                        productNameMap={productNameMap}
+                      />
+                    </FlexItem>
+                  ))}
+                </Flex>
+              </CardBody>
+            </Card>
+          </FlexItem>
+        ))}
+      </Flex>
+    </ExpandableSection>
+  );
+};

--- a/client/src/app/pages/advisory-details/components/csaf-vulnerability-card.tsx
+++ b/client/src/app/pages/advisory-details/components/csaf-vulnerability-card.tsx
@@ -17,6 +17,8 @@ import {
   ExpandableSection,
   Flex,
   FlexItem,
+  Grid,
+  GridItem,
   List,
   ListItem,
 } from "@patternfly/react-core";
@@ -80,46 +82,77 @@ export const CsafVulnerabilityCard: React.FC<CsafVulnerabilityCardProps> = ({
                     | "none"
                 }
                 score={cvss.baseScore}
+                showLabel
+                showScore
               />
-            </FlexItem>
-          )}
-          {vulnerability.title && (
-            <FlexItem>
-              <Content component="small">{vulnerability.title}</Content>
             </FlexItem>
           )}
         </Flex>
       </CardHeader>
       <CardBody>
         <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+          {vulnerability.title && (
+            <FlexItem>
+              <Content component="p">{vulnerability.title}</Content>
+            </FlexItem>
+          )}
           {/* Metadata */}
           <FlexItem>
-            <DescriptionList isHorizontal isCompact>
-              {vulnerability.cwe && (
-                <DescriptionListGroup>
-                  <DescriptionListTerm>CWE</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {vulnerability.cwe.id} — {vulnerability.cwe.name}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-              )}
-              {vulnerability.discovery_date && (
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Discovered</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {dayjs(vulnerability.discovery_date).format("YYYY-MM-DD")}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-              )}
-              {vulnerability.release_date && (
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Released</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {dayjs(vulnerability.release_date).format("YYYY-MM-DD")}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-              )}
-            </DescriptionList>
+            <Grid hasGutter>
+              <GridItem md={6}>
+                <DescriptionList isHorizontal isCompact>
+                  {vulnerability.cwe && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>CWE</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {vulnerability.cwe.id}: {vulnerability.cwe.name}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
+                  {vulnerability.discovery_date && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Discovered</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {dayjs(vulnerability.discovery_date).format(
+                          "MMM D, YYYY",
+                        )}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
+                  {cvss && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Impact</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {cvss.baseSeverity.charAt(0).toUpperCase() +
+                          cvss.baseSeverity.slice(1).toLowerCase()}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
+                </DescriptionList>
+              </GridItem>
+              <GridItem md={6}>
+                <DescriptionList isHorizontal isCompact>
+                  {cvss && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>CVSS score</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {cvss.baseScore} / 10
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
+                  {vulnerability.release_date && (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Released</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {dayjs(vulnerability.release_date).format(
+                          "MMM D, YYYY",
+                        )}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  )}
+                </DescriptionList>
+              </GridItem>
+            </Grid>
           </FlexItem>
 
           {/* CVSS Details */}

--- a/client/src/app/pages/advisory-details/components/csaf-vulnerability-card.tsx
+++ b/client/src/app/pages/advisory-details/components/csaf-vulnerability-card.tsx
@@ -1,0 +1,191 @@
+/** Individual CVE card with severity, CVSS breakdown, products, remediations, and references. */
+import React from "react";
+import { Link } from "react-router-dom";
+
+import dayjs from "dayjs";
+
+import {
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Content,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  ExpandableSection,
+  Flex,
+  FlexItem,
+  List,
+  ListItem,
+} from "@patternfly/react-core";
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+
+import { Paths } from "@app/Routes";
+import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
+import type { CsafVulnerability } from "@app/types/csaf";
+
+import { CsafCvssDetails } from "./csaf-cvss-details";
+import { CsafRemediations } from "./csaf-remediations";
+
+interface CsafVulnerabilityCardProps {
+  vulnerability: CsafVulnerability;
+  productNameMap: Map<string, string>;
+}
+
+const INITIAL_PRODUCTS_SHOWN = 5;
+
+export const CsafVulnerabilityCard: React.FC<CsafVulnerabilityCardProps> = ({
+  vulnerability,
+  productNameMap,
+}) => {
+  const [showAllProducts, setShowAllProducts] = React.useState(false);
+  const cvss = vulnerability.scores?.[0]?.cvss_v3;
+  const affectedProducts = vulnerability.product_status?.known_affected || [];
+  const visibleProducts = showAllProducts
+    ? affectedProducts
+    : affectedProducts.slice(0, INITIAL_PRODUCTS_SHOWN);
+  const hiddenCount = affectedProducts.length - INITIAL_PRODUCTS_SHOWN;
+
+  return (
+    <Card>
+      <CardHeader>
+        <Flex
+          alignItems={{ default: "alignItemsCenter" }}
+          gap={{ default: "gapMd" }}
+          flexWrap={{ default: "wrap" }}
+        >
+          {vulnerability.cve && (
+            <FlexItem>
+              <Link
+                to={Paths.vulnerabilityDetails.replace(
+                  ":vulnerabilityId",
+                  vulnerability.cve,
+                )}
+              >
+                <strong>{vulnerability.cve}</strong>
+              </Link>
+            </FlexItem>
+          )}
+          {cvss && (
+            <FlexItem>
+              <SeverityShieldAndText
+                value={
+                  cvss.baseSeverity.toLowerCase() as
+                    | "critical"
+                    | "high"
+                    | "medium"
+                    | "low"
+                    | "none"
+                }
+                score={cvss.baseScore}
+              />
+            </FlexItem>
+          )}
+          {vulnerability.title && (
+            <FlexItem>
+              <Content component="small">{vulnerability.title}</Content>
+            </FlexItem>
+          )}
+        </Flex>
+      </CardHeader>
+      <CardBody>
+        <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+          {/* Metadata */}
+          <FlexItem>
+            <DescriptionList isHorizontal isCompact>
+              {vulnerability.cwe && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>CWE</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {vulnerability.cwe.id} — {vulnerability.cwe.name}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {vulnerability.discovery_date && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Discovered</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {dayjs(vulnerability.discovery_date).format("YYYY-MM-DD")}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {vulnerability.release_date && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Released</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {dayjs(vulnerability.release_date).format("YYYY-MM-DD")}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+            </DescriptionList>
+          </FlexItem>
+
+          {/* CVSS Details */}
+          {cvss && (
+            <FlexItem>
+              <CsafCvssDetails cvss={cvss} />
+            </FlexItem>
+          )}
+
+          {/* Affected Products */}
+          {affectedProducts.length > 0 && (
+            <FlexItem>
+              <ExpandableSection toggleText="Affected Products">
+                <List isPlain>
+                  {visibleProducts.map((pid) => (
+                    <ListItem key={pid}>
+                      {productNameMap.get(pid) || pid}
+                    </ListItem>
+                  ))}
+                </List>
+                {hiddenCount > 0 && !showAllProducts && (
+                  <Button
+                    variant="link"
+                    isInline
+                    onClick={() => setShowAllProducts(true)}
+                  >
+                    +{hiddenCount} more
+                  </Button>
+                )}
+              </ExpandableSection>
+            </FlexItem>
+          )}
+
+          {/* Remediations */}
+          {vulnerability.remediations &&
+            vulnerability.remediations.length > 0 && (
+              <FlexItem>
+                <CsafRemediations
+                  remediations={vulnerability.remediations}
+                  productNameMap={productNameMap}
+                />
+              </FlexItem>
+            )}
+
+          {/* References */}
+          {vulnerability.references && vulnerability.references.length > 0 && (
+            <FlexItem>
+              <ExpandableSection toggleText="References">
+                <List isPlain>
+                  {vulnerability.references.map((ref, i) => (
+                    <ListItem key={`ref-${i}`}>
+                      <a
+                        href={ref.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {ref.summary || ref.url} <ExternalLinkAltIcon />
+                      </a>
+                    </ListItem>
+                  ))}
+                </List>
+              </ExpandableSection>
+            </FlexItem>
+          )}
+        </Flex>
+      </CardBody>
+    </Card>
+  );
+};

--- a/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
@@ -1,0 +1,133 @@
+/** CSAF-specific advisory details with 5-tab layout for VEX document visualization. */
+import React from "react";
+
+import {
+  PageSection,
+  Tab,
+  TabContent,
+  Tabs,
+  TabTitleText,
+} from "@patternfly/react-core";
+
+import { LoadingWrapper } from "@app/components/LoadingWrapper";
+import { useTabControls } from "@app/hooks/tab-controls";
+import { useFetchAdvisoryCsafById } from "@app/queries/advisories";
+
+import { CsafOverview } from "./csaf-overview";
+import { CsafProductTree } from "./csaf-product-tree";
+import { CsafRelationshipTree } from "./csaf-relationship-tree";
+import { CsafSource } from "./csaf-source";
+import { CsafVulnerabilities } from "./csaf-vulnerabilities";
+
+interface CsafAdvisoryDetailsProps {
+  advisoryId: string;
+}
+
+export const CsafAdvisoryDetails: React.FC<CsafAdvisoryDetailsProps> = ({
+  advisoryId,
+}) => {
+  const { csafDocument, isFetching, fetchError } =
+    useFetchAdvisoryCsafById(advisoryId);
+
+  const {
+    propHelpers: { getTabsProps, getTabProps, getTabContentProps },
+  } = useTabControls({
+    persistenceKeyPrefix: "cad",
+    persistTo: "urlParams",
+    tabKeys: [
+      "overview",
+      "vulnerabilities",
+      "product-tree",
+      "relationship-tree",
+      "source",
+    ],
+  });
+
+  const overviewTabRef = React.createRef<HTMLElement>();
+  const vulnerabilitiesTabRef = React.createRef<HTMLElement>();
+  const productTreeTabRef = React.createRef<HTMLElement>();
+  const relationshipTreeTabRef = React.createRef<HTMLElement>();
+  const sourceTabRef = React.createRef<HTMLElement>();
+
+  return (
+    <>
+      <PageSection>
+        <Tabs
+          mountOnEnter
+          {...getTabsProps()}
+          aria-label="CSAF advisory visualization tabs"
+          role="region"
+        >
+          <Tab
+            {...getTabProps("overview")}
+            title={<TabTitleText>Overview</TabTitleText>}
+            tabContentRef={overviewTabRef}
+          />
+          <Tab
+            {...getTabProps("vulnerabilities")}
+            title={<TabTitleText>Vulnerabilities</TabTitleText>}
+            tabContentRef={vulnerabilitiesTabRef}
+          />
+          <Tab
+            {...getTabProps("product-tree")}
+            title={<TabTitleText>Product Tree</TabTitleText>}
+            tabContentRef={productTreeTabRef}
+          />
+          <Tab
+            {...getTabProps("relationship-tree")}
+            title={<TabTitleText>Relationship Tree</TabTitleText>}
+            tabContentRef={relationshipTreeTabRef}
+          />
+          <Tab
+            {...getTabProps("source")}
+            title={<TabTitleText>Source</TabTitleText>}
+            tabContentRef={sourceTabRef}
+          />
+        </Tabs>
+      </PageSection>
+      <PageSection>
+        <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+          <TabContent
+            {...getTabContentProps("overview")}
+            ref={overviewTabRef}
+            aria-label="CSAF document overview"
+          >
+            {csafDocument && <CsafOverview csafDocument={csafDocument} />}
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("vulnerabilities")}
+            ref={vulnerabilitiesTabRef}
+            aria-label="CSAF vulnerabilities"
+          >
+            {csafDocument && (
+              <CsafVulnerabilities csafDocument={csafDocument} />
+            )}
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("product-tree")}
+            ref={productTreeTabRef}
+            aria-label="CSAF product tree"
+          >
+            {csafDocument && <CsafProductTree csafDocument={csafDocument} />}
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("relationship-tree")}
+            ref={relationshipTreeTabRef}
+            aria-label="CSAF relationship tree"
+          >
+            {csafDocument && (
+              <CsafRelationshipTree csafDocument={csafDocument} />
+            )}
+          </TabContent>
+          <TabContent
+            {...getTabContentProps("source")}
+            ref={sourceTabRef}
+            aria-label="CSAF source document"
+          >
+            {csafDocument && <CsafSource csafDocument={csafDocument} />}
+          </TabContent>
+        </LoadingWrapper>
+      </PageSection>
+    </>
+  );
+};

--- a/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/csaf-advisory-details.tsx
@@ -37,7 +37,7 @@ export const CsafAdvisoryDetails: React.FC<CsafAdvisoryDetailsProps> = ({
     tabKeys: [
       "overview",
       "vulnerabilities",
-      "product-tree",
+      "products",
       "relationship-tree",
       "source",
     ],
@@ -69,8 +69,8 @@ export const CsafAdvisoryDetails: React.FC<CsafAdvisoryDetailsProps> = ({
             tabContentRef={vulnerabilitiesTabRef}
           />
           <Tab
-            {...getTabProps("product-tree")}
-            title={<TabTitleText>Product Tree</TabTitleText>}
+            {...getTabProps("products")}
+            title={<TabTitleText>Products</TabTitleText>}
             tabContentRef={productTreeTabRef}
           />
           <Tab
@@ -104,7 +104,7 @@ export const CsafAdvisoryDetails: React.FC<CsafAdvisoryDetailsProps> = ({
             )}
           </TabContent>
           <TabContent
-            {...getTabContentProps("product-tree")}
+            {...getTabContentProps("products")}
             ref={productTreeTabRef}
             aria-label="CSAF product tree"
           >

--- a/client/src/app/pages/advisory-details/csaf-overview.tsx
+++ b/client/src/app/pages/advisory-details/csaf-overview.tsx
@@ -3,11 +3,17 @@ import React from "react";
 
 import dayjs from "dayjs";
 
-import { ChartDonut } from "@patternfly/react-charts/victory";
+import {
+  Chart,
+  ChartAxis,
+  ChartBar,
+  ChartDonut,
+} from "@patternfly/react-charts/victory";
 
 import {
   Card,
   CardBody,
+  CardHeader,
   CardTitle,
   Content,
   DescriptionList,
@@ -24,7 +30,9 @@ import {
 } from "@patternfly/react-core";
 import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
 
-import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
+import { Link } from "react-router-dom";
+
+import { Paths } from "@app/Routes";
 import type { CsafDocument, CsafVulnerability } from "@app/types/csaf";
 
 interface CsafOverviewProps {
@@ -40,22 +48,48 @@ const SEVERITY_COLORS: Record<string, string> = {
   NONE: "#8A8D90",
 };
 
-/** Derives severity counts from CSAF vulnerabilities. */
+/** Collects all product IDs from every product_status category. */
+function getAllProductIds(status?: {
+  [key: string]: string[] | undefined;
+}): string[] {
+  if (!status) return [];
+  return [
+    ...(status.known_affected ?? []),
+    ...(status.fixed ?? []),
+    ...(status.first_affected ?? []),
+    ...(status.last_affected ?? []),
+    ...(status.under_investigation ?? []),
+    ...(status.known_not_affected ?? []),
+    ...(status.first_fixed ?? []),
+    ...(status.recommended ?? []),
+  ];
+}
+
+/** Derives affected-product counts per severity from CSAF vulnerabilities. */
 function computeSeverityCounts(
   vulnerabilities?: CsafVulnerability[],
 ): { severity: string; count: number }[] {
-  const counts: Record<string, number> = {};
+  const productsBySeverity: Record<string, Set<string>> = {};
   if (vulnerabilities) {
     for (const vuln of vulnerabilities) {
       const baseSeverity =
         vuln.scores?.[0]?.cvss_v3?.baseSeverity?.toUpperCase() || "NONE";
-      counts[baseSeverity] = (counts[baseSeverity] || 0) + 1;
+      if (!productsBySeverity[baseSeverity]) {
+        productsBySeverity[baseSeverity] = new Set();
+      }
+      const allProducts = getAllProductIds(vuln.product_status);
+      for (const pid of allProducts) {
+        productsBySeverity[baseSeverity].add(pid);
+      }
     }
   }
   const order = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "NONE"];
   return order
-    .filter((s) => (counts[s] || 0) > 0)
-    .map((severity) => ({ severity, count: counts[severity] || 0 }));
+    .filter((s) => productsBySeverity[s]?.size)
+    .map((severity) => ({
+      severity,
+      count: productsBySeverity[severity].size,
+    }));
 }
 
 /** Derives remediation category counts from CSAF vulnerabilities. */
@@ -100,31 +134,69 @@ export const CsafOverview: React.FC<CsafOverviewProps> = ({ csafDocument }) => {
     (sum, r) => sum + r.count,
     0,
   );
+  const totalAffectedProducts = React.useMemo(() => {
+    const productIds = new Set<string>();
+    if (vulnerabilities) {
+      for (const vuln of vulnerabilities) {
+        for (const pid of getAllProductIds(vuln.product_status)) {
+          productIds.add(pid);
+        }
+      }
+    }
+    return productIds.size;
+  }, [vulnerabilities]);
 
   return (
     <Flex direction={{ default: "column" }} gap={{ default: "gapLg" }}>
       {/* Metadata */}
       <FlexItem>
-        <Card isPlain>
-          <CardTitle>Document Metadata</CardTitle>
+        <Card>
+          <CardHeader
+            actions={{
+              actions: (
+                <Flex gap={{ default: "gapSm" }}>
+                  {doc.aggregate_severity && (
+                    <FlexItem>
+                      <Label color="blue">
+                        Severity: {doc.aggregate_severity.text}
+                      </Label>
+                    </FlexItem>
+                  )}
+                  {doc.distribution?.tlp && (
+                    <FlexItem>
+                      <Label>TLP: {doc.distribution.tlp.label}</Label>
+                    </FlexItem>
+                  )}
+                </Flex>
+              ),
+              hasNoOffset: true,
+            }}
+          >
+            <Content component="h2">{doc.title}</Content>
+          </CardHeader>
           <CardBody>
             <DescriptionList isHorizontal>
               <DescriptionListGroup>
-                <DescriptionListTerm>Title</DescriptionListTerm>
-                <DescriptionListDescription>
-                  {doc.title}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
                 <DescriptionListTerm>Tracking ID</DescriptionListTerm>
                 <DescriptionListDescription>
-                  {doc.tracking.id}
+                  {/^CVE-\d{4}-\d+$/.test(doc.tracking.id) ? (
+                    <Link
+                      to={Paths.vulnerabilityDetails.replace(
+                        ":vulnerabilityId",
+                        doc.tracking.id,
+                      )}
+                    >
+                      {doc.tracking.id}
+                    </Link>
+                  ) : (
+                    doc.tracking.id
+                  )}
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>
                 <DescriptionListTerm>Status</DescriptionListTerm>
                 <DescriptionListDescription>
-                  <Label>{doc.tracking.status}</Label>
+                  <Label color="green">{doc.tracking.status}</Label>
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>
@@ -142,14 +214,24 @@ export const CsafOverview: React.FC<CsafOverviewProps> = ({ csafDocument }) => {
               <DescriptionListGroup>
                 <DescriptionListTerm>Publisher</DescriptionListTerm>
                 <DescriptionListDescription>
-                  {doc.publisher.name}
+                  <Flex
+                    gap={{ default: "gapSm" }}
+                    alignItems={{ default: "alignItemsCenter" }}
+                  >
+                    <FlexItem>{doc.publisher.name}</FlexItem>
+                    {doc.publisher.category && (
+                      <FlexItem>
+                        <Label isCompact>{doc.publisher.category}</Label>
+                      </FlexItem>
+                    )}
+                  </Flex>
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>
                 <DescriptionListTerm>Initial release</DescriptionListTerm>
                 <DescriptionListDescription>
                   {dayjs(doc.tracking.initial_release_date).format(
-                    "YYYY-MM-DD",
+                    "MMM D, YYYY",
                   )}
                 </DescriptionListDescription>
               </DescriptionListGroup>
@@ -157,7 +239,7 @@ export const CsafOverview: React.FC<CsafOverviewProps> = ({ csafDocument }) => {
                 <DescriptionListTerm>Current release</DescriptionListTerm>
                 <DescriptionListDescription>
                   {dayjs(doc.tracking.current_release_date).format(
-                    "YYYY-MM-DD",
+                    "MMM D, YYYY",
                   )}
                 </DescriptionListDescription>
               </DescriptionListGroup>
@@ -168,32 +250,6 @@ export const CsafOverview: React.FC<CsafOverviewProps> = ({ csafDocument }) => {
                     {doc.tracking.generator.engine.name}
                     {doc.tracking.generator.engine.version &&
                       ` v${doc.tracking.generator.engine.version}`}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-              )}
-              {doc.aggregate_severity && (
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Severity</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <SeverityShieldAndText
-                      value={
-                        doc.aggregate_severity.text.toLowerCase() as
-                          | "critical"
-                          | "high"
-                          | "medium"
-                          | "low"
-                          | "none"
-                      }
-                      score={null}
-                    />
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-              )}
-              {doc.distribution?.tlp && (
-                <DescriptionListGroup>
-                  <DescriptionListTerm>TLP</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    <Label>{doc.distribution.tlp.label}</Label>
                   </DescriptionListDescription>
                 </DescriptionListGroup>
               )}
@@ -208,62 +264,73 @@ export const CsafOverview: React.FC<CsafOverviewProps> = ({ csafDocument }) => {
           <Grid hasGutter>
             {severityCounts.length > 0 && (
               <GridItem md={6}>
-                <Card isPlain>
-                  <CardTitle>Impact Summary</CardTitle>
+                <Card>
+                  <CardTitle>Impact summary</CardTitle>
                   <CardBody>
-                    <Flex
-                      direction={{ default: "column" }}
-                      gap={{ default: "gapSm" }}
-                    >
-                      {severityCounts.map(({ severity, count }) => (
-                        <FlexItem key={severity}>
-                          <Flex
-                            alignItems={{ default: "alignItemsCenter" }}
-                            gap={{ default: "gapSm" }}
-                          >
-                            <FlexItem style={{ minWidth: 120 }}>
-                              <SeverityShieldAndText
-                                value={
-                                  severity.toLowerCase() as
-                                    | "critical"
-                                    | "high"
-                                    | "medium"
-                                    | "low"
-                                    | "none"
-                                }
-                                score={null}
-                              />
-                            </FlexItem>
-                            <FlexItem>
-                              <div
-                                style={{
-                                  height: 16,
-                                  width: count * 40,
-                                  maxWidth: 300,
-                                  minWidth: 20,
-                                  backgroundColor:
-                                    SEVERITY_COLORS[severity] || "#8A8D90",
-                                  borderRadius: 2,
-                                }}
-                              />
-                            </FlexItem>
-                            <FlexItem>
-                              <strong>{count}</strong>{" "}
-                              {count === 1 ? "CVE" : "CVEs"}
-                            </FlexItem>
-                          </Flex>
-                        </FlexItem>
-                      ))}
-                    </Flex>
+                    <Content component="small">
+                      {vulnerabilities?.length ?? 0}{" "}
+                      {(vulnerabilities?.length ?? 0) === 1 ? "CVE" : "CVEs"}{" "}
+                      affecting {totalAffectedProducts} products
+                    </Content>
+                    <div style={{ height: 40 + severityCounts.length * 40 }}>
+                      <Chart
+                        ariaDesc="Impact summary by severity"
+                        name="impact-summary-chart"
+                        horizontal
+                        domainPadding={{ x: [10, 10] }}
+                        height={40 + severityCounts.length * 40}
+                        padding={{
+                          bottom: 30,
+                          left: 80,
+                          right: 20,
+                          top: 10,
+                        }}
+                      >
+                        <ChartAxis
+                          dependentAxis
+                          style={{
+                            tickLabels: { fontSize: 12 },
+                          }}
+                        />
+                        <ChartAxis
+                          style={{
+                            grid: { stroke: "#D2D2D2", strokeDasharray: "4,4" },
+                            tickLabels: { fontSize: 12 },
+                          }}
+                        />
+                        <ChartBar
+                          horizontal
+                          barWidth={16}
+                          data={severityCounts.map(({ severity, count }) => ({
+                            x:
+                              severity.charAt(0) +
+                              severity.slice(1).toLowerCase(),
+                            y: count,
+                          }))}
+                          style={{
+                            data: {
+                              fill: ({ datum }) =>
+                                SEVERITY_COLORS[
+                                  (datum.x as string).toUpperCase()
+                                ] || "#8A8D90",
+                            },
+                          }}
+                          labels={({ datum }) => `${datum.x}: ${datum.y}`}
+                        />
+                      </Chart>
+                    </div>
                   </CardBody>
                 </Card>
               </GridItem>
             )}
             {remediationCounts.length > 0 && (
               <GridItem md={6}>
-                <Card isPlain>
-                  <CardTitle>Remediation Status</CardTitle>
+                <Card>
+                  <CardTitle>Remediation status</CardTitle>
                   <CardBody>
+                    <Content component="small">
+                      Fix availability across affected products
+                    </Content>
                     <div style={{ height: "230px", maxWidth: "350px" }}>
                       <ChartDonut
                         constrainToVisibleArea
@@ -276,7 +343,7 @@ export const CsafOverview: React.FC<CsafOverviewProps> = ({ csafDocument }) => {
                           top: 20,
                         }}
                         title={`${totalRemediations}`}
-                        subTitle="Remediations"
+                        subTitle="entries"
                         width={350}
                         legendData={remediationCounts.map(
                           ({ category, count }) => ({
@@ -337,7 +404,7 @@ export const CsafOverview: React.FC<CsafOverviewProps> = ({ csafDocument }) => {
                 {doc.tracking.revision_history.map((rev) => (
                   <DescriptionListGroup key={rev.number}>
                     <DescriptionListTerm>
-                      v{rev.number} — {dayjs(rev.date).format("YYYY-MM-DD")}
+                      v{rev.number} — {dayjs(rev.date).format("MMM D, YYYY")}
                     </DescriptionListTerm>
                     <DescriptionListDescription>
                       {rev.summary}

--- a/client/src/app/pages/advisory-details/csaf-overview.tsx
+++ b/client/src/app/pages/advisory-details/csaf-overview.tsx
@@ -1,0 +1,376 @@
+/** CSAF Overview tab displaying document metadata, charts, references, revision history, and notes. */
+import React from "react";
+
+import dayjs from "dayjs";
+
+import { ChartDonut } from "@patternfly/react-charts/victory";
+
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Content,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Flex,
+  FlexItem,
+  Grid,
+  GridItem,
+  Label,
+  List,
+  ListItem,
+} from "@patternfly/react-core";
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+
+import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
+import type { CsafDocument, CsafVulnerability } from "@app/types/csaf";
+
+interface CsafOverviewProps {
+  csafDocument: CsafDocument;
+}
+
+/** Severity color mapping for impact summary. */
+const SEVERITY_COLORS: Record<string, string> = {
+  CRITICAL: "#A30000",
+  HIGH: "#C9190B",
+  MEDIUM: "#F0AB00",
+  LOW: "#0066CC",
+  NONE: "#8A8D90",
+};
+
+/** Derives severity counts from CSAF vulnerabilities. */
+function computeSeverityCounts(
+  vulnerabilities?: CsafVulnerability[],
+): { severity: string; count: number }[] {
+  const counts: Record<string, number> = {};
+  if (vulnerabilities) {
+    for (const vuln of vulnerabilities) {
+      const baseSeverity =
+        vuln.scores?.[0]?.cvss_v3?.baseSeverity?.toUpperCase() || "NONE";
+      counts[baseSeverity] = (counts[baseSeverity] || 0) + 1;
+    }
+  }
+  const order = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "NONE"];
+  return order
+    .filter((s) => (counts[s] || 0) > 0)
+    .map((severity) => ({ severity, count: counts[severity] || 0 }));
+}
+
+/** Derives remediation category counts from CSAF vulnerabilities. */
+function computeRemediationCounts(
+  vulnerabilities?: CsafVulnerability[],
+): { category: string; count: number }[] {
+  const counts: Record<string, number> = {};
+  if (vulnerabilities) {
+    for (const vuln of vulnerabilities) {
+      if (vuln.remediations) {
+        for (const rem of vuln.remediations) {
+          counts[rem.category] = (counts[rem.category] || 0) + 1;
+        }
+      }
+    }
+  }
+  return Object.entries(counts).map(([category, count]) => ({
+    category,
+    count,
+  }));
+}
+
+const REMEDIATION_COLORS: Record<string, string> = {
+  vendor_fix: "#4CB140",
+  workaround: "#F0AB00",
+  no_fix_planned: "#C9190B",
+  none_available: "#8A8D90",
+  mitigation: "#0066CC",
+};
+
+export const CsafOverview: React.FC<CsafOverviewProps> = ({ csafDocument }) => {
+  const { document: doc, vulnerabilities } = csafDocument;
+  const severityCounts = React.useMemo(
+    () => computeSeverityCounts(vulnerabilities),
+    [vulnerabilities],
+  );
+  const remediationCounts = React.useMemo(
+    () => computeRemediationCounts(vulnerabilities),
+    [vulnerabilities],
+  );
+  const totalRemediations = remediationCounts.reduce(
+    (sum, r) => sum + r.count,
+    0,
+  );
+
+  return (
+    <Flex direction={{ default: "column" }} gap={{ default: "gapLg" }}>
+      {/* Metadata */}
+      <FlexItem>
+        <Card isPlain>
+          <CardTitle>Document Metadata</CardTitle>
+          <CardBody>
+            <DescriptionList isHorizontal>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Title</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {doc.title}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Tracking ID</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {doc.tracking.id}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Status</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <Label>{doc.tracking.status}</Label>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Version</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {doc.tracking.version}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Category</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {doc.category}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Publisher</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {doc.publisher.name}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Initial release</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {dayjs(doc.tracking.initial_release_date).format(
+                    "YYYY-MM-DD",
+                  )}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Current release</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {dayjs(doc.tracking.current_release_date).format(
+                    "YYYY-MM-DD",
+                  )}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              {doc.tracking.generator && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Generator</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {doc.tracking.generator.engine.name}
+                    {doc.tracking.generator.engine.version &&
+                      ` v${doc.tracking.generator.engine.version}`}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {doc.aggregate_severity && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Severity</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <SeverityShieldAndText
+                      value={
+                        doc.aggregate_severity.text.toLowerCase() as
+                          | "critical"
+                          | "high"
+                          | "medium"
+                          | "low"
+                          | "none"
+                      }
+                      score={null}
+                    />
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+              {doc.distribution?.tlp && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>TLP</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <Label>{doc.distribution.tlp.label}</Label>
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+            </DescriptionList>
+          </CardBody>
+        </Card>
+      </FlexItem>
+
+      {/* Charts */}
+      {(severityCounts.length > 0 || remediationCounts.length > 0) && (
+        <FlexItem>
+          <Grid hasGutter>
+            {severityCounts.length > 0 && (
+              <GridItem md={6}>
+                <Card isPlain>
+                  <CardTitle>Impact Summary</CardTitle>
+                  <CardBody>
+                    <Flex
+                      direction={{ default: "column" }}
+                      gap={{ default: "gapSm" }}
+                    >
+                      {severityCounts.map(({ severity, count }) => (
+                        <FlexItem key={severity}>
+                          <Flex
+                            alignItems={{ default: "alignItemsCenter" }}
+                            gap={{ default: "gapSm" }}
+                          >
+                            <FlexItem style={{ minWidth: 120 }}>
+                              <SeverityShieldAndText
+                                value={
+                                  severity.toLowerCase() as
+                                    | "critical"
+                                    | "high"
+                                    | "medium"
+                                    | "low"
+                                    | "none"
+                                }
+                                score={null}
+                              />
+                            </FlexItem>
+                            <FlexItem>
+                              <div
+                                style={{
+                                  height: 16,
+                                  width: count * 40,
+                                  maxWidth: 300,
+                                  minWidth: 20,
+                                  backgroundColor:
+                                    SEVERITY_COLORS[severity] || "#8A8D90",
+                                  borderRadius: 2,
+                                }}
+                              />
+                            </FlexItem>
+                            <FlexItem>
+                              <strong>{count}</strong>{" "}
+                              {count === 1 ? "CVE" : "CVEs"}
+                            </FlexItem>
+                          </Flex>
+                        </FlexItem>
+                      ))}
+                    </Flex>
+                  </CardBody>
+                </Card>
+              </GridItem>
+            )}
+            {remediationCounts.length > 0 && (
+              <GridItem md={6}>
+                <Card isPlain>
+                  <CardTitle>Remediation Status</CardTitle>
+                  <CardBody>
+                    <div style={{ height: "230px", maxWidth: "350px" }}>
+                      <ChartDonut
+                        constrainToVisibleArea
+                        legendOrientation="vertical"
+                        legendPosition="right"
+                        padding={{
+                          bottom: 20,
+                          left: 20,
+                          right: 140,
+                          top: 20,
+                        }}
+                        title={`${totalRemediations}`}
+                        subTitle="Remediations"
+                        width={350}
+                        legendData={remediationCounts.map(
+                          ({ category, count }) => ({
+                            name: `${category.replace(/_/g, " ")}: ${count}`,
+                          }),
+                        )}
+                        data={remediationCounts.map(({ category, count }) => ({
+                          x: category.replace(/_/g, " "),
+                          y: count,
+                        }))}
+                        labels={({ datum }) => `${datum.x}: ${datum.y}`}
+                        colorScale={remediationCounts.map(
+                          ({ category }) =>
+                            REMEDIATION_COLORS[category] || "#8A8D90",
+                        )}
+                      />
+                    </div>
+                  </CardBody>
+                </Card>
+              </GridItem>
+            )}
+          </Grid>
+        </FlexItem>
+      )}
+
+      {/* References */}
+      {doc.references && doc.references.length > 0 && (
+        <FlexItem>
+          <Card isPlain>
+            <CardTitle>References</CardTitle>
+            <CardBody>
+              <List isPlain>
+                {doc.references.map((ref, i) => (
+                  <ListItem key={`ref-${i}`}>
+                    <a href={ref.url} target="_blank" rel="noopener noreferrer">
+                      {ref.summary || ref.url} <ExternalLinkAltIcon />
+                    </a>
+                    {ref.category && (
+                      <Label isCompact color="grey" style={{ marginLeft: 8 }}>
+                        {ref.category}
+                      </Label>
+                    )}
+                  </ListItem>
+                ))}
+              </List>
+            </CardBody>
+          </Card>
+        </FlexItem>
+      )}
+
+      {/* Revision History */}
+      {doc.tracking.revision_history.length > 0 && (
+        <FlexItem>
+          <Card isPlain>
+            <CardTitle>Revision History</CardTitle>
+            <CardBody>
+              <DescriptionList isHorizontal>
+                {doc.tracking.revision_history.map((rev) => (
+                  <DescriptionListGroup key={rev.number}>
+                    <DescriptionListTerm>
+                      v{rev.number} — {dayjs(rev.date).format("YYYY-MM-DD")}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {rev.summary}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                ))}
+              </DescriptionList>
+            </CardBody>
+          </Card>
+        </FlexItem>
+      )}
+
+      {/* Notes */}
+      {doc.notes && doc.notes.length > 0 && (
+        <FlexItem>
+          <Card isPlain>
+            <CardTitle>Notes</CardTitle>
+            <CardBody>
+              {doc.notes.map((note, i) => (
+                <div key={`note-${i}`} style={{ marginBottom: 16 }}>
+                  {note.title && <Content component="h4">{note.title}</Content>}
+                  {!note.title && note.category && (
+                    <Content component="h4">
+                      {note.category.replace(/_/g, " ")}
+                    </Content>
+                  )}
+                  <Content component="p">{note.text}</Content>
+                </div>
+              ))}
+            </CardBody>
+          </Card>
+        </FlexItem>
+      )}
+    </Flex>
+  );
+};

--- a/client/src/app/pages/advisory-details/csaf-product-tree.tsx
+++ b/client/src/app/pages/advisory-details/csaf-product-tree.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import ReactECharts from "echarts-for-react";
 
 import {
+  Content,
   EmptyState,
   EmptyStateBody,
   EmptyStateVariant,
@@ -127,15 +128,21 @@ export const CsafProductTree: React.FC<CsafProductTreeProps> = ({
   return (
     <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
       <FlexItem>
+        <Content component="h3">Product tree</Content>
+        <Content component="small">
+          Click a node to expand or collapse. Scroll to zoom, drag to pan.
+        </Content>
+      </FlexItem>
+      <FlexItem>
+        <CategoryLegend />
+      </FlexItem>
+      <FlexItem>
         <ReactECharts
           option={option}
           style={{ height: "600px", width: "100%" }}
           notMerge
           lazyUpdate
         />
-      </FlexItem>
-      <FlexItem>
-        <CategoryLegend />
       </FlexItem>
     </Flex>
   );

--- a/client/src/app/pages/advisory-details/csaf-product-tree.tsx
+++ b/client/src/app/pages/advisory-details/csaf-product-tree.tsx
@@ -1,0 +1,142 @@
+/** CSAF Product Tree tab with ECharts interactive tree visualization. */
+import React from "react";
+
+import ReactECharts from "echarts-for-react";
+
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Flex,
+  FlexItem,
+} from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+
+import type { CsafDocument } from "@app/types/csaf";
+
+import {
+  BRANCH_CATEGORY_COLORS,
+  transformBranchesToTreeData,
+} from "./helpers/csaf-tree-helpers";
+
+interface CsafProductTreeProps {
+  csafDocument: CsafDocument;
+}
+
+/** Color-coded legend for branch categories. */
+const CategoryLegend: React.FC = () => {
+  const entries = Object.entries(BRANCH_CATEGORY_COLORS);
+  return (
+    <Flex
+      gap={{ default: "gapMd" }}
+      flexWrap={{ default: "wrap" }}
+      justifyContent={{ default: "justifyContentCenter" }}
+    >
+      {entries.map(([category, color]) => (
+        <FlexItem key={category}>
+          <Flex
+            gap={{ default: "gapXs" }}
+            alignItems={{ default: "alignItemsCenter" }}
+          >
+            <FlexItem>
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 12,
+                  height: 12,
+                  borderRadius: "50%",
+                  backgroundColor: color,
+                }}
+              />
+            </FlexItem>
+            <FlexItem>
+              <span style={{ fontSize: "var(--pf-t--global--font--size--sm)" }}>
+                {category.replace(/_/g, " ")}
+              </span>
+            </FlexItem>
+          </Flex>
+        </FlexItem>
+      ))}
+    </Flex>
+  );
+};
+
+export const CsafProductTree: React.FC<CsafProductTreeProps> = ({
+  csafDocument,
+}) => {
+  const branches = csafDocument.product_tree?.branches;
+
+  const treeData = React.useMemo(() => {
+    if (!branches || branches.length === 0) return null;
+    return transformBranchesToTreeData(branches);
+  }, [branches]);
+
+  if (!treeData) {
+    return (
+      <EmptyState
+        titleText="No product tree available"
+        headingLevel="h2"
+        icon={CubesIcon}
+        variant={EmptyStateVariant.sm}
+      >
+        <EmptyStateBody>
+          This advisory does not contain product tree data.
+        </EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  const option = {
+    tooltip: {
+      trigger: "item" as const,
+      triggerOn: "mousemove" as const,
+      formatter: (params: { data?: { name?: string; value?: string } }) => {
+        const category = params.data?.value;
+        return category
+          ? `${params.data?.name}<br/><em>${category.replace(/_/g, " ")}</em>`
+          : params.data?.name || "";
+      },
+    },
+    series: [
+      {
+        type: "tree" as const,
+        data: [treeData],
+        orient: "LR" as const,
+        roam: true,
+        initialTreeDepth: 2,
+        expandAndCollapse: true,
+        animationDuration: 550,
+        animationDurationUpdate: 750,
+        label: {
+          position: "left" as const,
+          verticalAlign: "middle" as const,
+          align: "right" as const,
+          fontSize: 11,
+        },
+        leaves: {
+          label: {
+            position: "right" as const,
+            verticalAlign: "middle" as const,
+            align: "left" as const,
+          },
+        },
+      },
+    ],
+  };
+
+  return (
+    <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+      <FlexItem>
+        <ReactECharts
+          option={option}
+          style={{ height: "600px", width: "100%" }}
+          notMerge
+          lazyUpdate
+        />
+      </FlexItem>
+      <FlexItem>
+        <CategoryLegend />
+      </FlexItem>
+    </Flex>
+  );
+};

--- a/client/src/app/pages/advisory-details/csaf-relationship-tree.tsx
+++ b/client/src/app/pages/advisory-details/csaf-relationship-tree.tsx
@@ -1,0 +1,143 @@
+/** CSAF Relationship Tree tab with ECharts interactive graph visualization. */
+import React from "react";
+
+import ReactECharts from "echarts-for-react";
+
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Flex,
+  FlexItem,
+} from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+
+import type { CsafDocument } from "@app/types/csaf";
+
+import {
+  RELATIONSHIP_CATEGORY_COLORS,
+  transformRelationshipsToTreeData,
+} from "./helpers/csaf-relationship-helpers";
+
+interface CsafRelationshipTreeProps {
+  csafDocument: CsafDocument;
+}
+
+/** Color-coded legend for relationship types. */
+const RelationshipLegend: React.FC = () => {
+  const entries = Object.entries(RELATIONSHIP_CATEGORY_COLORS);
+  return (
+    <Flex
+      gap={{ default: "gapMd" }}
+      flexWrap={{ default: "wrap" }}
+      justifyContent={{ default: "justifyContentCenter" }}
+    >
+      {entries.map(([category, color]) => (
+        <FlexItem key={category}>
+          <Flex
+            gap={{ default: "gapXs" }}
+            alignItems={{ default: "alignItemsCenter" }}
+          >
+            <FlexItem>
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 12,
+                  height: 12,
+                  borderRadius: "50%",
+                  backgroundColor: color,
+                }}
+              />
+            </FlexItem>
+            <FlexItem>
+              <span style={{ fontSize: "var(--pf-t--global--font--size--sm)" }}>
+                {category.replace(/_/g, " ")}
+              </span>
+            </FlexItem>
+          </Flex>
+        </FlexItem>
+      ))}
+    </Flex>
+  );
+};
+
+export const CsafRelationshipTree: React.FC<CsafRelationshipTreeProps> = ({
+  csafDocument,
+}) => {
+  const relationships = csafDocument.product_tree?.relationships;
+  const fullProductNames = csafDocument.product_tree?.full_product_names;
+
+  const treeData = React.useMemo(() => {
+    if (!relationships || relationships.length === 0) return null;
+    return transformRelationshipsToTreeData(relationships, fullProductNames);
+  }, [relationships, fullProductNames]);
+
+  if (!treeData) {
+    return (
+      <EmptyState
+        titleText="No relationships found in this advisory"
+        headingLevel="h2"
+        icon={CubesIcon}
+        variant={EmptyStateVariant.sm}
+      >
+        <EmptyStateBody>
+          This advisory does not contain product relationship data.
+        </EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  const option = {
+    tooltip: {
+      trigger: "item" as const,
+      triggerOn: "mousemove" as const,
+      formatter: (params: { data?: { name?: string; value?: string } }) => {
+        const category = params.data?.value;
+        return category
+          ? `${params.data?.name}<br/><em>${category.replace(/_/g, " ")}</em>`
+          : params.data?.name || "";
+      },
+    },
+    series: [
+      {
+        type: "tree" as const,
+        data: [treeData],
+        orient: "LR" as const,
+        roam: true,
+        initialTreeDepth: 3,
+        expandAndCollapse: true,
+        animationDuration: 550,
+        animationDurationUpdate: 750,
+        label: {
+          position: "left" as const,
+          verticalAlign: "middle" as const,
+          align: "right" as const,
+          fontSize: 11,
+        },
+        leaves: {
+          label: {
+            position: "right" as const,
+            verticalAlign: "middle" as const,
+            align: "left" as const,
+          },
+        },
+      },
+    ],
+  };
+
+  return (
+    <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+      <FlexItem>
+        <ReactECharts
+          option={option}
+          style={{ height: "600px", width: "100%" }}
+          notMerge
+          lazyUpdate
+        />
+      </FlexItem>
+      <FlexItem>
+        <RelationshipLegend />
+      </FlexItem>
+    </Flex>
+  );
+};

--- a/client/src/app/pages/advisory-details/csaf-relationship-tree.tsx
+++ b/client/src/app/pages/advisory-details/csaf-relationship-tree.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import ReactECharts from "echarts-for-react";
 
 import {
+  Content,
   EmptyState,
   EmptyStateBody,
   EmptyStateVariant,
@@ -18,21 +19,38 @@ import {
   RELATIONSHIP_CATEGORY_COLORS,
   transformRelationshipsToTreeData,
 } from "./helpers/csaf-relationship-helpers";
+import { BRANCH_CATEGORY_COLORS } from "./helpers/csaf-tree-helpers";
 
 interface CsafRelationshipTreeProps {
   csafDocument: CsafDocument;
 }
 
-/** Color-coded legend for relationship types. */
+const NODE_TYPE_SUBSET: Record<string, string> = {
+  vendor: BRANCH_CATEGORY_COLORS.vendor,
+  product_name: BRANCH_CATEGORY_COLORS.product_name,
+  product_version: BRANCH_CATEGORY_COLORS.product_version,
+  product_version_range: BRANCH_CATEGORY_COLORS.product_version_range,
+  product_family: BRANCH_CATEGORY_COLORS.product_family,
+  architecture: BRANCH_CATEGORY_COLORS.architecture,
+};
+
+const EDGE_STYLES: Record<string, { color: string; dash: string }> = {
+  default_component_of: { color: "#0066CC", dash: "" },
+  external_component_of: { color: "#EC7A08", dash: "8 4" },
+  installed_on: { color: "#6753AC", dash: "2 3" },
+  installed_with: { color: "#009596", dash: "5 2 2 2" },
+  optional_component_of: { color: "#8A8D90", dash: "4 4" },
+};
+
+/** Legend with node-type colors and edge line styles. */
 const RelationshipLegend: React.FC = () => {
-  const entries = Object.entries(RELATIONSHIP_CATEGORY_COLORS);
   return (
     <Flex
       gap={{ default: "gapMd" }}
       flexWrap={{ default: "wrap" }}
       justifyContent={{ default: "justifyContentCenter" }}
     >
-      {entries.map(([category, color]) => (
+      {Object.entries(NODE_TYPE_SUBSET).map(([category, color]) => (
         <FlexItem key={category}>
           <Flex
             gap={{ default: "gapXs" }}
@@ -48,6 +66,33 @@ const RelationshipLegend: React.FC = () => {
                   backgroundColor: color,
                 }}
               />
+            </FlexItem>
+            <FlexItem>
+              <span style={{ fontSize: "var(--pf-t--global--font--size--sm)" }}>
+                {category.replace(/_/g, " ")}
+              </span>
+            </FlexItem>
+          </Flex>
+        </FlexItem>
+      ))}
+      {Object.entries(EDGE_STYLES).map(([category, { color, dash }]) => (
+        <FlexItem key={category}>
+          <Flex
+            gap={{ default: "gapXs" }}
+            alignItems={{ default: "alignItemsCenter" }}
+          >
+            <FlexItem>
+              <svg width="24" height="12">
+                <line
+                  x1="0"
+                  y1="6"
+                  x2="24"
+                  y2="6"
+                  stroke={color}
+                  strokeWidth="2"
+                  strokeDasharray={dash || undefined}
+                />
+              </svg>
             </FlexItem>
             <FlexItem>
               <span style={{ fontSize: "var(--pf-t--global--font--size--sm)" }}>
@@ -128,15 +173,22 @@ export const CsafRelationshipTree: React.FC<CsafRelationshipTreeProps> = ({
   return (
     <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
       <FlexItem>
+        <Content component="h3">Relationship tree</Content>
+        <Content component="small">
+          Hover to highlight path. Click a node to expand or collapse. Drag to
+          pan, scroll to zoom.
+        </Content>
+      </FlexItem>
+      <FlexItem>
+        <RelationshipLegend />
+      </FlexItem>
+      <FlexItem>
         <ReactECharts
           option={option}
           style={{ height: "600px", width: "100%" }}
           notMerge
           lazyUpdate
         />
-      </FlexItem>
-      <FlexItem>
-        <RelationshipLegend />
       </FlexItem>
     </Flex>
   );

--- a/client/src/app/pages/advisory-details/csaf-source.tsx
+++ b/client/src/app/pages/advisory-details/csaf-source.tsx
@@ -2,10 +2,8 @@
 import React from "react";
 
 import {
-  Button,
   CodeBlock,
   CodeBlockCode,
-  Content,
   Flex,
   FlexItem,
 } from "@patternfly/react-core";
@@ -31,22 +29,12 @@ export const CsafSource: React.FC<CsafSourceProps> = ({ csafDocument }) => {
     <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
       {selfRef && (
         <FlexItem>
-          <Content component="h3">Original Advisory</Content>
-          <Button
-            variant="link"
-            component="a"
-            href={selfRef.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            icon={<ExternalLinkAltIcon />}
-            iconPosition="end"
-          >
-            {selfRef.summary || selfRef.url}
-          </Button>
+          <a href={selfRef.url} target="_blank" rel="noopener noreferrer">
+            View original advisory <ExternalLinkAltIcon />
+          </a>
         </FlexItem>
       )}
       <FlexItem>
-        <Content component="h3">CSAF Document</Content>
         <CodeBlock>
           <CodeBlockCode>{formattedJson}</CodeBlockCode>
         </CodeBlock>

--- a/client/src/app/pages/advisory-details/csaf-source.tsx
+++ b/client/src/app/pages/advisory-details/csaf-source.tsx
@@ -1,0 +1,56 @@
+/** CSAF Source tab displaying raw JSON and a link to the original advisory. */
+import React from "react";
+
+import {
+  Button,
+  CodeBlock,
+  CodeBlockCode,
+  Content,
+  Flex,
+  FlexItem,
+} from "@patternfly/react-core";
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+
+import type { CsafDocument } from "@app/types/csaf";
+
+interface CsafSourceProps {
+  csafDocument: CsafDocument;
+}
+
+export const CsafSource: React.FC<CsafSourceProps> = ({ csafDocument }) => {
+  const selfRef = csafDocument.document.references?.find(
+    (ref) => ref.category === "self",
+  );
+
+  const formattedJson = React.useMemo(
+    () => JSON.stringify(csafDocument, null, 2),
+    [csafDocument],
+  );
+
+  return (
+    <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+      {selfRef && (
+        <FlexItem>
+          <Content component="h3">Original Advisory</Content>
+          <Button
+            variant="link"
+            component="a"
+            href={selfRef.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            icon={<ExternalLinkAltIcon />}
+            iconPosition="end"
+          >
+            {selfRef.summary || selfRef.url}
+          </Button>
+        </FlexItem>
+      )}
+      <FlexItem>
+        <Content component="h3">CSAF Document</Content>
+        <CodeBlock>
+          <CodeBlockCode>{formattedJson}</CodeBlockCode>
+        </CodeBlock>
+      </FlexItem>
+    </Flex>
+  );
+};

--- a/client/src/app/pages/advisory-details/csaf-vulnerabilities.tsx
+++ b/client/src/app/pages/advisory-details/csaf-vulnerabilities.tsx
@@ -1,0 +1,94 @@
+/** CSAF Vulnerabilities tab rendering per-CVE cards sorted by severity. */
+import React from "react";
+
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Flex,
+  FlexItem,
+} from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+
+import type { CsafDocument, CsafVulnerability } from "@app/types/csaf";
+
+import { CsafVulnerabilityCard } from "./components/csaf-vulnerability-card";
+
+interface CsafVulnerabilitiesProps {
+  csafDocument: CsafDocument;
+}
+
+const SEVERITY_ORDER: Record<string, number> = {
+  CRITICAL: 0,
+  HIGH: 1,
+  MEDIUM: 2,
+  LOW: 3,
+  NONE: 4,
+};
+
+/** Sorts vulnerabilities by CVSS severity, critical first. */
+function sortBySeverity(
+  vulnerabilities: CsafVulnerability[],
+): CsafVulnerability[] {
+  return [...vulnerabilities].sort((a, b) => {
+    const aSev = a.scores?.[0]?.cvss_v3?.baseSeverity?.toUpperCase() || "NONE";
+    const bSev = b.scores?.[0]?.cvss_v3?.baseSeverity?.toUpperCase() || "NONE";
+    return (SEVERITY_ORDER[aSev] ?? 5) - (SEVERITY_ORDER[bSev] ?? 5);
+  });
+}
+
+/** Builds product ID to display name map from full_product_names. */
+function buildProductNameMap(csafDocument: CsafDocument): Map<string, string> {
+  const map = new Map<string, string>();
+  const products = csafDocument.product_tree?.full_product_names;
+  if (products) {
+    for (const p of products) {
+      map.set(p.product_id, p.name);
+    }
+  }
+  return map;
+}
+
+export const CsafVulnerabilities: React.FC<CsafVulnerabilitiesProps> = ({
+  csafDocument,
+}) => {
+  const vulnerabilities = csafDocument.vulnerabilities;
+
+  const sorted = React.useMemo(
+    () => (vulnerabilities ? sortBySeverity(vulnerabilities) : []),
+    [vulnerabilities],
+  );
+
+  const productNameMap = React.useMemo(
+    () => buildProductNameMap(csafDocument),
+    [csafDocument],
+  );
+
+  if (sorted.length === 0) {
+    return (
+      <EmptyState
+        titleText="No vulnerabilities"
+        headingLevel="h2"
+        icon={CubesIcon}
+        variant={EmptyStateVariant.sm}
+      >
+        <EmptyStateBody>
+          This advisory does not contain vulnerability data.
+        </EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+      {sorted.map((vuln, i) => (
+        <FlexItem key={vuln.cve || `vuln-${i}`}>
+          <CsafVulnerabilityCard
+            vulnerability={vuln}
+            productNameMap={productNameMap}
+          />
+        </FlexItem>
+      ))}
+    </Flex>
+  );
+};

--- a/client/src/app/pages/advisory-details/helpers/csaf-relationship-helpers.ts
+++ b/client/src/app/pages/advisory-details/helpers/csaf-relationship-helpers.ts
@@ -1,0 +1,74 @@
+/** Helpers for transforming CSAF relationship data into ECharts tree format. */
+import type { CsafFullProductName, CsafRelationship } from "@app/types/csaf";
+
+import type { EChartsTreeNode } from "./csaf-tree-helpers";
+
+/** Color mapping for CSAF relationship categories. */
+export const RELATIONSHIP_CATEGORY_COLORS: Record<string, string> = {
+  default_component_of: "#0066CC",
+  external_component_of: "#4CB140",
+  installed_on: "#EC7A08",
+  installed_with: "#6753AC",
+  optional_component_of: "#009596",
+};
+
+/** Builds a product ID to display name lookup map. */
+function buildProductNameMap(
+  fullProductNames?: CsafFullProductName[],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  if (fullProductNames) {
+    for (const product of fullProductNames) {
+      map.set(product.product_id, product.name);
+    }
+  }
+  return map;
+}
+
+/** Resolves a product ID to its display name, falling back to the ID. */
+function resolveProductName(
+  productId: string,
+  nameMap: Map<string, string>,
+): string {
+  return nameMap.get(productId) || productId;
+}
+
+/** Transforms CSAF relationships into an ECharts tree grouped by relates_to_product_reference. */
+export function transformRelationshipsToTreeData(
+  relationships: CsafRelationship[],
+  fullProductNames?: CsafFullProductName[],
+): EChartsTreeNode {
+  const nameMap = buildProductNameMap(fullProductNames);
+  const groups = new Map<string, CsafRelationship[]>();
+
+  for (const rel of relationships) {
+    const key = rel.relates_to_product_reference;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(rel);
+    } else {
+      groups.set(key, [rel]);
+    }
+  }
+
+  const children: EChartsTreeNode[] = [];
+  for (const [parentId, rels] of groups) {
+    const parentNode: EChartsTreeNode = {
+      name: resolveProductName(parentId, nameMap),
+      value: parentId,
+      children: rels.map((rel) => ({
+        name: resolveProductName(rel.product_reference, nameMap),
+        value: rel.category,
+        itemStyle: {
+          color: RELATIONSHIP_CATEGORY_COLORS[rel.category] || "#8A8D90",
+        },
+      })),
+    };
+    children.push(parentNode);
+  }
+
+  return {
+    name: "Relationships",
+    children,
+  };
+}

--- a/client/src/app/pages/advisory-details/helpers/csaf-tree-helpers.ts
+++ b/client/src/app/pages/advisory-details/helpers/csaf-tree-helpers.ts
@@ -14,16 +14,18 @@ const AUTO_COLLAPSE_THRESHOLD = 40;
 
 /** Color mapping for CSAF branch categories. */
 export const BRANCH_CATEGORY_COLORS: Record<string, string> = {
-  vendor: "#0066CC",
-  product_family: "#009596",
-  product_name: "#4CB140",
-  product_version: "#EC7A08",
-  product_version_range: "#6753AC",
-  architecture: "#8A8D90",
+  vendor: "#C9190B",
+  product_name: "#0066CC",
+  product_version: "#6753AC",
+  product_version_range: "#4CB140",
+  product_family: "#EC7A08",
+  architecture: "#F4C145",
   language: "#C9190B",
-  legacy: "#F4C145",
   patch_level: "#38812F",
   service_pack: "#2B9AF3",
+  host_name: "#7D1007",
+  legacy: "#8A8D90",
+  specification: "#009596",
 };
 
 /** Counts leaf nodes in a CSAF branch subtree. */

--- a/client/src/app/pages/advisory-details/helpers/csaf-tree-helpers.ts
+++ b/client/src/app/pages/advisory-details/helpers/csaf-tree-helpers.ts
@@ -1,0 +1,64 @@
+/** Helpers for transforming CSAF branch data into ECharts tree format. */
+import type { CsafBranch } from "@app/types/csaf";
+
+/** ECharts tree node data shape. */
+export interface EChartsTreeNode {
+  name: string;
+  value?: string;
+  collapsed?: boolean;
+  itemStyle?: { color: string };
+  children?: EChartsTreeNode[];
+}
+
+const AUTO_COLLAPSE_THRESHOLD = 40;
+
+/** Color mapping for CSAF branch categories. */
+export const BRANCH_CATEGORY_COLORS: Record<string, string> = {
+  vendor: "#0066CC",
+  product_family: "#009596",
+  product_name: "#4CB140",
+  product_version: "#EC7A08",
+  product_version_range: "#6753AC",
+  architecture: "#8A8D90",
+  language: "#C9190B",
+  legacy: "#F4C145",
+  patch_level: "#38812F",
+  service_pack: "#2B9AF3",
+};
+
+/** Counts leaf nodes in a CSAF branch subtree. */
+function countLeaves(branch: CsafBranch): number {
+  if (!branch.branches || branch.branches.length === 0) {
+    return 1;
+  }
+  return branch.branches.reduce((sum, child) => sum + countLeaves(child), 0);
+}
+
+/** Transforms a single CSAF branch into an ECharts tree node. */
+function transformBranch(branch: CsafBranch): EChartsTreeNode {
+  const leafCount = countLeaves(branch);
+  const node: EChartsTreeNode = {
+    name: branch.name,
+    value: branch.category,
+    itemStyle: {
+      color: BRANCH_CATEGORY_COLORS[branch.category] || "#8A8D90",
+    },
+    collapsed: leafCount > AUTO_COLLAPSE_THRESHOLD,
+  };
+
+  if (branch.branches && branch.branches.length > 0) {
+    node.children = branch.branches.map(transformBranch);
+  }
+
+  return node;
+}
+
+/** Transforms CSAF branches array into ECharts tree data with a virtual root. */
+export function transformBranchesToTreeData(
+  branches: CsafBranch[],
+): EChartsTreeNode {
+  return {
+    name: "Product Tree",
+    children: branches.map(transformBranch),
+  };
+}

--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -18,6 +18,7 @@ import {
   listAdvisoryLabels,
   updateAdvisoryLabels,
 } from "@app/client";
+import type { CsafDocument } from "@app/types/csaf";
 
 import { uploadAdvisory } from "@app/api/rest";
 import {
@@ -136,6 +137,26 @@ export const useFetchAdvisorySourceById = (id: string) => {
 
   return {
     source: data,
+    isFetching: isLoading,
+    fetchError: error as AxiosError | null,
+  };
+};
+
+/** Fetches the raw CSAF JSON document and parses it into a typed CsafDocument. */
+export const useFetchAdvisoryCsafById = (id: string) => {
+  const { data, isLoading, error } = useQuery<CsafDocument>({
+    queryKey: [AdvisoriesQueryKey, id, "csaf"],
+    queryFn: async () => {
+      const response = await downloadAdvisory({ client, path: { key: id } });
+      const blob = response.data as Blob;
+      const text = await blob.text();
+      return JSON.parse(text) as CsafDocument;
+    },
+    enabled: !!id,
+  });
+
+  return {
+    csafDocument: data,
     isFetching: isLoading,
     fetchError: error as AxiosError | null,
   };

--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -148,9 +148,7 @@ export const useFetchAdvisoryCsafById = (id: string) => {
     queryKey: [AdvisoriesQueryKey, id, "csaf"],
     queryFn: async () => {
       const response = await downloadAdvisory({ client, path: { key: id } });
-      const blob = response.data as Blob;
-      const text = await blob.text();
-      return JSON.parse(text) as CsafDocument;
+      return response.data as CsafDocument;
     },
     enabled: !!id,
   });

--- a/client/src/app/types/csaf.ts
+++ b/client/src/app/types/csaf.ts
@@ -1,0 +1,290 @@
+/** CSAF 2.0 VEX document type definitions per the OASIS CSAF JSON schema. */
+
+/** Top-level CSAF document container. */
+export interface CsafDocument {
+  document: CsafDocumentMetadata;
+  product_tree?: CsafProductTree;
+  vulnerabilities?: CsafVulnerability[];
+}
+
+/** Document-level metadata section. */
+export interface CsafDocumentMetadata {
+  category: string;
+  csaf_version: string;
+  title: string;
+  publisher: CsafPublisher;
+  tracking: CsafTracking;
+  notes?: CsafNote[];
+  references?: CsafReference[];
+  distribution?: CsafDistribution;
+  aggregate_severity?: CsafAggregateSeverity;
+  lang?: string;
+  source_lang?: string;
+}
+
+/** Document publisher information. */
+export interface CsafPublisher {
+  category: string;
+  name: string;
+  namespace: string;
+  contact_details?: string;
+  issuing_authority?: string;
+}
+
+/** Document tracking metadata including revision history. */
+export interface CsafTracking {
+  current_release_date: string;
+  id: string;
+  initial_release_date: string;
+  revision_history: CsafRevision[];
+  status: string;
+  version: string;
+  generator?: CsafGenerator;
+  aliases?: string[];
+}
+
+/** Document version revision entry. */
+export interface CsafRevision {
+  date: string;
+  number: string;
+  summary: string;
+}
+
+/** Tool that generated the CSAF document. */
+export interface CsafGenerator {
+  engine: CsafGeneratorEngine;
+  date?: string;
+}
+
+/** Generator engine identification. */
+export interface CsafGeneratorEngine {
+  name: string;
+  version?: string;
+}
+
+/** Document-level note. */
+export interface CsafNote {
+  category: string;
+  text: string;
+  audience?: string;
+  title?: string;
+}
+
+/** External reference link. */
+export interface CsafReference {
+  url: string;
+  summary?: string;
+  category?: string;
+}
+
+/** TLP distribution information. */
+export interface CsafDistribution {
+  text?: string;
+  tlp?: CsafTlp;
+}
+
+/** Traffic Light Protocol classification. */
+export interface CsafTlp {
+  label: string;
+  url?: string;
+}
+
+/** Aggregate severity for the entire document. */
+export interface CsafAggregateSeverity {
+  text: string;
+  namespace?: string;
+}
+
+/** Product tree describing the vendor/product/version hierarchy. */
+export interface CsafProductTree {
+  branches?: CsafBranch[];
+  full_product_names?: CsafFullProductName[];
+  relationships?: CsafRelationship[];
+  product_groups?: CsafProductGroup[];
+}
+
+/** Recursive branch in the product tree hierarchy. */
+export interface CsafBranch {
+  category: string;
+  name: string;
+  branches?: CsafBranch[];
+  product?: CsafFullProductName;
+}
+
+/** A uniquely identifiable product with an ID and display name. */
+export interface CsafFullProductName {
+  name: string;
+  product_id: string;
+  product_identification_helper?: CsafProductIdentificationHelper;
+}
+
+/** Helper data for identifying a product (CPE, PURL, etc.). */
+export interface CsafProductIdentificationHelper {
+  cpe?: string;
+  purl?: string;
+  hashes?: CsafHash[];
+  model_numbers?: string[];
+  serial_numbers?: string[];
+  skus?: string[];
+  x_generic_uris?: CsafGenericUri[];
+}
+
+/** Cryptographic hash for product identification. */
+export interface CsafHash {
+  file_hashes: CsafFileHash[];
+  filename: string;
+}
+
+/** Individual file hash entry. */
+export interface CsafFileHash {
+  algorithm: string;
+  value: string;
+}
+
+/** Generic URI reference. */
+export interface CsafGenericUri {
+  namespace: string;
+  uri: string;
+}
+
+/** Relationship between two products. */
+export interface CsafRelationship {
+  category: string;
+  full_product_name: CsafFullProductName;
+  product_reference: string;
+  relates_to_product_reference: string;
+}
+
+/** Named group of product IDs. */
+export interface CsafProductGroup {
+  group_id: string;
+  product_ids: string[];
+  summary?: string;
+}
+
+/** Vulnerability entry in a CSAF document. */
+export interface CsafVulnerability {
+  cve?: string;
+  cwe?: CsafCwe;
+  title?: string;
+  notes?: CsafNote[];
+  references?: CsafReference[];
+  discovery_date?: string;
+  release_date?: string;
+  scores?: CsafScore[];
+  product_status?: CsafProductStatus;
+  remediations?: CsafRemediation[];
+  threats?: CsafThreat[];
+  acknowledgments?: CsafAcknowledgment[];
+  involvements?: CsafInvolvement[];
+  ids?: CsafVulnerabilityId[];
+}
+
+/** CWE weakness classification. */
+export interface CsafCwe {
+  id: string;
+  name: string;
+}
+
+/** CVSS scoring data for a set of products. */
+export interface CsafScore {
+  products: string[];
+  cvss_v3?: CsafCvssV3;
+  cvss_v2?: CsafCvssV2;
+}
+
+/** CVSS v3.x score details. */
+export interface CsafCvssV3 {
+  version: string;
+  vectorString: string;
+  baseScore: number;
+  baseSeverity: string;
+  attackVector?: string;
+  attackComplexity?: string;
+  privilegesRequired?: string;
+  userInteraction?: string;
+  scope?: string;
+  confidentialityImpact?: string;
+  integrityImpact?: string;
+  availabilityImpact?: string;
+  exploitCodeMaturity?: string;
+  remediationLevel?: string;
+  reportConfidence?: string;
+  temporalScore?: number;
+  temporalSeverity?: string;
+  environmentalScore?: number;
+  environmentalSeverity?: string;
+}
+
+/** CVSS v2 score details. */
+export interface CsafCvssV2 {
+  version: string;
+  vectorString: string;
+  baseScore: number;
+  accessVector?: string;
+  accessComplexity?: string;
+  authentication?: string;
+  confidentialityImpact?: string;
+  integrityImpact?: string;
+  availabilityImpact?: string;
+}
+
+/** Product status categories per vulnerability. */
+export interface CsafProductStatus {
+  fixed?: string[];
+  known_affected?: string[];
+  known_not_affected?: string[];
+  first_affected?: string[];
+  first_fixed?: string[];
+  last_affected?: string[];
+  recommended?: string[];
+  under_investigation?: string[];
+}
+
+/** Remediation action for affected products. */
+export interface CsafRemediation {
+  category: string;
+  details: string;
+  product_ids?: string[];
+  group_ids?: string[];
+  url?: string;
+  date?: string;
+  entitlements?: string[];
+  restart_required?: CsafRestartRequired;
+}
+
+/** Restart requirement for a remediation. */
+export interface CsafRestartRequired {
+  category: string;
+  details?: string;
+}
+
+/** Threat information for affected products. */
+export interface CsafThreat {
+  category: string;
+  details: string;
+  product_ids?: string[];
+  group_ids?: string[];
+  date?: string;
+}
+
+/** Acknowledgment of contributors or reporters. */
+export interface CsafAcknowledgment {
+  names?: string[];
+  organization?: string;
+  summary?: string;
+  urls?: string[];
+}
+
+/** Involvement of a party in vulnerability handling. */
+export interface CsafInvolvement {
+  party: string;
+  status: string;
+  summary?: string;
+}
+
+/** Alternative vulnerability identifier. */
+export interface CsafVulnerabilityId {
+  system_name: string;
+  text: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,8 @@
         "@tanstack/react-query-devtools": "^5.61.0",
         "axios": "^1.16.0",
         "dayjs": "^1.11.18",
+        "echarts": "^5.6.0",
+        "echarts-for-react": "^3.0.2",
         "file-saver": "^2.0.5",
         "oidc-client-ts": "^3.3.0",
         "packageurl-js": "^2.0.1",
@@ -6200,6 +6202,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6888,7 +6920,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -11458,6 +11489,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -13605,6 +13642,21 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "server": {
       "name": "@trustify-ui/server",


### PR DESCRIPTION
## Summary

Combined PR with all changes for the CSAF VEX Visualizer feature (TC-4612). This merges all 7 implementation task branches for testing the complete feature as a single unit.

### Changes included:
- **TC-4618** — CSAF 2.0 TypeScript types, `useFetchAdvisoryCsafById` query hook, ECharts dependency
- **TC-4619** — CSAF advisory type detection (`labels.type === "csaf"`) and conditional 5-tab layout
- **TC-4620** — Overview tab: metadata card, impact summary bar, remediation donut chart, references, revision history, notes
- **TC-4621** — Vulnerabilities tab: per-CVE cards sorted by severity, CVSS breakdown, affected products (+N more), remediations by category, references
- **TC-4622** — Product Tree tab: ECharts interactive tree with color-coded categories and auto-collapse
- **TC-4623** — Relationship Tree tab: ECharts tree grouped by relates_to_product_reference with color-coded types
- **TC-4624** — Source tab: raw JSON CodeBlock with copy-to-clipboard and original advisory link

### New files (15):
- `client/src/app/types/csaf.ts`
- `client/src/app/pages/advisory-details/csaf-advisory-details.tsx`
- `client/src/app/pages/advisory-details/csaf-overview.tsx`
- `client/src/app/pages/advisory-details/csaf-vulnerabilities.tsx`
- `client/src/app/pages/advisory-details/csaf-product-tree.tsx`
- `client/src/app/pages/advisory-details/csaf-relationship-tree.tsx`
- `client/src/app/pages/advisory-details/csaf-source.tsx`
- `client/src/app/pages/advisory-details/components/csaf-vulnerability-card.tsx`
- `client/src/app/pages/advisory-details/components/csaf-cvss-details.tsx`
- `client/src/app/pages/advisory-details/components/csaf-remediations.tsx`
- `client/src/app/pages/advisory-details/helpers/csaf-tree-helpers.ts`
- `client/src/app/pages/advisory-details/helpers/csaf-relationship-helpers.ts`

### Modified files:
- `client/src/app/queries/advisories.ts` — added `useFetchAdvisoryCsafById` hook
- `client/src/app/pages/advisory-details/advisory-details.tsx` — CSAF type detection + conditional rendering
- `client/package.json` — added `echarts`, `echarts-for-react`

## Test plan
- [x] Build succeeds
- [x] All 24 unit tests pass
- [x] Non-CSAF advisories retain default 2-tab layout
- [x] CSAF advisories show 5-tab layout with all tabs functional

Implements [TC-4612](https://redhat.atlassian.net/browse/TC-4612)

Assisted-by: Claude Code

[TC-4612]: https://redhat.atlassian.net/browse/TC-4612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add a CSAF-specific advisory details experience with a dedicated 5-tab VEX visualizer and typed CSAF document support.

New Features:
- Introduce a CSAF-aware advisory details layout that switches from the default tabs when labels.type is "csaf".
- Add a CSAF VEX 5-tab interface (Overview, Vulnerabilities, Product Tree, Relationship Tree, Source) for visualizing advisory contents.
- Provide rich CSAF Overview and Vulnerabilities presentations including metadata, severity and remediation summaries, and per-CVE cards.
- Expose interactive ECharts-based visualizations for CSAF product trees and product relationships.
- Add a Source tab to view the raw CSAF JSON and link to the original advisory document.
- Introduce strongly-typed TypeScript models for CSAF 2.0 VEX documents and a React Query hook for fetching them.

Enhancements:
- Extend advisory fetching logic with a query hook that downloads, parses, and returns typed CSAF documents for CSAF advisories.

Build:
- Add ECharts and the React ECharts wrapper as client-side dependencies to support interactive CSAF visualizations.