### PR TITLE
fix: dependabot commit and tooling aligment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,14 @@ updates:
     schedule:
       interval: "monthly"
     commit-message:
-      prefix: ":ghost: "
+      prefix: "ci: "
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
     commit-message:
-      prefix: ":ghost: "
+      prefix: "chore(deps): "
 
     allow:
       - dependency-type: direct
@@ -40,11 +40,19 @@ updates:
           - "rollup"
           - "rollup-*"
 
-      linting:
+      linting-formatting:
         patterns:
-          - "@biomejs/*"
+          - "eslint"
+          - "eslint-*"
+          - "@eslint-*"
+          - "@eslint/*"
+          - "*-eslint"
+          - "prettier"
 
       tools:
         patterns:
-          - "@rsbuild/*"
+          - "vite"
+          - "vite-*"
+          - "vitest"
+          - "@vitest/*"
           - "@hey-api/*"


### PR DESCRIPTION
## Summary
- Change dependabot title configuration to be aligned to the new commit message standards
- Remove biome and old references to libraries and align them to the new tooling

## Summary by Sourcery

Align Dependabot configuration with new commit message conventions and updated tooling classifications.

Build:
- Update Dependabot commit message prefixes for GitHub Actions and npm updates to match new conventions.
- Retarget Dependabot linting and tooling dependency patterns from Biome and rsbuild to ESLint/Prettier and Vite/Vitest ecosystems.