### PR TITLE
fix: auto-merge only for main branch

### DIFF
--- a/.github/workflows/auto-merge-bots.yaml
+++ b/.github/workflows/auto-merge-bots.yaml
@@ -6,6 +6,7 @@ on:
   # pull_request_target always fires and runs in the base branch context.
   pull_request_target:
     types: [ opened, synchronize ]
+    branches: [ main ]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Enable auto merge of PRs only when PRs are done against the main branch

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] Other (describe below)

## Testing
- [ ] All tests pass (`npm test`)
- [ ] No lint errors (`npm run check`)
- [ ] No type errors (TypeScript compiles cleanly)
- [ ] New/changed UI behavior visually verified in browser
- [ ] Mock data updated if API types changed

## Summary by Sourcery

CI:
- Limit the auto-merge-bots GitHub Actions workflow to pull_request_target events against the main branch only.