### PR TITLE
fix: enhancements to our ai docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 
 ## Testing
 - [ ] All tests pass (`npm test`)
-- [ ] No lint errors (`npm run check`)
+- [ ] No lint errors (`npm run lint`)
 - [ ] No type errors (TypeScript compiles cleanly)
 - [ ] New/changed UI behavior visually verified in browser
 - [ ] Mock data updated if API types changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Four npm workspaces:
   - Exports `TrustificationEnvType`, `encodeEnv`, `decodeEnv`, branding assets
   - Built with Rollup to both ESM (.mjs) and CommonJS (.cjs)
 - **`client/`** — React SPA
-  - Tech: React 19, TypeScript, Rsbuild (Rspack), PatternFly 6
+  - Tech: ReactJS, TypeScript, Vite, PatternFly
   - Dev server: port 3000 with proxy to backend
   - Key paths (with `@app` alias mapping to `client/src/app/`):
     - `@app/Routes.tsx` — route definitions with lazy() imports


### PR DESCRIPTION
## Summary
- Minor alignments about right usage of commands
- Remove tool Versioning. E.g. instead of `ReactJS 19` just `React`. I believe the tooling versions will be discovered by the code agent and the code itself. But open to suggestions

## Summary by Sourcery

Update project documentation and PR template to reflect current tooling and lint command.

Bug Fixes:
- Correct the referenced lint command in the PR checklist to use the current npm script.

Documentation:
- Refresh AGENTS.md client tech stack description to remove specific React versioning and align with current build tooling.