### PR TITLE
fix: static branding copy

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -50,9 +50,9 @@ export default defineConfig({
     },
     viteStaticCopy({
       targets: [
-        { src: manifestPath, dest: "." },
-        { src: faviconPath, dest: "." },
-        { src: brandingPath, dest: "." },
+        { src: manifestPath, dest: ".", rename: { stripBase: true } },
+        { src: faviconPath, dest: ".", rename: { stripBase: true } },
+        { src: brandingPath, dest: ".", rename: { stripBase: 2 } },
       ],
     }),
     ...(process.env.NODE_ENV === "production"

--- a/e2e/tests/ui/pages/branding/branding.spec.ts
+++ b/e2e/tests/ui/pages/branding/branding.spec.ts
@@ -1,0 +1,23 @@
+// @ts-check
+
+import { expect } from "../../assertions";
+import { test } from "../../fixtures";
+import { login } from "../../helpers/Auth";
+
+test.describe("Branding", () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test("should render the brand image in the masthead", async ({ page }) => {
+    await page.goto("/");
+
+    const brandImg = page.getByRole("img", { name: "brand" });
+    await expect(brandImg).toBeVisible();
+
+    const naturalWidth = await brandImg.evaluate(
+      (img: HTMLImageElement) => img.naturalWidth,
+    );
+    expect(naturalWidth).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- A recent major upgrade of `vite-plugin-static-copy` resulted in the branded images not being rendered in the browser (See screenshot attached to this PR).
  - The upgraded version contained breaking changes
- This PR is aligning the latest version of `vite-plugin-static-copy` to its upgraded configuration settings

As a final result the brand images should be visible again.

## Screenshots

The following image is what we currently see in the main branch

<img width="2523" height="749" alt="Screenshot From 2026-06-01 17-57-13" src="https://github.com/user-attachments/assets/674f2f05-ac98-4760-8088-9cb64aabd097" />


