### PR TITLE
feat(csaf): add CSAF tab container with type detection, source query hook, and Source tab

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,8 @@
     "@tanstack/react-query-devtools": "^5.61.0",
     "axios": "^1.16.0",
     "dayjs": "^1.11.18",
+    "echarts": "^6.1.0",
+    "echarts-for-react": "^3.0.6",
     "file-saver": "^2.0.5",
     "oidc-client-ts": "^3.3.0",
     "packageurl-js": "^2.0.1",

--- a/client/src/app/pages/advisory-details/advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/advisory-details.tsx
@@ -43,9 +43,11 @@ import {
   useFetchAdvisoryById,
 } from "@app/queries/advisories";
 
+import { DocumentMetadata } from "@app/components/DocumentMetadata";
+
+import { CsafAdvisoryTabs } from "./csaf-advisory-tabs";
 import { Overview } from "./overview";
 import { VulnerabilitiesByAdvisory } from "./vulnerabilities-by-advisory";
-import { DocumentMetadata } from "@app/components/DocumentMetadata";
 
 export const AdvisoryDetails: React.FC = () => {
   const navigate = useNavigate();
@@ -177,47 +179,53 @@ export const AdvisoryDetails: React.FC = () => {
           </SplitItem>
         </Split>
       </PageSection>
-      <PageSection>
-        <Tabs
-          mountOnEnter
-          {...getTabsProps()}
-          aria-label="Tabs that contain the Advisory information"
-          role="region"
-        >
-          <Tab
-            {...getTabProps("info")}
-            title={<TabTitleText>Info</TabTitleText>}
-            tabContentRef={infoTabRef}
-          />
-          <Tab
-            {...getTabProps("vulnerabilities")}
-            title={<TabTitleText>Vulnerabilities</TabTitleText>}
-            tabContentRef={vulnerabilitiesTabRef}
-          />
-        </Tabs>
-      </PageSection>
-      <PageSection>
-        <TabContent
-          {...getTabContentProps("info")}
-          ref={infoTabRef}
-          aria-label="Information of the Advisory"
-        >
-          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
-            {advisory && <Overview advisory={advisory} />}
-          </LoadingWrapper>
-        </TabContent>
-        <TabContent
-          {...getTabContentProps("vulnerabilities")}
-          ref={vulnerabilitiesTabRef}
-          aria-label="Vulnerabilities within the Advisory"
-        >
-          <VulnerabilitiesByAdvisory
-            isFetching={isFetching}
-            fetchError={fetchError}
-            vulnerabilities={advisory?.vulnerabilities || []}
-          />
-        </TabContent>
-      </PageSection>
+      {advisory?.labels.type === "csaf" ? (
+        <CsafAdvisoryTabs advisoryId={advisoryId} />
+      ) : (
+        <>
+          <PageSection>
+            <Tabs
+              mountOnEnter
+              {...getTabsProps()}
+              aria-label="Tabs that contain the Advisory information"
+              role="region"
+            >
+              <Tab
+                {...getTabProps("info")}
+                title={<TabTitleText>Info</TabTitleText>}
+                tabContentRef={infoTabRef}
+              />
+              <Tab
+                {...getTabProps("vulnerabilities")}
+                title={<TabTitleText>Vulnerabilities</TabTitleText>}
+                tabContentRef={vulnerabilitiesTabRef}
+              />
+            </Tabs>
+          </PageSection>
+          <PageSection>
+            <TabContent
+              {...getTabContentProps("info")}
+              ref={infoTabRef}
+              aria-label="Information of the Advisory"
+            >
+              <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+                {advisory && <Overview advisory={advisory} />}
+              </LoadingWrapper>
+            </TabContent>
+            <TabContent
+              {...getTabContentProps("vulnerabilities")}
+              ref={vulnerabilitiesTabRef}
+              aria-label="Vulnerabilities within the Advisory"
+            >
+              <VulnerabilitiesByAdvisory
+                isFetching={isFetching}
+                fetchError={fetchError}
+                vulnerabilities={advisory?.vulnerabilities || []}
+              />
+            </TabContent>
+          </PageSection>
+        </>
+      )}
 
       <ConfirmDialog
         {...advisoryDeleteDialogProps(advisory)}

--- a/client/src/app/pages/advisory-details/csaf-advisory-tabs.tsx
+++ b/client/src/app/pages/advisory-details/csaf-advisory-tabs.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+
+import {
+  PageSection,
+  Tab,
+  TabContent,
+  Tabs,
+  TabTitleText,
+} from "@patternfly/react-core";
+
+import { LoadingWrapper } from "@app/components/LoadingWrapper";
+import { useTabControls } from "@app/hooks/tab-controls";
+import { DocumentOverview } from "@app/pages/csaf-visualizer/components/DocumentOverview";
+import { ProductsTable } from "@app/pages/csaf-visualizer/components/ProductsTable";
+import { RelationshipTree } from "@app/pages/csaf-visualizer/components/RelationshipTree";
+import { SourceView } from "@app/pages/csaf-visualizer/components/SourceView";
+import { VulnerabilitySection } from "@app/pages/csaf-visualizer/components/VulnerabilitySection";
+import { useFetchCsafSource } from "@app/queries/advisories";
+
+interface CsafAdvisoryTabsProps {
+  advisoryId: string;
+}
+
+/** CSAF-specific tab container replacing standard advisory tabs. */
+export const CsafAdvisoryTabs: React.FC<CsafAdvisoryTabsProps> = ({
+  advisoryId,
+}) => {
+  const { csafDocument, isFetching, fetchError } =
+    useFetchCsafSource(advisoryId);
+
+  const {
+    propHelpers: { getTabsProps, getTabProps, getTabContentProps },
+  } = useTabControls({
+    persistenceKeyPrefix: "ad",
+    persistTo: "urlParams",
+    tabKeys: [
+      "overview",
+      "vulnerabilities",
+      "product-tree",
+      "relationship-tree",
+      "source",
+    ],
+  });
+
+  const overviewTabRef = React.useRef<HTMLElement>();
+  const vulnerabilitiesTabRef = React.useRef<HTMLElement>();
+  const productTreeTabRef = React.useRef<HTMLElement>();
+  const relationshipTreeTabRef = React.useRef<HTMLElement>();
+  const sourceTabRef = React.useRef<HTMLElement>();
+
+  return (
+    <>
+      <PageSection>
+        <Tabs
+          mountOnEnter
+          {...getTabsProps()}
+          aria-label="Tabs that contain the CSAF advisory information"
+          role="region"
+        >
+          <Tab
+            {...getTabProps("overview")}
+            title={<TabTitleText>Overview</TabTitleText>}
+            tabContentRef={overviewTabRef}
+          />
+          <Tab
+            {...getTabProps("vulnerabilities")}
+            title={<TabTitleText>Vulnerabilities</TabTitleText>}
+            tabContentRef={vulnerabilitiesTabRef}
+          />
+          <Tab
+            {...getTabProps("product-tree")}
+            title={<TabTitleText>Product Tree</TabTitleText>}
+            tabContentRef={productTreeTabRef}
+          />
+          <Tab
+            {...getTabProps("relationship-tree")}
+            title={<TabTitleText>Relationship Tree</TabTitleText>}
+            tabContentRef={relationshipTreeTabRef}
+          />
+          <Tab
+            {...getTabProps("source")}
+            title={<TabTitleText>Source</TabTitleText>}
+            tabContentRef={sourceTabRef}
+          />
+        </Tabs>
+      </PageSection>
+      <PageSection>
+        <TabContent
+          {...getTabContentProps("overview")}
+          ref={overviewTabRef}
+          aria-label="CSAF advisory overview"
+        >
+          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+            {csafDocument && <DocumentOverview csafDocument={csafDocument} />}
+          </LoadingWrapper>
+        </TabContent>
+        <TabContent
+          {...getTabContentProps("vulnerabilities")}
+          ref={vulnerabilitiesTabRef}
+          aria-label="CSAF advisory vulnerabilities"
+        >
+          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+            {csafDocument && (
+              <VulnerabilitySection csafDocument={csafDocument} />
+            )}
+          </LoadingWrapper>
+        </TabContent>
+        <TabContent
+          {...getTabContentProps("product-tree")}
+          ref={productTreeTabRef}
+          aria-label="CSAF advisory product tree"
+        >
+          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+            {csafDocument && <ProductsTable csafDocument={csafDocument} />}
+          </LoadingWrapper>
+        </TabContent>
+        <TabContent
+          {...getTabContentProps("relationship-tree")}
+          ref={relationshipTreeTabRef}
+          aria-label="CSAF advisory relationship tree"
+        >
+          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+            {csafDocument && <RelationshipTree csafDocument={csafDocument} />}
+          </LoadingWrapper>
+        </TabContent>
+        <TabContent
+          {...getTabContentProps("source")}
+          ref={sourceTabRef}
+          aria-label="CSAF advisory source"
+        >
+          <LoadingWrapper isFetching={isFetching} fetchError={fetchError}>
+            {csafDocument && <SourceView csafDocument={csafDocument} />}
+          </LoadingWrapper>
+        </TabContent>
+      </PageSection>
+    </>
+  );
+};

--- a/client/src/app/pages/csaf-visualizer/components/DocumentOverview.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/DocumentOverview.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import type { CsafDocument } from "@app/pages/csaf-visualizer";
+
+interface DocumentOverviewProps {
+  csafDocument: CsafDocument;
+}
+
+/** Placeholder stub — replaced by full implementation in a later task. */
+export const DocumentOverview: React.FC<DocumentOverviewProps> = () => {
+  return <></>;
+};

--- a/client/src/app/pages/csaf-visualizer/components/ProductsTable.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/ProductsTable.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import type { CsafDocument } from "@app/pages/csaf-visualizer";
+
+interface ProductsTableProps {
+  csafDocument: CsafDocument;
+}
+
+/** Placeholder stub — replaced by full implementation in a later task. */
+export const ProductsTable: React.FC<ProductsTableProps> = () => {
+  return <></>;
+};

--- a/client/src/app/pages/csaf-visualizer/components/RelationshipTree.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/RelationshipTree.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import type { CsafDocument } from "@app/pages/csaf-visualizer";
+
+interface RelationshipTreeProps {
+  csafDocument: CsafDocument;
+}
+
+/** Placeholder stub — replaced by full implementation in a later task. */
+export const RelationshipTree: React.FC<RelationshipTreeProps> = () => {
+  return <></>;
+};

--- a/client/src/app/pages/csaf-visualizer/components/SourceView.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/SourceView.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+
+import {
+  Button,
+  CodeBlock,
+  CodeBlockCode,
+  Content,
+  Flex,
+  FlexItem,
+  Icon,
+} from "@patternfly/react-core";
+import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
+
+import type { CsafDocument } from "@app/pages/csaf-visualizer";
+
+interface SourceViewProps {
+  csafDocument: CsafDocument;
+}
+
+/** Displays raw CSAF JSON with an optional link to the original advisory. */
+export const SourceView: React.FC<SourceViewProps> = ({ csafDocument }) => {
+  const selfRef = csafDocument.document.references?.find(
+    (ref) => ref.category === "self",
+  );
+
+  return (
+    <Flex direction={{ default: "column" }} gap={{ default: "gapMd" }}>
+      {selfRef && (
+        <FlexItem>
+          <Content>
+            <Content component="p">
+              <Button
+                variant="link"
+                isInline
+                component="a"
+                href={selfRef.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                icon={
+                  <Icon isInline>
+                    <ExternalLinkAltIcon />
+                  </Icon>
+                }
+                iconPosition="end"
+              >
+                Original advisory
+              </Button>
+            </Content>
+          </Content>
+        </FlexItem>
+      )}
+      <FlexItem>
+        <CodeBlock>
+          <CodeBlockCode>{JSON.stringify(csafDocument, null, 2)}</CodeBlockCode>
+        </CodeBlock>
+      </FlexItem>
+    </Flex>
+  );
+};

--- a/client/src/app/pages/csaf-visualizer/components/VulnerabilitySection.tsx
+++ b/client/src/app/pages/csaf-visualizer/components/VulnerabilitySection.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import type { CsafDocument } from "@app/pages/csaf-visualizer";
+
+interface VulnerabilitySectionProps {
+  csafDocument: CsafDocument;
+}
+
+/** Placeholder stub — replaced by full implementation in a later task. */
+export const VulnerabilitySection: React.FC<VulnerabilitySectionProps> = () => {
+  return <></>;
+};

--- a/client/src/app/pages/csaf-visualizer/index.ts
+++ b/client/src/app/pages/csaf-visualizer/index.ts
@@ -1,0 +1,25 @@
+export type {
+  Branch,
+  CsafDocument,
+  CsafDocumentMetadata,
+  CsafNote,
+  CsafPublisher,
+  CsafReference,
+  CsafRevision,
+  CsafTracking,
+  CvssV3,
+  Product,
+  ProductStatus,
+  ProductTree,
+  Relationship,
+  Remediation,
+  Score,
+  Threat,
+  Vulnerability,
+} from "./types";
+
+export {
+  collectAllProducts,
+  collectProducts,
+  collectRelationshipProducts,
+} from "./utils";

--- a/client/src/app/pages/csaf-visualizer/types.ts
+++ b/client/src/app/pages/csaf-visualizer/types.ts
@@ -1,0 +1,165 @@
+/** Top-level CSAF 2.0 document structure. */
+export interface CsafDocument {
+  document: CsafDocumentMetadata;
+  product_tree: ProductTree;
+  vulnerabilities: Vulnerability[];
+}
+
+/** Document-level metadata section of a CSAF document. */
+export interface CsafDocumentMetadata {
+  aggregate_severity?: { namespace: string; text: string };
+  category: string;
+  csaf_version: string;
+  distribution?: {
+    text: string;
+    tlp?: { label: string; url: string };
+  };
+  lang?: string;
+  notes?: CsafNote[];
+  publisher: CsafPublisher;
+  references?: CsafReference[];
+  title: string;
+  tracking: CsafTracking;
+}
+
+/** Publisher information from a CSAF document. */
+export interface CsafPublisher {
+  category: string;
+  contact_details?: string;
+  issuing_authority?: string;
+  name: string;
+  namespace: string;
+}
+
+/** Document tracking metadata. */
+export interface CsafTracking {
+  current_release_date: string;
+  generator?: {
+    date: string;
+    engine: { name: string; version: string };
+  };
+  id: string;
+  initial_release_date: string;
+  revision_history: CsafRevision[];
+  status: string;
+  version: string;
+}
+
+/** A single revision entry in the document tracking history. */
+export interface CsafRevision {
+  date: string;
+  number: string;
+  summary: string;
+}
+
+/** A document-level or vulnerability-level note. */
+export interface CsafNote {
+  category: string;
+  text: string;
+  title: string;
+}
+
+/** An external reference link. */
+export interface CsafReference {
+  category: string;
+  summary: string;
+  url: string;
+}
+
+/** Product tree containing branch hierarchy and relationships. */
+export interface ProductTree {
+  branches: Branch[];
+  relationships?: Relationship[];
+}
+
+/** A recursive branch in the product tree hierarchy. */
+export interface Branch {
+  category: string;
+  name: string;
+  branches?: Branch[];
+  product?: Product;
+}
+
+/** A leaf product in the product tree. */
+export interface Product {
+  name: string;
+  product_id: string;
+  product_identification_helper?: {
+    cpe?: string;
+    purl?: string;
+  };
+}
+
+/** A relationship between products in the product tree. */
+export interface Relationship {
+  category: string;
+  full_product_name: {
+    name: string;
+    product_id: string;
+  };
+  product_reference: string;
+  relates_to_product_reference: string;
+}
+
+/** A vulnerability entry in the CSAF document. */
+export interface Vulnerability {
+  cve: string;
+  cwe?: { id: string; name: string };
+  discovery_date?: string;
+  ids?: { system_name: string; text: string }[];
+  notes?: CsafNote[];
+  product_status?: ProductStatus;
+  references?: CsafReference[];
+  release_date?: string;
+  remediations?: Remediation[];
+  scores?: Score[];
+  threats?: Threat[];
+  title: string;
+}
+
+/** Product status groupings for a vulnerability. */
+export interface ProductStatus {
+  fixed?: string[];
+  known_affected?: string[];
+  known_not_affected?: string[];
+  under_investigation?: string[];
+}
+
+/** A remediation action for a vulnerability. */
+export interface Remediation {
+  category: string;
+  date?: string;
+  details: string;
+  group_ids?: string[];
+  product_ids?: string[];
+  url?: string;
+}
+
+/** A CVSS score entry for a vulnerability. */
+export interface Score {
+  cvss_v3: CvssV3;
+  products: string[];
+}
+
+/** CVSS v3 scoring details. */
+export interface CvssV3 {
+  attackComplexity: string;
+  attackVector: string;
+  availabilityImpact: string;
+  baseScore: number;
+  baseSeverity: string;
+  confidentialityImpact: string;
+  integrityImpact: string;
+  privilegesRequired: string;
+  scope: string;
+  userInteraction: string;
+  vectorString: string;
+  version: string;
+}
+
+/** A threat statement associated with a vulnerability. */
+export interface Threat {
+  category: string;
+  details: string;
+  product_ids: string[];
+}

--- a/client/src/app/pages/csaf-visualizer/utils.test.ts
+++ b/client/src/app/pages/csaf-visualizer/utils.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import type { Branch, Relationship } from "./types";
+import { collectProducts, collectRelationshipProducts } from "./utils";
+
+describe("collectProducts", () => {
+  /** Verifies that a nested branch tree (3+ levels) is flattened into a product map. */
+  it("should flatten a nested branch tree into a product map", () => {
+    // Given a 3-level branch tree with products at leaf nodes
+    const branches: Branch[] = [
+      {
+        category: "vendor",
+        name: "Red Hat",
+        branches: [
+          {
+            category: "product_family",
+            name: "Enterprise Linux",
+            branches: [
+              {
+                category: "product_version",
+                name: "RHEL 8",
+                product: {
+                  name: "Red Hat Enterprise Linux 8",
+                  product_id: "rhel-8",
+                },
+              },
+              {
+                category: "product_version",
+                name: "RHEL 9",
+                product: {
+                  name: "Red Hat Enterprise Linux 9",
+                  product_id: "rhel-9",
+                },
+              },
+            ],
+          },
+          {
+            category: "product_family",
+            name: "OpenShift",
+            branches: [
+              {
+                category: "product_version",
+                name: "OCP 4.14",
+                product: {
+                  name: "Red Hat OpenShift Container Platform 4.14",
+                  product_id: "ocp-4.14",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    // When collecting products
+    const result = collectProducts(branches);
+
+    // Then all leaf products are in the map
+    expect(result.size).toBe(3);
+    expect(result.get("rhel-8")).toBe("Red Hat Enterprise Linux 8");
+    expect(result.get("rhel-9")).toBe("Red Hat Enterprise Linux 9");
+    expect(result.get("ocp-4.14")).toBe(
+      "Red Hat OpenShift Container Platform 4.14",
+    );
+  });
+
+  /** Verifies that an empty branch array returns an empty map. */
+  it("should return an empty map for empty branches", () => {
+    const result = collectProducts([]);
+    expect(result.size).toBe(0);
+  });
+
+  /** Verifies that branches without products are skipped. */
+  it("should handle branches with no leaf products", () => {
+    // Given branches that contain only intermediate nodes (no product fields)
+    const branches: Branch[] = [
+      {
+        category: "vendor",
+        name: "Red Hat",
+        branches: [
+          {
+            category: "product_family",
+            name: "Enterprise Linux",
+          },
+        ],
+      },
+    ];
+
+    // When collecting products
+    const result = collectProducts(branches);
+
+    // Then the map is empty
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("collectRelationshipProducts", () => {
+  /** Verifies that valid relationships are resolved to product names. */
+  it("should map relationship references to product names", () => {
+    // Given a product map and relationships referencing known products
+    const productMap = new Map([
+      ["prod-1", "Product One"],
+      ["prod-2", "Product Two"],
+    ]);
+    const relationships: Relationship[] = [
+      {
+        category: "default_component_of",
+        full_product_name: { name: "Component A", product_id: "comp-a" },
+        product_reference: "prod-1",
+        relates_to_product_reference: "prod-2",
+      },
+    ];
+
+    // When collecting relationship products
+    const result = collectRelationshipProducts(relationships, productMap);
+
+    // Then the full_product_name is returned with its name
+    expect(result).toHaveLength(1);
+    expect(result[0].product_id).toBe("comp-a");
+    expect(result[0].name).toBe("Component A");
+  });
+
+  /** Verifies that undefined relationships return an empty array. */
+  it("should return empty array for undefined relationships", () => {
+    const productMap = new Map<string, string>();
+    const result = collectRelationshipProducts(undefined, productMap);
+    expect(result).toEqual([]);
+  });
+
+  /** Verifies that missing product references fall back to full_product_name.name. */
+  it("should use full_product_name when product not in map", () => {
+    // Given a relationship with a product_id not in the map
+    const productMap = new Map<string, string>();
+    const relationships: Relationship[] = [
+      {
+        category: "installed_on",
+        full_product_name: { name: "Fallback Name", product_id: "unknown-id" },
+        product_reference: "ref-1",
+        relates_to_product_reference: "ref-2",
+      },
+    ];
+
+    // When collecting relationship products
+    const result = collectRelationshipProducts(relationships, productMap);
+
+    // Then the fallback name from full_product_name is used
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Fallback Name");
+    expect(result[0].product_id).toBe("unknown-id");
+  });
+});

--- a/client/src/app/pages/csaf-visualizer/utils.ts
+++ b/client/src/app/pages/csaf-visualizer/utils.ts
@@ -1,0 +1,54 @@
+import type { Branch, Product, ProductTree, Relationship } from "./types";
+
+/** Flattens the recursive branch tree into a map of product_id to product name. */
+export function collectProducts(branches: Branch[]): Map<string, string> {
+  const products = new Map<string, string>();
+
+  function walkBranches(branchList: Branch[]) {
+    for (const branch of branchList) {
+      if (branch.product) {
+        products.set(branch.product.product_id, branch.product.name);
+      }
+      if (branch.branches) {
+        walkBranches(branch.branches);
+      }
+    }
+  }
+
+  walkBranches(branches);
+  return products;
+}
+
+/** Maps relationship references to resolved product names for display. */
+export function collectRelationshipProducts(
+  relationships: Relationship[] | undefined,
+  productMap: Map<string, string>,
+): { name: string; product_id: string }[] {
+  if (!relationships) return [];
+
+  return relationships.map((r) => ({
+    name:
+      productMap.get(r.full_product_name.product_id) ??
+      r.full_product_name.name,
+    product_id: r.full_product_name.product_id,
+  }));
+}
+
+/** Collects all leaf products from a product tree, combining branch and relationship products. */
+export function collectAllProducts(tree: ProductTree): Product[] {
+  const products: Product[] = [];
+
+  function walkBranches(branches: Branch[]) {
+    for (const branch of branches) {
+      if (branch.product) {
+        products.push(branch.product);
+      }
+      if (branch.branches) {
+        walkBranches(branch.branches);
+      }
+    }
+  }
+
+  walkBranches(tree.branches);
+  return products;
+}

--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -8,6 +8,7 @@ import type { AxiosError } from "axios";
 
 import type { HubRequestParams, Label } from "@app/api/models";
 import { client } from "@app/axios-config/apiInit";
+import type { CsafDocument } from "@app/pages/csaf-visualizer";
 import {
   type AdvisoryDetails,
   type Labels,
@@ -136,6 +137,25 @@ export const useFetchAdvisorySourceById = (id: string) => {
 
   return {
     source: data,
+    isFetching: isLoading,
+    fetchError: error as AxiosError | null,
+  };
+};
+
+export const CsafSourceQueryKey = "csaf-source";
+
+export const useFetchCsafSource = (id: string) => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: [CsafSourceQueryKey, id],
+    queryFn: () =>
+      downloadAdvisory({ client, path: { key: id } }).then(
+        (response) => response.data as CsafDocument,
+      ),
+    enabled: !!id,
+  });
+
+  return {
+    csafDocument: data,
     isFetching: isLoading,
     fetchError: error as AxiosError | null,
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,8 @@
         "@tanstack/react-query-devtools": "^5.61.0",
         "axios": "^1.16.0",
         "dayjs": "^1.11.18",
+        "echarts": "^6.1.0",
+        "echarts-for-react": "^3.0.6",
         "file-saver": "^2.0.5",
         "oidc-client-ts": "^3.3.0",
         "packageurl-js": "^2.0.1",
@@ -5778,6 +5780,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/echarts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.1.0"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6489,7 +6521,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -10901,6 +10932,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -13004,6 +13041,21 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "server": {
       "name": "@trustify-ui/server",


### PR DESCRIPTION
## Summary

- Add conditional rendering in `advisory-details.tsx` to show CSAF-specific tabs when `advisory.labels.type === "csaf"`
- Create `useFetchCsafSource` query hook that fetches and parses raw CSAF JSON via the download endpoint
- Implement `SourceView` component with PatternFly `CodeBlock` and self-reference link
- Create placeholder stubs for Overview, Vulnerabilities, Product Tree, and Relationship Tree tabs
- Create `CsafAdvisoryTabs` container following existing tab pattern with URL-persisted tab state

## Test plan

- [ ] Navigate to a CSAF advisory and confirm 5 CSAF tabs appear (Overview, Vulnerabilities, Product Tree, Relationship Tree, Source)
- [ ] Navigate to a non-CSAF advisory (e.g., CVE type) and confirm standard 2 tabs appear (Info, Vulnerabilities)
- [ ] Source tab renders formatted JSON and "self" reference link
- [ ] Tab switching updates URL query parameter
- [ ] Build passes (`npm run build -w client`)
- [ ] Lint passes (`npm run lint -w client`)

Implements [TC-4601](https://redhat.atlassian.net/browse/TC-4601)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4601]: https://redhat.atlassian.net/browse/TC-4601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add a CSAF-specific advisory details view with dedicated tabs and source loading for CSAF advisories.

New Features:
- Introduce a CSAF-specific tab container that replaces the standard advisory tabs when viewing CSAF-type advisories.
- Add a query hook to fetch and parse CSAF JSON documents from the advisory download endpoint.
- Provide a Source tab that displays the raw CSAF JSON and links to the original advisory when available.
- Stub out CSAF visualizer components for overview, vulnerabilities, product tree, and relationship tree views.

Enhancements:
- Define shared TypeScript types and utility helpers for working with CSAF documents and product trees.
- Expose CSAF types and utilities through a dedicated csaf-visualizer module for reuse.
- Persist CSAF tab selection in the URL query parameters following the existing tab pattern.

Build:
- Add echarts and echarts-for-react dependencies to support upcoming CSAF visualizations.