### PR TITLE
test: add a test for the crate, the ensure that resources as present

### DIFF
--- a/.github/workflows/ci-repo.yaml
+++ b/.github/workflows/ci-repo.yaml
@@ -44,6 +44,9 @@ jobs:
       - name: Crate Clippy
         working-directory: ./crate
         run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Crate Test
+        working-directory: ./crate
+        run: cargo test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -11,6 +11,9 @@ serde_json = "1.0.117"
 static-files = "0.2.1"
 tera = "1.19.1"
 
+[dev-dependencies]
+rstest = "0.26"
+
 [build-dependencies]
 anyhow = "1"
 static-files = "0.2.1"

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -12,6 +12,8 @@ use std::collections::HashMap;
 use std::str::from_utf8;
 use std::sync::OnceLock;
 
+mod test;
+
 #[derive(Serialize, Clone, Default)]
 pub struct UI {
     #[serde(rename(serialize = "VERSION"))]

--- a/crate/src/test.rs
+++ b/crate/src/test.rs
@@ -1,0 +1,13 @@
+#![cfg(test)]
+
+use crate::{trustify_ui, UI};
+use rstest::rstest;
+
+/// This test ensures that
+#[rstest]
+#[case::index_html_ejs("index.html.ejs")]
+#[case::branding_strings_json("branding/strings.json")]
+fn ensure_resources(#[case] res: &str) {
+    let resources = trustify_ui(&UI::default()).expect("must be created");
+    resources.get(res).expect("must exist");
+}


### PR DESCRIPTION
## Summary

add a test for the crate, the ensure that resources as present

## Type of Change
- [x] Other (describe below)

## Testing
- [x] All tests pass (`cargo test`)

## Summary by Sourcery

Add a crate-level test to ensure expected UI resources are present and wire it into CI.

Build:
- Add rstest as a dev-dependency for the crate.

CI:
- Extend the crate CI workflow to run `cargo test` for the crate.

Tests:
- Add an rstest-based unit test that verifies key UI resources are generated and accessible from the crate.