### PR TITLE
feat: switch Codecov uploads from token auth to OIDC

### DIFF
--- a/.github/workflows/ci-coverage.yaml
+++ b/.github/workflows/ci-coverage.yaml
@@ -17,6 +17,8 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -63,6 +65,6 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           flags: e2e
           slug: ${{ github.repository_owner }}/trustify-ui

--- a/.github/workflows/ci-repo.yaml
+++ b/.github/workflows/ci-repo.yaml
@@ -16,6 +16,8 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js
@@ -50,7 +52,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           flags: unit
           slug: ${{ github.repository_owner }}/trustify-ui
           directory: client/coverage


### PR DESCRIPTION
## Summary

Switch both Codecov upload steps from token-based authentication to **OIDC** — the preferred method for public repos on app.codecov.io. This eliminates the need for the `CODECOV_TOKEN` secret.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci-repo.yaml` | Replace `token` with `use_oidc: true`, add `permissions: id-token: write` |
| `.github/workflows/ci-coverage.yaml` | Replace `token` with `use_oidc: true`, add `permissions: id-token: write` |

## Why OIDC?

- No secret management needed — GitHub issues an OIDC token automatically
- More secure — no long-lived token to rotate or leak
- Consistent with the pattern used across other trustify repos

## Note

- OIDC is not available for PRs from forks (GitHub security restriction) — fork PR coverage uploads will be skipped, which is acceptable since the baseline comes from main branch pushes
- Flag names (`unit`, `e2e`) are preserved to maintain carryforward history

Ref: [COVERPORT-259](https://redhat.atlassian.net/browse/COVERPORT-259)

[COVERPORT-259]: https://redhat.atlassian.net/browse/COVERPORT-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Switch Codecov coverage uploads in CI workflows from token-based authentication to GitHub OIDC.

CI:
- Grant GitHub Actions jobs id-token: write permissions required for OIDC-based Codecov uploads.
- Configure Codecov actions in coverage workflows to use OIDC authentication instead of a CODECOV_TOKEN secret.