### PR TITLE
fix: e2e test db connections

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
     image: ${TRUSTIFY_IMAGE}
     environment:
       TRUSTD_DB_HOST: trustify-db
+      TRUSTD_DB_MAX_CONN: "40"
       RUST_LOG: "error"
     entrypoint: /usr/local/bin/trustd
     command: importer --working-dir /data/workdir
@@ -56,6 +57,7 @@ services:
     image: ${TRUSTIFY_IMAGE}
     environment:
       TRUSTD_DB_HOST: trustify-db
+      TRUSTD_DB_MAX_CONN: "40"
       HTTP_SERVER_BIND_ADDR: "::"
       AUTH_DISABLED: true
       RUST_LOG: "error"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
     image: ${TRUSTIFY_IMAGE}
     environment:
       TRUSTD_DB_HOST: trustify-db
-      TRUSTD_DB_MAX_CONN: "40"
+      TRUSTD_DB_MAX_CONN: "30"
       RUST_LOG: "error"
     entrypoint: /usr/local/bin/trustd
     command: importer --working-dir /data/workdir
@@ -57,7 +57,7 @@ services:
     image: ${TRUSTIFY_IMAGE}
     environment:
       TRUSTD_DB_HOST: trustify-db
-      TRUSTD_DB_MAX_CONN: "40"
+      TRUSTD_DB_MAX_CONN: "50"
       HTTP_SERVER_BIND_ADDR: "::"
       AUTH_DISABLED: true
       RUST_LOG: "error"


### PR DESCRIPTION
## Summary
Recent changes in the backend had an influence in the default DB Pool connections. As a consequence all our current e2e tests are failing with 500 error on the upload phase

This PR sets limits to the max number of connections so the default pool of Postgresql (which is 100) is not exceeded

## Summary by Sourcery

Bug Fixes:
- Prevent e2e test failures caused by exceeding the default PostgreSQL connection limit by capping trustd DB connections in docker-compose.