### PR TITLE
feat(sbom): add AIBOM visual markers to SBOM list and detail pages

### DIFF
--- a/client/src/app/pages/sbom-details/sbom-details.tsx
+++ b/client/src/app/pages/sbom-details/sbom-details.tsx
@@ -129,8 +129,12 @@ export const SbomDetails: React.FC = () => {
                 </Content>
               </FlexItem>
               <FlexItem>
-                {sbom?.labels.type && (
-                  <Label color="blue">{sbom?.labels.type}</Label>
+                {sbom?.labels.kind === "aibom" ? (
+                  <Label color="blue">AIBOM</Label>
+                ) : (
+                  sbom?.labels.type && (
+                    <Label color="blue">{sbom?.labels.type}</Label>
+                  )
                 )}
               </FlexItem>
             </Flex>

--- a/client/src/app/pages/sbom-list/sbom-context.ts
+++ b/client/src/app/pages/sbom-list/sbom-context.ts
@@ -23,6 +23,7 @@ interface ISbomSearchContext {
     | "published"
     | "supplier"
     | "labels"
+    | "type"
     | "vulnerabilities",
     "name" | "published",
     "" | "published" | "labels" | "license",

--- a/client/src/app/pages/sbom-list/sbom-provider.tsx
+++ b/client/src/app/pages/sbom-list/sbom-provider.tsx
@@ -62,6 +62,7 @@ export const SbomSearchProvider: React.FunctionComponent<ISbomProvider> = ({
       version: "Version",
       supplier: "Supplier",
       labels: "Labels",
+      type: "Type",
       published: "Created on",
       packages: "Dependencies",
       vulnerabilities: "Vulnerabilities",

--- a/client/src/app/pages/sbom-list/sbom-table.tsx
+++ b/client/src/app/pages/sbom-list/sbom-table.tsx
@@ -4,7 +4,7 @@ import { generatePath, NavLink } from "react-router-dom";
 import { Modal, ModalBody, ModalHeader } from "@patternfly/react-core";
 import type { AxiosError } from "axios";
 
-import { ButtonVariant } from "@patternfly/react-core";
+import { ButtonVariant, Label } from "@patternfly/react-core";
 import {
   ActionsColumn,
   Table,
@@ -119,6 +119,7 @@ export const SbomTable: React.FC = () => {
               <Th {...getThProps({ columnKey: "version" })} />
               <Th {...getThProps({ columnKey: "supplier" })} />
               <Th {...getThProps({ columnKey: "labels" })} />
+              <Th {...getThProps({ columnKey: "type" })} />
               <Th {...getThProps({ columnKey: "published" })} />
               <Th {...getThProps({ columnKey: "packages" })} />
               <Th {...getThProps({ columnKey: "vulnerabilities" })} />
@@ -204,6 +205,14 @@ export const SbomTable: React.FC = () => {
                           }
                         }}
                       />
+                    </Td>
+                    <Td
+                      width={10}
+                      {...getTdProps({ columnKey: "type" })}
+                    >
+                      {item.labels.kind === "aibom" && (
+                        <Label color="blue">AIBOM</Label>
+                      )}
                     </Td>
                     <Td
                       width={10}


### PR DESCRIPTION
## Summary

- Add a "Type" column to the BOM Explorer list table that renders an "AIBOM" blue label when `sbom.labels.kind === "aibom"`, empty cell otherwise
- Update the SBOM detail page header to show "AIBOM" badge when `labels.kind === "aibom"`, falling back to `labels.type` for non-AIBOM documents

Implements [TC-4519](https://redhat.atlassian.net/browse/TC-4519)

## Test plan

- [ ] Upload an AIBOM fixture, verify "AIBOM" label appears in BOM Explorer list Type column
- [ ] Open an AIBOM detail page, verify "AIBOM" label is shown in header
- [ ] Verify regular SBOMs show no type marker in list (empty cell) and show `labels.type` in detail header
- [ ] Verify TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4519]: https://redhat.atlassian.net/browse/TC-4519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add visual type indicators for AIBOM and other SBOM types in the SBOM list and detail views.

New Features:
- Show an AIBOM label in the SBOM list when an SBOM has labels.kind set to aibom.
- Display an AIBOM badge in the SBOM detail header for AIBOM documents and fall back to labels.type for other SBOMs.

Enhancements:
- Extend SBOM list table configuration and search context to include a Type column.