### PR TITLE
feat: conditionally show Models tab only for AIBOM SBOMs

### DIFF
--- a/client/src/app/pages/sbom-details/sbom-details.tsx
+++ b/client/src/app/pages/sbom-details/sbom-details.tsx
@@ -100,6 +100,8 @@ export const SbomDetails: React.FC = () => {
     tabKeys: ["info", "packages", "vulnerabilities", "models"],
   });
 
+  const isAibom = sbom?.labels["kind"] === "aibom";
+
   const infoTabRef = React.useRef<HTMLElement>();
   const packagesTabRef = React.useRef<HTMLElement>();
   const vulnerabilitiesTabRef = React.useRef<HTMLElement>();
@@ -229,11 +231,13 @@ export const SbomDetails: React.FC = () => {
               </>
             }
           />
-          <Tab
-            {...getTabProps("models")}
-            title={<TabTitleText>Models</TabTitleText>}
-            tabContentRef={modelsTabRef}
-          />
+          {isAibom && (
+            <Tab
+              {...getTabProps("models")}
+              title={<TabTitleText>Models</TabTitleText>}
+              tabContentRef={modelsTabRef}
+            />
+          )}
         </Tabs>
       </PageSection>
       <PageSection>
@@ -260,13 +264,15 @@ export const SbomDetails: React.FC = () => {
         >
           {sbomId && <VulnerabilitiesBySbom sbomId={sbomId} />}
         </TabContent>
-        <TabContent
-          {...getTabContentProps("models")}
-          ref={modelsTabRef}
-          aria-label="AI models within the SBOM"
-        >
-          {sbomId && <ModelsBySbom sbomId={sbomId} />}
-        </TabContent>
+        {isAibom && (
+          <TabContent
+            {...getTabContentProps("models")}
+            ref={modelsTabRef}
+            aria-label="AI models within the SBOM"
+          >
+            {sbomId && <ModelsBySbom sbomId={sbomId} />}
+          </TabContent>
+        )}
       </PageSection>
 
       <ConfirmDialog


### PR DESCRIPTION
## Summary
- Show the Models tab in the SBOM details page only when the SBOM has the label `kind=aibom`
- Non-AIBOM SBOMs no longer display an irrelevant Models tab

Resolves: [TC-4794](https://redhat.atlassian.net/browse/TC-4794)

## Test plan
- [ ] Navigate to an AIBOM SBOM details page — verify the Models tab is visible
- [ ] Click the Models tab and verify models are listed with clickable names that open the detail drawer
- [ ] Navigate to a non-AIBOM SBOM details page — verify the Models tab is **not** visible
- [ ] Verify Info, Packages, and Vulnerabilities tabs still work on both AIBOM and non-AIBOM SBOMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4794]: https://redhat.atlassian.net/browse/TC-4794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Hide the Models tab and its content for SBOMs that are not labeled with kind=aibom to avoid showing irrelevant AI model information.