### PR TITLE
feat(ai-model): reorganize AIModelDetails into tabbed layout

### DIFF
--- a/client/src/app/components/AIModelDetails/AIModelDetails.tsx
+++ b/client/src/app/components/AIModelDetails/AIModelDetails.tsx
@@ -1,10 +1,9 @@
-import type React from "react";
+import React from "react";
 
 import {
+  Alert,
   Button,
-  Card,
-  CardBody,
-  CardTitle,
+  Content,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
@@ -12,12 +11,15 @@ import {
   Label,
   Stack,
   StackItem,
+  Tab,
+  Tabs,
+  TabTitleText,
 } from "@patternfly/react-core";
 import ExternalLinkAltIcon from "@patternfly/react-icons/dist/esm/icons/external-link-alt-icon";
 
 import type { SbomModel } from "@app/client";
 
-import { getModelProperties } from "./utils";
+import { getModelProperties, parseSafetyRisks } from "./utils";
 
 export interface ExternalReference {
   type: string;
@@ -40,21 +42,23 @@ interface IAIModelDetailsProps {
 }
 
 export const AIModelDetails: React.FC<IAIModelDetailsProps> = ({ model }) => {
+  const [activeTabKey, setActiveTabKey] = React.useState("overview");
   const props = getModelProperties(model.properties);
   const externalRefs = parseExternalReferences(props.external_references);
+  const safetyRisks = parseSafetyRisks(props.safetyRiskAssessment);
 
   return (
-    <Stack hasGutter>
-      <StackItem>
-        <Card isCompact>
-          <CardTitle>Identity & Purpose</CardTitle>
-          <CardBody>
-            <DescriptionList
-              isCompact
-              columnModifier={{
-                default: "2Col",
-              }}
-            >
+    <Tabs
+      isFilled
+      activeKey={activeTabKey}
+      onSelect={(_e, key) => setActiveTabKey(key as string)}
+      aria-label="AI model details tabs"
+      role="region"
+    >
+      <Tab eventKey="overview" title={<TabTitleText>Overview</TabTitleText>}>
+        <Stack hasGutter style={{ paddingTop: 16 }}>
+          <StackItem>
+            <DescriptionList isCompact columnModifier={{ default: "2Col" }}>
               {props.typeOfModel && (
                 <DescriptionListGroup>
                   <DescriptionListTerm>Model type</DescriptionListTerm>
@@ -88,20 +92,41 @@ export const AIModelDetails: React.FC<IAIModelDetailsProps> = ({ model }) => {
                 </DescriptionListGroup>
               )}
             </DescriptionList>
-          </CardBody>
-        </Card>
-      </StackItem>
+          </StackItem>
+          {safetyRisks.length > 0 && (
+            <StackItem>
+              <Alert variant="warning" isInline title="Safety Risk Assessment">
+                <Stack hasGutter>
+                  {safetyRisks.map((risk, index) => (
+                    <StackItem key={index}>
+                      <strong>{risk.name}</strong>
+                      {risk.mitigationStrategy && (
+                        <Content component="p">
+                          Mitigation: {risk.mitigationStrategy}
+                        </Content>
+                      )}
+                    </StackItem>
+                  ))}
+                </Stack>
+              </Alert>
+            </StackItem>
+          )}
+          {props.limitation && (
+            <StackItem>
+              <Content component="h4">Limitations</Content>
+              <Content component="p">{props.limitation}</Content>
+            </StackItem>
+          )}
+        </Stack>
+      </Tab>
 
-      <StackItem>
-        <Card isCompact>
-          <CardTitle>SBOM Metadata</CardTitle>
-          <CardBody>
-            <DescriptionList
-              isCompact
-              columnModifier={{
-                default: "2Col",
-              }}
-            >
+      <Tab
+        eventKey="metadata"
+        title={<TabTitleText>SBOM Metadata</TabTitleText>}
+      >
+        <Stack hasGutter style={{ paddingTop: 16 }}>
+          <StackItem>
+            <DescriptionList isCompact columnModifier={{ default: "2Col" }}>
               {props.bomFormat && (
                 <DescriptionListGroup>
                   <DescriptionListTerm>Format</DescriptionListTerm>
@@ -135,15 +160,17 @@ export const AIModelDetails: React.FC<IAIModelDetailsProps> = ({ model }) => {
                 </DescriptionListGroup>
               )}
             </DescriptionList>
-          </CardBody>
-        </Card>
-      </StackItem>
+          </StackItem>
+        </Stack>
+      </Tab>
 
-      {externalRefs.length > 0 && (
-        <StackItem>
-          <Card isCompact>
-            <CardTitle>External References</CardTitle>
-            <CardBody>
+      <Tab
+        eventKey="references"
+        title={<TabTitleText>References</TabTitleText>}
+      >
+        <Stack hasGutter style={{ paddingTop: 16 }}>
+          {externalRefs.length > 0 && (
+            <StackItem>
               <DescriptionList isCompact>
                 {externalRefs.map((ref) => (
                   <DescriptionListGroup key={`${ref.type}-${ref.url}`}>
@@ -160,26 +187,25 @@ export const AIModelDetails: React.FC<IAIModelDetailsProps> = ({ model }) => {
                   </DescriptionListGroup>
                 ))}
               </DescriptionList>
-            </CardBody>
-          </Card>
-        </StackItem>
-      )}
-
-      {props.downloadLocation && (
-        <StackItem>
-          <Button
-            variant="secondary"
-            component="a"
-            href={props.downloadLocation}
-            target="_blank"
-            rel="noopener noreferrer"
-            icon={<ExternalLinkAltIcon />}
-            iconPosition="end"
-          >
-            Download
-          </Button>
-        </StackItem>
-      )}
-    </Stack>
+            </StackItem>
+          )}
+          {props.downloadLocation && (
+            <StackItem>
+              <Button
+                variant="secondary"
+                component="a"
+                href={props.downloadLocation}
+                target="_blank"
+                rel="noopener noreferrer"
+                icon={<ExternalLinkAltIcon />}
+                iconPosition="end"
+              >
+                Download
+              </Button>
+            </StackItem>
+          )}
+        </Stack>
+      </Tab>
+    </Tabs>
   );
 };

--- a/client/src/app/components/AIModelDetails/utils.ts
+++ b/client/src/app/components/AIModelDetails/utils.ts
@@ -1,3 +1,8 @@
+export interface SafetyRisk {
+  name: string;
+  mitigationStrategy?: string;
+}
+
 export interface ModelProperties {
   version?: string;
   licenses?: string;
@@ -10,7 +15,7 @@ export interface ModelProperties {
   downloadLocation?: string;
   external_references?: string;
   limitation?: string;
-  safetyRiskAssessment?: string;
+  safetyRiskAssessment?: string | SafetyRisk[];
 }
 
 export const getModelProperties = (properties: unknown): ModelProperties => {
@@ -18,4 +23,12 @@ export const getModelProperties = (properties: unknown): ModelProperties => {
     return properties as ModelProperties;
   }
   return {};
+};
+
+export const parseSafetyRisks = (
+  value?: string | SafetyRisk[],
+): SafetyRisk[] => {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  return [{ name: value }];
 };


### PR DESCRIPTION
## Summary
- Reorganize `AIModelDetails` component from a vertical card stack into 3 horizontal PatternFly tabs: **Overview**, **SBOM Metadata**, and **References**
- Add rendering for `limitation` (text block) and `safetyRiskAssessment` (warning Alert) fields on the Overview tab, absorbing TC-4520 scope
- Add `SafetyRisk` type and `parseSafetyRisks` helper to handle both string and structured array formats from the backend

Implements [TC-4795](https://redhat.atlassian.net/browse/TC-4795)

## Test plan
- [ ] Manual UI test: open model drawer from Models list → verify 3 tabs render with correct content distribution
- [ ] Manual UI test: open model drawer from SBOM details Models tab → verify same 3-tab layout
- [ ] Manual UI test: verify limitation and safetyRiskAssessment render on Overview tab when present in model data
- [ ] Manual UI test: verify absent optional fields are hidden (no empty placeholders)
- [ ] Manual UI test: verify tab switching works without drawer close (state persists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4795]: https://redhat.atlassian.net/browse/TC-4795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Reorganize the AI model details drawer into a tabbed layout separating overview, SBOM metadata, and references, while supporting richer safety risk metadata.

New Features:
- Introduce a PatternFly tabbed layout for AI model details with Overview, SBOM Metadata, and References sections.
- Render safety risk assessments and model limitations in the Overview tab when present in model properties.
- Support structured safety risk metadata through a new SafetyRisk type and parsing helper for mixed backend formats.

Enhancements:
- Preserve AI model download and external reference actions within the new References tab layout.