### PR TITLE
test: SBOM group deletion UI test

### DIFF
--- a/e2e/tests/ui/features/@sbom-groups/sbom-groups.feature
+++ b/e2e/tests/ui/features/@sbom-groups/sbom-groups.feature
@@ -28,6 +28,20 @@ Feature: SBOM Groups - Manage SBOM groups
     And User submits the group form
     Then The group creation is successful
 
+  Scenario: Create empty group, assert it exists, delete it and verify it is gone
+    Given User navigates to SBOM Groups page
+    When User clicks "Create group" button
+    And User fills group name with unique timestamp
+    And User submits the group form
+    Then The group creation is successful
+    When User filters SBOM Groups by created group name
+    Then The SBOM Groups table contains the created group
+    When User clicks kebab menu for the created group
+    And User selects "Delete" action
+    Then The delete confirmation dialog is displayed
+    When User confirms deletion
+    Then The created group is not in the SBOM Groups table
+
   # CRUD Operations - Edit
   Scenario: Edit SBOM group with unique name
     Given User navigates to SBOM Groups page

--- a/e2e/tests/ui/features/@sbom-groups/sbom-groups.step.ts
+++ b/e2e/tests/ui/features/@sbom-groups/sbom-groups.step.ts
@@ -419,6 +419,43 @@ When("User clears all filters on SBOM List page", async ({ page }) => {
 });
 
 // Filtering
+When("User filters SBOM Groups by created group name", async ({ page }) => {
+  if (!generatedGroupName) {
+    throw new Error("No generated group name found - step order issue");
+  }
+  const listPage = await SbomGroupListPage.fromCurrentPage(page);
+  const toolbar = await listPage.getToolbar();
+  await toolbar.applyFilter({ Filter: generatedGroupName });
+});
+
+Then("The SBOM Groups table contains the created group", async ({ page }) => {
+  if (!generatedGroupName) {
+    throw new Error("No generated group name found - step order issue");
+  }
+  await expect(
+    page.getByRole("treegrid").getByRole("link", { name: generatedGroupName }),
+  ).toBeVisible();
+});
+
+When("User clicks kebab menu for the created group", async ({ page }) => {
+  if (!generatedGroupName) {
+    throw new Error("No generated group name found - step order issue");
+  }
+  const row = page
+    .getByRole("treegrid")
+    .getByRole("row", { name: new RegExp(generatedGroupName) });
+  await row.locator('button[aria-label="Kebab toggle"]').click();
+});
+
+Then("The created group is not in the SBOM Groups table", async ({ page }) => {
+  if (!generatedGroupName) {
+    throw new Error("No generated group name found - step order issue");
+  }
+  await expect(
+    page.getByRole("treegrid").getByRole("link", { name: generatedGroupName }),
+  ).not.toBeVisible();
+});
+
 When("User clears all filters on SBOM Groups page", async ({ page }) => {
   const listPage = await SbomGroupListPage.fromCurrentPage(page);
   const toolbar = await listPage.getToolbar();


### PR DESCRIPTION
related to [TC-3999](redhat.atlassian.net/browse/TC-3999)

[TC-3999]: https://redhat.atlassian.net/browse/TC-3999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add end-to-end UI coverage for creating and deleting SBOM groups via the groups list page.

Tests:
- Add a scenario that creates an SBOM group, verifies its presence via filtering, deletes it from the kebab menu, and confirms it is removed from the list.
- Extend SBOM Groups step definitions with actions and assertions for filtering by generated group name, opening the kebab menu, and verifying absence after deletion.