### PR TITLE
Fix: Dashboard - Not-disabled changing of Watched SBOMs in ReadOnly mode

### DIFF
--- a/client/src/app/pages/home/components/WatchedSbom.tsx
+++ b/client/src/app/pages/home/components/WatchedSbom.tsx
@@ -20,16 +20,12 @@ import {
   TextInputGroup,
   TextInputGroupMain,
   TextInputGroupUtilities,
-  Tooltip,
 } from "@patternfly/react-core";
 import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
 import text from "@patternfly/react-styles/css/utilities/Text/text";
 
 import { LoadingWrapper } from "@app/components/LoadingWrapper";
-import {
-  READ_ONLY_TOOLTIP,
-  ReadOnlyContext,
-} from "@app/components/ReadOnlyContext";
+import { ReadOnlyContext } from "@app/components/ReadOnlyContext";
 import { useFetchSBOMById, useFetchSBOMs } from "@app/queries/sboms";
 import { Paths } from "@app/Routes";
 
@@ -179,44 +175,37 @@ export const WatchedSbom: React.FC<WatchedSbomProps> = ({
             if (!isOpen) closeMenu();
           }}
           toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-            <Tooltip
-              content={READ_ONLY_TOOLTIP}
-              trigger={isReadOnly ? "mouseenter" : "manual"}
+            <MenuToggle
+              ref={toggleRef}
+              variant="typeahead"
+              onClick={onToggleClick}
+              isExpanded={isSelectOpen}
+              isFullWidth
+              isDisabled={isReadOnly}
             >
-              <span style={{ cursor: isReadOnly ? "not-allowed" : undefined }}>
-                <MenuToggle
-                  ref={toggleRef}
-                  variant="typeahead"
-                  onClick={onToggleClick}
+              <TextInputGroup isPlain>
+                <TextInputGroupMain
+                  autoComplete="off"
+                  value={inputValue}
+                  onClick={onInputClick}
+                  onChange={onTextInputChange}
+                  innerRef={textInputRef}
                   isExpanded={isSelectOpen}
-                  isFullWidth
-                  isDisabled={isReadOnly}
-                >
-                  <TextInputGroup isPlain>
-                    <TextInputGroupMain
-                      autoComplete="off"
-                      value={inputValue}
-                      onClick={onInputClick}
-                      onChange={onTextInputChange}
-                      innerRef={textInputRef}
-                      isExpanded={isSelectOpen}
-                      placeholder="Select a new SBOM to watch"
-                    />
+                  placeholder="Select a new SBOM to watch"
+                />
 
-                    <TextInputGroupUtilities
-                      {...(!inputValue ? { style: { display: "none" } } : {})}
-                    >
-                      <Button
-                        icon={<TimesIcon aria-hidden />}
-                        variant="plain"
-                        onClick={onClearButtonClick}
-                        aria-label="Clear input value"
-                      />
-                    </TextInputGroupUtilities>
-                  </TextInputGroup>
-                </MenuToggle>
-              </span>
-            </Tooltip>
+                <TextInputGroupUtilities
+                  {...(!inputValue ? { style: { display: "none" } } : {})}
+                >
+                  <Button
+                    icon={<TimesIcon aria-hidden />}
+                    variant="plain"
+                    onClick={onClearButtonClick}
+                    aria-label="Clear input value"
+                  />
+                </TextInputGroupUtilities>
+              </TextInputGroup>
+            </MenuToggle>
           )}
         >
           <SelectList>

--- a/client/src/app/pages/home/components/WatchedSbom.tsx
+++ b/client/src/app/pages/home/components/WatchedSbom.tsx
@@ -20,11 +20,16 @@ import {
   TextInputGroup,
   TextInputGroupMain,
   TextInputGroupUtilities,
+  Tooltip,
 } from "@patternfly/react-core";
 import TimesIcon from "@patternfly/react-icons/dist/esm/icons/times-icon";
 import text from "@patternfly/react-styles/css/utilities/Text/text";
 
 import { LoadingWrapper } from "@app/components/LoadingWrapper";
+import {
+  READ_ONLY_TOOLTIP,
+  ReadOnlyContext,
+} from "@app/components/ReadOnlyContext";
 import { useFetchSBOMById, useFetchSBOMs } from "@app/queries/sboms";
 import { Paths } from "@app/Routes";
 
@@ -43,6 +48,7 @@ export const WatchedSbom: React.FC<WatchedSbomProps> = ({
   sbomId,
 }) => {
   const { patch, mutatingKeys } = React.useContext(WatchedSbomsContext);
+  const { isReadOnly } = React.useContext(ReadOnlyContext);
 
   const textInputRef = React.useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = React.useState<string>("");
@@ -173,36 +179,44 @@ export const WatchedSbom: React.FC<WatchedSbomProps> = ({
             if (!isOpen) closeMenu();
           }}
           toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-            <MenuToggle
-              ref={toggleRef}
-              variant="typeahead"
-              onClick={onToggleClick}
-              isExpanded={isSelectOpen}
-              isFullWidth
+            <Tooltip
+              content={READ_ONLY_TOOLTIP}
+              trigger={isReadOnly ? "mouseenter" : "manual"}
             >
-              <TextInputGroup isPlain>
-                <TextInputGroupMain
-                  autoComplete="off"
-                  value={inputValue}
-                  onClick={onInputClick}
-                  onChange={onTextInputChange}
-                  innerRef={textInputRef}
+              <span style={{ cursor: isReadOnly ? "not-allowed" : undefined }}>
+                <MenuToggle
+                  ref={toggleRef}
+                  variant="typeahead"
+                  onClick={onToggleClick}
                   isExpanded={isSelectOpen}
-                  placeholder="Select a new SBOM to watch"
-                />
-
-                <TextInputGroupUtilities
-                  {...(!inputValue ? { style: { display: "none" } } : {})}
+                  isFullWidth
+                  isDisabled={isReadOnly}
                 >
-                  <Button
-                    icon={<TimesIcon aria-hidden />}
-                    variant="plain"
-                    onClick={onClearButtonClick}
-                    aria-label="Clear input value"
-                  />
-                </TextInputGroupUtilities>
-              </TextInputGroup>
-            </MenuToggle>
+                  <TextInputGroup isPlain>
+                    <TextInputGroupMain
+                      autoComplete="off"
+                      value={inputValue}
+                      onClick={onInputClick}
+                      onChange={onTextInputChange}
+                      innerRef={textInputRef}
+                      isExpanded={isSelectOpen}
+                      placeholder="Select a new SBOM to watch"
+                    />
+
+                    <TextInputGroupUtilities
+                      {...(!inputValue ? { style: { display: "none" } } : {})}
+                    >
+                      <Button
+                        icon={<TimesIcon aria-hidden />}
+                        variant="plain"
+                        onClick={onClearButtonClick}
+                        aria-label="Clear input value"
+                      />
+                    </TextInputGroupUtilities>
+                  </TextInputGroup>
+                </MenuToggle>
+              </span>
+            </Tooltip>
           )}
         >
           <SelectList>


### PR DESCRIPTION
## Summary

- Added isDisabled to Select component in ReadOnly mode
- Added informative tooltip

## Related Issues
This pr is trying to resolve this issue: https://redhat.atlassian.net/browse/TC-4818

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] Other (describe below)

## Testing
- [ ] All tests pass (`npm test`)
- [ ] No lint errors (`npm run lint`)
- [ ] No type errors (TypeScript compiles cleanly)
- [ ] New/changed UI behavior visually verified in browser
- [ ] Mock data updated if API types changed

## Screenshots
<img width="1146" height="701" alt="Screenshot 2026-06-22 at 10 20 42" src="https://github.com/user-attachments/assets/91a9fa58-5580-4f95-90fd-64dd9b764615" />

## Summary by Sourcery

Disable changing of watched SBOMs when the dashboard is in read-only mode and surface a tooltip explaining the restriction.

Bug Fixes:
- Prevent interaction with the watched SBOM selector when the dashboard is in read-only mode to align UI behavior with permissions.

Enhancements:
- Add a contextual tooltip on the watched SBOM selector to explain why it is disabled in read-only mode.