### PR TITLE
fix: Fix/error message upload

### DIFF
--- a/client/src/app/pages/advisory-upload/advisory-upload.tsx
+++ b/client/src/app/pages/advisory-upload/advisory-upload.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-import type { AxiosError, AxiosResponse } from "axios";
+import type { AxiosResponse } from "axios";
 
 import {
   Breadcrumb,
@@ -19,6 +19,7 @@ import { ReadOnlyContext } from "@app/components/ReadOnlyContext";
 import { UploadFiles } from "@app/components/UploadFiles";
 import { useUploadAdvisory } from "@app/queries/advisories";
 import { Paths } from "@app/Routes";
+import { getAxiosErrorMessage } from "@app/utils/utils";
 
 export const AdvisoryUpload: React.FC = () => {
   const { isReadOnly } = React.useContext(ReadOnlyContext);
@@ -72,11 +73,7 @@ export const AdvisoryUpload: React.FC = () => {
               ) => {
                 return `${response.data.document_id} uploaded`;
               }}
-              extractErrorMessage={(error: AxiosError) =>
-                error.response?.data
-                  ? error.message
-                  : "Error while uploading file"
-              }
+              extractErrorMessage={getAxiosErrorMessage}
             />
           </PageSection>
         </>

--- a/client/src/app/pages/sbom-upload/sbom-upload.tsx
+++ b/client/src/app/pages/sbom-upload/sbom-upload.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-import type { AxiosError, AxiosResponse } from "axios";
+import type { AxiosResponse } from "axios";
 
 import {
   Breadcrumb,
@@ -19,6 +19,7 @@ import { ReadOnlyContext } from "@app/components/ReadOnlyContext";
 import { UploadFiles } from "@app/components/UploadFiles";
 import { useUploadSBOM } from "@app/queries/sboms";
 import { Paths } from "@app/Routes";
+import { getAxiosErrorMessage } from "@app/utils/utils";
 
 export const SbomUpload: React.FC = () => {
   const { isReadOnly } = React.useContext(ReadOnlyContext);
@@ -74,11 +75,7 @@ export const SbomUpload: React.FC = () => {
               ) => {
                 return `${response.data.document_id} uploaded`;
               }}
-              extractErrorMessage={(error: AxiosError) =>
-                error.response?.data
-                  ? error.message
-                  : "Error while uploading file"
-              }
+              extractErrorMessage={getAxiosErrorMessage}
             />
           </PageSection>
         </>

--- a/client/src/app/utils/utils.test.ts
+++ b/client/src/app/utils/utils.test.ts
@@ -1,4 +1,17 @@
-import { getToolbarChipKey } from "./utils";
+import type { AxiosError } from "axios";
+
+import { getAxiosErrorMessage, getToolbarChipKey } from "./utils";
+
+const createAxiosError = (
+  overrides: Partial<AxiosError> = {},
+): AxiosError<unknown> =>
+  ({
+    message: "Request failed with status code 400",
+    isAxiosError: true,
+    name: "AxiosError",
+    toJSON: () => ({}),
+    ...overrides,
+  }) as AxiosError<unknown>;
 
 describe("utils", () => {
   // getToolbarChipKey
@@ -11,5 +24,84 @@ describe("utils", () => {
   it("getToolbarChipKey: test 'ToolbarChip'", () => {
     const result = getToolbarChipKey({ key: "myKey", node: "myNode" });
     expect(result).toBe("myKey");
+  });
+
+  // getAxiosErrorMessage
+
+  it("getAxiosErrorMessage: returns errorMessage when present", () => {
+    const error = createAxiosError({
+      response: {
+        data: { errorMessage: "Detailed error from errorMessage" },
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        config: {} as never,
+      },
+    });
+    expect(getAxiosErrorMessage(error)).toBe(
+      "Detailed error from errorMessage",
+    );
+  });
+
+  it("getAxiosErrorMessage: returns message when present", () => {
+    const error = createAxiosError({
+      response: {
+        data: { message: "Invalid SBOM format" },
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        config: {} as never,
+      },
+    });
+    expect(getAxiosErrorMessage(error)).toBe("Invalid SBOM format");
+  });
+
+  it("getAxiosErrorMessage: returns error string when present", () => {
+    const error = createAxiosError({
+      response: {
+        data: { error: "Something went wrong" },
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: {},
+        config: {} as never,
+      },
+    });
+    expect(getAxiosErrorMessage(error)).toBe("Something went wrong");
+  });
+
+  it("getAxiosErrorMessage: returns plain string response data", () => {
+    const error = createAxiosError({
+      response: {
+        data: "Plain text error body",
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        config: {} as never,
+      },
+    });
+    expect(getAxiosErrorMessage(error)).toBe("Plain text error body");
+  });
+
+  it("getAxiosErrorMessage: falls back to axiosError.message", () => {
+    const error = createAxiosError({
+      message: "Network Error",
+    });
+    expect(getAxiosErrorMessage(error)).toBe("Network Error");
+  });
+
+  it("getAxiosErrorMessage: errorMessage takes priority over message", () => {
+    const error = createAxiosError({
+      response: {
+        data: {
+          errorMessage: "Higher priority",
+          message: "Lower priority",
+        },
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        config: {} as never,
+      },
+    });
+    expect(getAxiosErrorMessage(error)).toBe("Higher priority");
   });
 });

--- a/client/src/app/utils/utils.test.ts
+++ b/client/src/app/utils/utils.test.ts
@@ -28,10 +28,10 @@ describe("utils", () => {
 
   // getAxiosErrorMessage
 
-  it("getAxiosErrorMessage: returns errorMessage when present", () => {
+  it("getAxiosErrorMessage: concatenates error and message (ErrorInformation)", () => {
     const error = createAxiosError({
       response: {
-        data: { errorMessage: "Detailed error from errorMessage" },
+        data: { error: "InvalidFormat", message: "expected CycloneDX or SPDX" },
         status: 400,
         statusText: "Bad Request",
         headers: {},
@@ -39,11 +39,30 @@ describe("utils", () => {
       },
     });
     expect(getAxiosErrorMessage(error)).toBe(
-      "Detailed error from errorMessage",
+      "InvalidFormat: expected CycloneDX or SPDX",
     );
   });
 
-  it("getAxiosErrorMessage: returns message when present", () => {
+  it("getAxiosErrorMessage: includes details when error and message present", () => {
+    const error = createAxiosError({
+      response: {
+        data: {
+          error: "InvalidFormat",
+          message: "could not parse document",
+          details: "line 42: unexpected token",
+        },
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        config: {} as never,
+      },
+    });
+    expect(getAxiosErrorMessage(error)).toBe(
+      "InvalidFormat: could not parse document\nline 42: unexpected token",
+    );
+  });
+
+  it("getAxiosErrorMessage: returns message when only message present", () => {
     const error = createAxiosError({
       response: {
         data: { message: "Invalid SBOM format" },
@@ -56,7 +75,7 @@ describe("utils", () => {
     expect(getAxiosErrorMessage(error)).toBe("Invalid SBOM format");
   });
 
-  it("getAxiosErrorMessage: returns error string when present", () => {
+  it("getAxiosErrorMessage: returns error when only error present", () => {
     const error = createAxiosError({
       response: {
         data: { error: "Something went wrong" },
@@ -89,12 +108,13 @@ describe("utils", () => {
     expect(getAxiosErrorMessage(error)).toBe("Network Error");
   });
 
-  it("getAxiosErrorMessage: errorMessage takes priority over message", () => {
+  it("getAxiosErrorMessage: ignores unknown fields and uses error+message", () => {
     const error = createAxiosError({
       response: {
         data: {
-          errorMessage: "Higher priority",
-          message: "Lower priority",
+          error: "SomeError",
+          message: "Something happened",
+          unknownField: "ignored",
         },
         status: 400,
         statusText: "Bad Request",
@@ -102,6 +122,6 @@ describe("utils", () => {
         config: {} as never,
       },
     });
-    expect(getAxiosErrorMessage(error)).toBe("Higher priority");
+    expect(getAxiosErrorMessage(error)).toBe("SomeError: Something happened");
   });
 });

--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -10,23 +10,25 @@ import type { ToolbarLabel } from "@patternfly/react-core";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- allowed
 export const getAxiosErrorMessage = (axiosError: AxiosError<any>) => {
-  if (axiosError.response?.data?.errorMessage) {
-    return axiosError.response.data.errorMessage;
+  const data = axiosError.response?.data;
+
+  const error = typeof data?.error === "string" ? data.error : undefined;
+  const message = typeof data?.message === "string" ? data.message : undefined;
+  const details = typeof data?.details === "string" ? data.details : undefined;
+
+  if (error && message) {
+    const base = `${error}: ${message}`;
+    return details ? `${base}\n${details}` : base;
   }
-  if (
-    axiosError.response?.data?.message &&
-    typeof axiosError.response.data.message === "string"
-  ) {
-    return axiosError.response.data.message;
+  if (message) {
+    return message;
   }
-  if (
-    axiosError.response?.data?.error &&
-    typeof axiosError.response.data.error === "string"
-  ) {
-    return axiosError.response.data.error;
+  if (error) {
+    return error;
   }
-  if (typeof axiosError.response?.data === "string") {
-    return axiosError.response.data;
+
+  if (typeof data === "string") {
+    return data;
   }
   return axiosError.message;
 };

--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -14,10 +14,19 @@ export const getAxiosErrorMessage = (axiosError: AxiosError<any>) => {
     return axiosError.response.data.errorMessage;
   }
   if (
-    axiosError.response?.data?.error &&
-    typeof axiosError?.response?.data?.error === "string"
+    axiosError.response?.data?.message &&
+    typeof axiosError.response.data.message === "string"
   ) {
-    return axiosError?.response?.data?.error;
+    return axiosError.response.data.message;
+  }
+  if (
+    axiosError.response?.data?.error &&
+    typeof axiosError.response.data.error === "string"
+  ) {
+    return axiosError.response.data.error;
+  }
+  if (typeof axiosError.response?.data === "string") {
+    return axiosError.response.data;
   }
   return axiosError.message;
 };

--- a/e2e/tests/ui/assertions/FileUploadMatchers.ts
+++ b/e2e/tests/ui/assertions/FileUploadMatchers.ts
@@ -11,6 +11,10 @@ export interface FileUploadMatchers {
     fileName: string;
     status: "success" | "danger";
   }): Promise<MatcherResult>;
+  toHaveItemUploadErrorMessage(expectedStatus: {
+    fileName: string;
+    errorMessage: string;
+  }): Promise<MatcherResult>;
 }
 
 type FileUploadMatcherDefinitions = {
@@ -71,6 +75,33 @@ export const fileUploadAssertions =
         return {
           pass: true,
           message: () => "Uploader has item with expected status",
+        };
+      } catch (error) {
+        return {
+          pass: false,
+          message: () =>
+            error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+    toHaveItemUploadErrorMessage: async (
+      fileUpload: FileUpload,
+      expectedStatus: {
+        fileName: string;
+        errorMessage: string;
+      },
+    ): Promise<MatcherResult> => {
+      try {
+        const statusItem = await fileUpload.getUploadStatusItem(
+          expectedStatus.fileName,
+        );
+        await baseExpect(
+          statusItem.locator(".pf-v6-c-helper-text__item.pf-m-error"),
+        ).toContainText(expectedStatus.errorMessage);
+
+        return {
+          pass: true,
+          message: () => "Uploader item has expected error message",
         };
       } catch (error) {
         return {

--- a/e2e/tests/ui/assertions/FileUploadMatchers.ts
+++ b/e2e/tests/ui/assertions/FileUploadMatchers.ts
@@ -10,10 +10,7 @@ export interface FileUploadMatchers {
   toHaveItemUploadStatus(expectedStatus: {
     fileName: string;
     status: "success" | "danger";
-  }): Promise<MatcherResult>;
-  toHaveItemUploadErrorMessage(expectedStatus: {
-    fileName: string;
-    errorMessage: string;
+    message?: string;
   }): Promise<MatcherResult>;
 }
 
@@ -59,6 +56,7 @@ export const fileUploadAssertions =
       expectedStatus: {
         fileName: string;
         status: "success" | "danger";
+        message?: string;
       },
     ): Promise<MatcherResult> => {
       try {
@@ -68,40 +66,26 @@ export const fileUploadAssertions =
         await baseExpect(
           statusItem.locator(`.pf-v6-c-progress.pf-m-${expectedStatus.status}`),
         ).toBeVisible();
-        await baseExpect(
-          statusItem.locator(".pf-v6-c-progress__status", { hasText: "100%" }),
-        ).toBeVisible();
+
+        if (expectedStatus.message) {
+          const helperTextVariant =
+            expectedStatus.status === "danger" ? "error" : "default";
+          await baseExpect(
+            statusItem.locator(
+              `.pf-v6-c-helper-text__item.pf-m-${helperTextVariant}`,
+            ),
+          ).toContainText(expectedStatus.message);
+        } else {
+          await baseExpect(
+            statusItem.locator(".pf-v6-c-progress__status", {
+              hasText: "100%",
+            }),
+          ).toBeVisible();
+        }
 
         return {
           pass: true,
           message: () => "Uploader has item with expected status",
-        };
-      } catch (error) {
-        return {
-          pass: false,
-          message: () =>
-            error instanceof Error ? error.message : String(error),
-        };
-      }
-    },
-    toHaveItemUploadErrorMessage: async (
-      fileUpload: FileUpload,
-      expectedStatus: {
-        fileName: string;
-        errorMessage: string;
-      },
-    ): Promise<MatcherResult> => {
-      try {
-        const statusItem = await fileUpload.getUploadStatusItem(
-          expectedStatus.fileName,
-        );
-        await baseExpect(
-          statusItem.locator(".pf-v6-c-helper-text__item.pf-m-error"),
-        ).toContainText(expectedStatus.errorMessage);
-
-        return {
-          pass: true,
-          message: () => "Uploader item has expected error message",
         };
       } catch (error) {
         return {

--- a/e2e/tests/ui/pages/advisory-upload/upload.spec.ts
+++ b/e2e/tests/ui/pages/advisory-upload/upload.spec.ts
@@ -5,6 +5,7 @@ import { login } from "../../helpers/Auth";
 import {
   testInvalidFileExtensions,
   testRemoveFiles,
+  testUploadApiErrorMessage,
   testUploadFilesParallel,
   testUploadFilesSequentially,
 } from "../common/upload-test-helpers";
@@ -141,6 +142,17 @@ test.describe("File Upload", { tag: ["@upload"] }, () => {
 
   testInvalidFileExtensions({
     filesPaths: [TEST_FILES.INVALID_TXT],
+    getConfig: async ({ page }) => {
+      const uploadPage = await AdvisoryUploadPage.buildFromBrowserPath(page);
+      const fileUploader = await uploadPage.getFileUploader();
+      return { fileUploader };
+    },
+  });
+
+  testUploadApiErrorMessage("displays API error message for advisory", {
+    filePath: TEST_FILES.INVALID_JSON,
+    apiRoutePattern: "**/api/v3/advisory",
+    errorMessage: "Invalid advisory: not a valid CSAF, CVE, or OSV document",
     getConfig: async ({ page }) => {
       const uploadPage = await AdvisoryUploadPage.buildFromBrowserPath(page);
       const fileUploader = await uploadPage.getFileUploader();

--- a/e2e/tests/ui/pages/advisory-upload/upload.spec.ts
+++ b/e2e/tests/ui/pages/advisory-upload/upload.spec.ts
@@ -152,7 +152,12 @@ test.describe("File Upload", { tag: ["@upload"] }, () => {
   testUploadApiErrorMessage("displays API error message for advisory", {
     filePath: TEST_FILES.INVALID_JSON,
     apiRoutePattern: "**/api/v3/advisory",
-    errorMessage: "Invalid advisory: not a valid CSAF, CVE, or OSV document",
+    errorResponseBody: {
+      error: "InvalidFormat",
+      message: "not a valid CSAF, CVE, or OSV document",
+    },
+    expectedErrorMessage:
+      "InvalidFormat: not a valid CSAF, CVE, or OSV document",
     getConfig: async ({ page }) => {
       const uploadPage = await AdvisoryUploadPage.buildFromBrowserPath(page);
       const fileUploader = await uploadPage.getFileUploader();

--- a/e2e/tests/ui/pages/common/upload-test-helpers.ts
+++ b/e2e/tests/ui/pages/common/upload-test-helpers.ts
@@ -176,10 +176,7 @@ export const testUploadApiErrorMessage = (
       await expect(fileUploader).toHaveItemUploadStatus({
         fileName,
         status: "danger",
-      });
-      await expect(fileUploader).toHaveItemUploadErrorMessage({
-        fileName,
-        errorMessage: expectedErrorMessage,
+        message: expectedErrorMessage,
       });
     } finally {
       await page.unroute(apiRoutePattern);

--- a/e2e/tests/ui/pages/common/upload-test-helpers.ts
+++ b/e2e/tests/ui/pages/common/upload-test-helpers.ts
@@ -146,12 +146,14 @@ export const testUploadApiErrorMessage = (
   {
     filePath,
     apiRoutePattern,
-    errorMessage,
+    errorResponseBody,
+    expectedErrorMessage,
     getConfig,
   }: {
     filePath: string;
     apiRoutePattern: string;
-    errorMessage: string;
+    errorResponseBody: { error: string; message?: string; details?: string };
+    expectedErrorMessage: string;
     getConfig: ({ page }: { page: Page }) => Promise<UploadTestConfig>;
   },
 ) =>
@@ -163,7 +165,7 @@ export const testUploadApiErrorMessage = (
       await route.fulfill({
         status: 400,
         contentType: "application/json",
-        body: JSON.stringify({ message: errorMessage }),
+        body: JSON.stringify(errorResponseBody),
       });
     });
 
@@ -177,7 +179,7 @@ export const testUploadApiErrorMessage = (
       });
       await expect(fileUploader).toHaveItemUploadErrorMessage({
         fileName,
-        errorMessage,
+        errorMessage: expectedErrorMessage,
       });
     } finally {
       await page.unroute(apiRoutePattern);

--- a/e2e/tests/ui/pages/common/upload-test-helpers.ts
+++ b/e2e/tests/ui/pages/common/upload-test-helpers.ts
@@ -141,6 +141,49 @@ export const testRemoveFiles = ({
     }
   });
 
+export const testUploadApiErrorMessage = (
+  testName: string,
+  {
+    filePath,
+    apiRoutePattern,
+    errorMessage,
+    getConfig,
+  }: {
+    filePath: string;
+    apiRoutePattern: string;
+    errorMessage: string;
+    getConfig: ({ page }: { page: Page }) => Promise<UploadTestConfig>;
+  },
+) =>
+  test(`Upload API error message - ${testName}`, async ({ page }) => {
+    const config = await getConfig({ page });
+    const fileUploader = config.fileUploader;
+
+    await page.route(apiRoutePattern, async (route) => {
+      await route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ message: errorMessage }),
+      });
+    });
+
+    try {
+      await fileUploader.uploadFiles([filePath]);
+
+      const fileName = path.basename(filePath);
+      await expect(fileUploader).toHaveItemUploadStatus({
+        fileName,
+        status: "danger",
+      });
+      await expect(fileUploader).toHaveItemUploadErrorMessage({
+        fileName,
+        errorMessage,
+      });
+    } finally {
+      await page.unroute(apiRoutePattern);
+    }
+  });
+
 export const testInvalidFileExtensions = ({
   filesPaths,
   getConfig,

--- a/e2e/tests/ui/pages/sbom-upload/upload.spec.ts
+++ b/e2e/tests/ui/pages/sbom-upload/upload.spec.ts
@@ -152,7 +152,11 @@ test.describe("File Upload", { tag: ["@upload"] }, () => {
   testUploadApiErrorMessage("displays API error message for SBOM", {
     filePath: TEST_FILES.INVALID_JSON,
     apiRoutePattern: "**/api/v3/sbom",
-    errorMessage: "Invalid SBOM format: expected CycloneDX or SPDX document",
+    errorResponseBody: {
+      error: "InvalidFormat",
+      message: "expected CycloneDX or SPDX document",
+    },
+    expectedErrorMessage: "InvalidFormat: expected CycloneDX or SPDX document",
     getConfig: async ({ page }) => {
       const uploadPage = await SBOMUploadPage.buildFromBrowserPath(page);
       const fileUploader = await uploadPage.getFileUploader();

--- a/e2e/tests/ui/pages/sbom-upload/upload.spec.ts
+++ b/e2e/tests/ui/pages/sbom-upload/upload.spec.ts
@@ -5,6 +5,7 @@ import { login } from "../../helpers/Auth";
 import {
   testInvalidFileExtensions,
   testRemoveFiles,
+  testUploadApiErrorMessage,
   testUploadFilesParallel,
   testUploadFilesSequentially,
 } from "../common/upload-test-helpers";
@@ -141,6 +142,17 @@ test.describe("File Upload", { tag: ["@upload"] }, () => {
 
   testInvalidFileExtensions({
     filesPaths: [TEST_FILES.INVALID_TXT],
+    getConfig: async ({ page }) => {
+      const uploadPage = await SBOMUploadPage.buildFromBrowserPath(page);
+      const fileUploader = await uploadPage.getFileUploader();
+      return { fileUploader };
+    },
+  });
+
+  testUploadApiErrorMessage("displays API error message for SBOM", {
+    filePath: TEST_FILES.INVALID_JSON,
+    apiRoutePattern: "**/api/v3/sbom",
+    errorMessage: "Invalid SBOM format: expected CycloneDX or SPDX document",
     getConfig: async ({ page }) => {
       const uploadPage = await SBOMUploadPage.buildFromBrowserPath(page);
       const fileUploader = await uploadPage.getFileUploader();


### PR DESCRIPTION
## Summary
When Upload SBOM/Advisory error happens and the REST API contains an error message, then the UI renders it

## Related Issues

https://redhat.atlassian.net/browse/TC-4931

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] Other (describe below)

## Testing
- [ ] All tests pass (`npm test`)
- [ ] No lint errors (`npm run lint`)
- [ ] No type errors (TypeScript compiles cleanly)
- [ ] New/changed UI behavior visually verified in browser
- [ ] Mock data updated if API types changed

## Screenshots
<!-- If UI changed, add before/after screenshots -->

## Summary by Sourcery

Improve upload error handling to display meaningful API-provided messages for SBOM and advisory uploads.

Bug Fixes:
- Use structured API error information to derive user-visible messages when file uploads fail instead of generic fallback text.

Enhancements:
- Extend axios error utility to parse standard error, message, and details fields and support string response bodies.
- Add UI test matchers and helpers to validate displayed upload error messages for advisory and SBOM flows.
- Increase unit test coverage for axios error message extraction under various response payload shapes.

Tests:
- Add end-to-end tests ensuring advisory and SBOM upload pages render API error messages from failed requests.
- Add unit tests for the axios error message utility covering combinations of error, message, details, and fallback cases.