### PR TITLE
fix(TC-2443): prevent redundant autocomplete API calls on Search page navigation

### DIFF
--- a/client/src/app/pages/search/components/SearchMenu.test.tsx
+++ b/client/src/app/pages/search/components/SearchMenu.test.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  type MockedFunction,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { MemoryRouter } from "react-router-dom";
+
+import { FILTER_TEXT_CATEGORY_KEY } from "@app/Constants";
+import { SbomSearchContext } from "@app/pages/sbom-list/sbom-context";
+import { useFetchAdvisories } from "@app/queries/advisories";
+import { useFetchPackages } from "@app/queries/packages";
+import { useFetchSBOMs } from "@app/queries/sboms";
+import { useFetchVulnerabilities } from "@app/queries/vulnerabilities";
+
+import { SearchMenu } from "./SearchMenu";
+
+vi.mock("@app/queries/advisories");
+vi.mock("@app/queries/packages");
+vi.mock("@app/queries/sboms");
+vi.mock("@app/queries/vulnerabilities");
+
+const mockedUseFetchAdvisories = useFetchAdvisories as MockedFunction<
+  typeof useFetchAdvisories
+>;
+const mockedUseFetchPackages = useFetchPackages as MockedFunction<
+  typeof useFetchPackages
+>;
+const mockedUseFetchSBOMs = useFetchSBOMs as MockedFunction<
+  typeof useFetchSBOMs
+>;
+const mockedUseFetchVulnerabilities = useFetchVulnerabilities as MockedFunction<
+  typeof useFetchVulnerabilities
+>;
+
+const emptyFetchResult = {
+  isFetching: false,
+  result: { data: [], total: 0, params: {} },
+  fetchError: null,
+  refetch: vi.fn(),
+};
+
+const getDisableSearchFlags = () => ({
+  advisories: mockedUseFetchAdvisories.mock.calls.at(-1)?.[2],
+  packages: mockedUseFetchPackages.mock.calls.at(-1)?.[1],
+  sboms: mockedUseFetchSBOMs.mock.calls.at(-1)?.[3],
+  vulnerabilities: mockedUseFetchVulnerabilities.mock.calls.at(-1)?.[1],
+});
+
+const allAutocompleteDisabled = (
+  flags: ReturnType<typeof getDisableSearchFlags>,
+) =>
+  flags.advisories === true &&
+  flags.packages === true &&
+  flags.sboms === true &&
+  flags.vulnerabilities === true;
+
+const allAutocompleteEnabled = (
+  flags: ReturnType<typeof getDisableSearchFlags>,
+) =>
+  flags.advisories === false &&
+  flags.packages === false &&
+  flags.sboms === false &&
+  flags.vulnerabilities === false;
+
+const renderSearchMenu = ({
+  filterValues = {},
+  onChangeSearch = vi.fn(),
+}: {
+  filterValues?: Record<string, string[]>;
+  onChangeSearch?: (searchValue: string | undefined) => void;
+} = {}) => {
+  const setFilterValues = vi.fn();
+
+  const contextValue = {
+    tableControls: {
+      filterState: {
+        filterValues,
+        setFilterValues,
+      },
+    },
+  } as unknown as React.ContextType<typeof SbomSearchContext>;
+
+  return {
+    onChangeSearch,
+    setFilterValues,
+    ...render(
+      <MemoryRouter>
+        <SbomSearchContext.Provider value={contextValue}>
+          <SearchMenu onChangeSearch={onChangeSearch} />
+        </SbomSearchContext.Provider>
+      </MemoryRouter>,
+    ),
+  };
+};
+
+describe("SearchMenu autocomplete fetch gating (TC-2443)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseFetchAdvisories.mockReturnValue(emptyFetchResult);
+    mockedUseFetchPackages.mockReturnValue(emptyFetchResult);
+    mockedUseFetchSBOMs.mockReturnValue(emptyFetchResult);
+    mockedUseFetchVulnerabilities.mockReturnValue(emptyFetchResult);
+  });
+
+  it("disables autocomplete fetches on initial mount with empty input", () => {
+    renderSearchMenu();
+
+    expect(allAutocompleteDisabled(getDisableSearchFlags())).toBe(true);
+  });
+
+  it("enables autocomplete fetches when typing a non-empty query", async () => {
+    renderSearchMenu();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search input" }), {
+      target: { value: "some" },
+    });
+
+    await waitFor(() => {
+      expect(allAutocompleteEnabled(getDisableSearchFlags())).toBe(true);
+    });
+  });
+
+  it("disables autocomplete fetches for whitespace-only input while dirty", () => {
+    renderSearchMenu();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search input" }), {
+      target: { value: "   " },
+    });
+
+    expect(allAutocompleteDisabled(getDisableSearchFlags())).toBe(true);
+  });
+
+  it("disables autocomplete fetches after submit", () => {
+    const onChangeSearch = vi.fn();
+    renderSearchMenu({ onChangeSearch });
+
+    const input = screen.getByRole("textbox", { name: "Search input" });
+    fireEvent.change(input, { target: { value: "some" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(onChangeSearch).toHaveBeenCalledWith("some");
+    expect(allAutocompleteDisabled(getDisableSearchFlags())).toBe(true);
+  });
+
+  it("disables autocomplete fetches after clear", () => {
+    const onChangeSearch = vi.fn();
+    renderSearchMenu({
+      filterValues: { [FILTER_TEXT_CATEGORY_KEY]: ["previous"] },
+      onChangeSearch,
+    });
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search input" }), {
+      target: { value: "previous" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(onChangeSearch).toHaveBeenCalledWith("");
+    expect(allAutocompleteDisabled(getDisableSearchFlags())).toBe(true);
+  });
+
+  it("does not flash stale filter text into the input while clearing filters", () => {
+    const onChangeSearch = vi.fn();
+    const { rerender } = renderSearchMenu({
+      filterValues: { [FILTER_TEXT_CATEGORY_KEY]: ["something"] },
+      onChangeSearch,
+    });
+
+    const input = screen.getByRole("textbox", { name: "Search input" });
+    fireEvent.change(input, { target: { value: "something" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+
+    const contextWithStaleFilter = {
+      tableControls: {
+        filterState: {
+          filterValues: { [FILTER_TEXT_CATEGORY_KEY]: ["something"] },
+          setFilterValues: vi.fn(),
+        },
+      },
+    } as unknown as React.ContextType<typeof SbomSearchContext>;
+
+    rerender(
+      <MemoryRouter>
+        <SbomSearchContext.Provider value={contextWithStaleFilter}>
+          <SearchMenu onChangeSearch={onChangeSearch} />
+        </SbomSearchContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(input).toHaveValue("");
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(input).toHaveValue("");
+  });
+});

--- a/client/src/app/pages/search/components/SearchMenu.tsx
+++ b/client/src/app/pages/search/components/SearchMenu.tsx
@@ -166,14 +166,30 @@ export const SearchMenu: React.FC<ISearchMenu> = ({ onChangeSearch }) => {
     React.useContext(SbomSearchContext);
 
   // Search value
+  // Stable string primitive — the filterState object is recreated every render
+  // (no useMemo in the useUrlParams → useFilterState → context chain), but the
+  // extracted string only changes when the URL filter param actually changes.
+  const appliedSearchValue =
+    sbomTableControls.filterState.filterValues[FILTER_TEXT_CATEGORY_KEY]?.[0] ??
+    "";
+
   const [searchValue, setSearchValue] = React.useState("");
   const [isSearchValueDirty, setIsSearchValueDirty] = React.useState(false);
+  const submittedSearchValueRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
-    const searchValueFromTableControls =
-      sbomTableControls.filterState.filterValues[FILTER_TEXT_CATEGORY_KEY]?.[0];
-    setSearchValue(searchValueFromTableControls ?? "");
-  }, [sbomTableControls.filterState]);
+    if (isSearchValueDirty) return;
+
+    if (submittedSearchValueRef.current !== null) {
+      if (appliedSearchValue === submittedSearchValueRef.current) {
+        submittedSearchValueRef.current = null;
+        setSearchValue(appliedSearchValue);
+      }
+      return;
+    }
+
+    setSearchValue(appliedSearchValue);
+  }, [appliedSearchValue, isSearchValueDirty]);
 
   // Debounce Search value
   const [debouncedSearchValue, setDebouncedSearchValue] = useDebounceValue(
@@ -185,10 +201,13 @@ export const SearchMenu: React.FC<ISearchMenu> = ({ onChangeSearch }) => {
     setDebouncedSearchValue(searchValue);
   }, [setDebouncedSearchValue, searchValue]);
 
+  const disableAutocomplete =
+    !isSearchValueDirty || debouncedSearchValue.trim() === "";
+
   // Fetch all entities
   const { isFetching, list: entityList } = useAllEntities(
     debouncedSearchValue,
-    !isSearchValueDirty,
+    disableAutocomplete,
   );
 
   const [isAutocompleteOpen, setIsAutocompleteOpen] =
@@ -217,9 +236,16 @@ export const SearchMenu: React.FC<ISearchMenu> = ({ onChangeSearch }) => {
 
   const onClearSearchValue = () => {
     setSearchValue("");
+    setIsSearchValueDirty(false);
+    setIsAutocompleteOpen(false);
+    submittedSearchValueRef.current = "";
+    onChangeSearch("");
   };
 
   const onSubmitInput = () => {
+    setIsSearchValueDirty(false);
+    setIsAutocompleteOpen(false);
+    submittedSearchValueRef.current = searchValue;
     onChangeSearch(searchValue);
   };
 


### PR DESCRIPTION
## Summary

Fixes [TC-2443](https://redhat.atlassian.net/browse/TC-2443) — Navigating to the Search page after performing a search triggered redundant autocomplete API calls with an empty query, causing a brief confusing spinner popup and doubled API load.

### Issues addressed

1. **Redundant autocomplete calls on navigation** — After searching (e.g. "quarkus") and navigating back to the Search page via the left nav, `useAllEntities` fired 4 extra API requests (`limit=5&q=`) because `isSearchValueDirty` was never reset when the search value was synced from external state (URL params).

2. **Stale value flash on clear/re-submit** — After searching "something", clearing the input, and pressing Enter, the previous search term briefly flashed in the input. This happened because `onChangeSearch("")` updates URL params asynchronously, so the context still held the old filter value for one render cycle.

3. **Unstable useEffect dependency** — The sync useEffect depended on `sbomTableControls.filterState` (an object recreated every render due to the non-memoized context chain). Replaced with `appliedSearchValue`, a stable string primitive that only changes when the actual URL filter param changes.

### Changes

**`SearchMenu.tsx`**:
- Extract `appliedSearchValue` as a stable string from `filterState` — avoids the unstable object reference
- Guard the sync `useEffect` with `isSearchValueDirty` to prevent overwriting user input during typing
- Add `submittedSearchValueRef` to bridge the async gap between calling `onChangeSearch()` and the context reflecting the new value — prevents the stale flash
- Combine `!isSearchValueDirty || debouncedSearchValue.trim() === ""` into `disableAutocomplete` — prevents empty-query autocomplete during both navigation AND the debounce window
- Reset `isSearchValueDirty` in `onSubmitInput` and `onClearSearchValue`
- Propagate clear to table controls via `onChangeSearch("")` in `onClearSearchValue`

**`SearchMenu.test.tsx`** (new):
- 6 unit tests validating the autocomplete fetch gating behavior

## Before / After

### Before fix

Notice the autocomplete generates 8 calls.

https://github.com/user-attachments/assets/9fa3585a-41f5-47b1-a835-ef260139ca13

### After fix

Notice the autocomplete generates 4 calls

https://github.com/user-attachments/assets/65790160-07a7-4209-ae83-8f231c48ebb6

## Test plan

- [x] Unit tests pass (`SearchMenu.test.tsx` — 6 tests)
- [ ] Manual: Search → navigate away → navigate back: no autocomplete popup/requests
- [ ] Manual: Type → Enter → clear → Enter: no flash of previous search term
- [ ] Manual: Autocomplete still works when typing a new search term

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-2443]: https://redhat.atlassian.net/browse/TC-2443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ