### PR TITLE
fix(deps): bump react-router to 7.18.1 to fix CVE-2026-42342 and CVE-2026-33245

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10431,9 +10431,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -10453,12 +10453,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"


### PR DESCRIPTION
## Summary

- Bumps `react-router` and `react-router-dom` from 7.13.1 to 7.18.1 via lockfile update
- Fixes [CVE-2026-42342](https://nvd.nist.gov/vuln/detail/CVE-2026-42342) (Moderate 6.5 — DoS via unbounded path expansion in `__manifest` endpoint)
- Fixes [CVE-2026-33245](https://nvd.nist.gov/vuln/detail/CVE-2026-33245) (Moderate — XSS via RSC redirects)
- No `package.json` change needed — the existing `^7.8.1` specifier already permits 7.18.1

## Jira

[TC-5007](https://redhat.atlassian.net/browse/TC-5007)

## Test plan

- [x] `npm run check` (biome lint) passes
- [x] `npm run test` results match base branch (no regressions)
- [x] CI pipeline passes

[TC-5007]: https://redhat.atlassian.net/browse/TC-5007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update React Router dependencies to 7.18.1 to address security vulnerabilities in routing and manifest endpoints.

Build:
- Update package-lock.json to bump react-router and react-router-dom from 7.13.1 to 7.18.1 to match existing semver range.

Chores:
- Align dependency lockfile with upstream security fixes for CVE-2026-42342 and CVE-2026-33245.