### PR TITLE
perf: use pre-fetched advisory severity summary on SBOM list

### DIFF
--- a/client/src/app/components/VulnerabilityGallery.tsx
+++ b/client/src/app/components/VulnerabilityGallery.tsx
@@ -8,15 +8,16 @@ import type { ExtendedSeverity } from "@app/api/models";
 import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
 
 interface VulnerabilityGalleryProps {
-  severities: { [key in ExtendedSeverity]: number };
+  severities: Partial<{ [key in ExtendedSeverity]: number }>;
 }
 
 export const VulnerabilityGallery: React.FC<VulnerabilityGalleryProps> = ({
   severities,
 }) => {
-  const severityCount = Object.values(severities).reduce((prev, acc) => {
-    return prev + acc;
-  }, 0);
+  const severityCount = Object.values(severities).reduce(
+    (prev, acc) => prev + (acc ?? 0),
+    0,
+  );
 
   return (
     <Flex

--- a/client/src/app/pages/sbom-list/components/SbomVulnerabilities.tsx
+++ b/client/src/app/pages/sbom-list/components/SbomVulnerabilities.tsx
@@ -1,31 +1,26 @@
 import type React from "react";
 
-import { Skeleton } from "@patternfly/react-core";
-
-import { LoadingWrapper } from "@app/components/LoadingWrapper";
-import { TableCellError } from "@app/components/TableCellError";
+import type { SbomAdvisorySummary } from "@app/client";
 import { VulnerabilityGallery } from "@app/components/VulnerabilityGallery";
-import { useVulnerabilitiesOfSbom } from "@app/hooks/domain-controls/useVulnerabilitiesOfSbom";
+import type { ExtendedSeverity } from "@app/api/models";
 
 interface SBOMVulnerabilitiesProps {
-  sbomId: string;
+  advisories?: SbomAdvisorySummary | null;
 }
 
-export const SBOMVulnerabilities: React.FC<SBOMVulnerabilitiesProps> = ({
-  sbomId,
-}) => {
-  const { data, isFetching, fetchError } = useVulnerabilitiesOfSbom(sbomId);
+const DEFAULT_SEVERITIES: { [key in ExtendedSeverity]: number } = {
+  unknown: 0,
+  none: 0,
+  low: 0,
+  medium: 0,
+  high: 0,
+  critical: 0,
+};
 
-  return (
-    <LoadingWrapper
-      isFetching={isFetching}
-      fetchError={fetchError}
-      isFetchingState={<Skeleton screenreaderText="Loading contents" />}
-      fetchErrorState={(error) => <TableCellError error={error} />}
-    >
-      <VulnerabilityGallery
-        severities={data.summary.vulnerabilityStatus.affected.severities}
-      />
-    </LoadingWrapper>
-  );
+export const SBOMVulnerabilities: React.FC<SBOMVulnerabilitiesProps> = ({
+  advisories,
+}) => {
+  const severities = { ...DEFAULT_SEVERITIES, ...advisories };
+
+  return <VulnerabilityGallery severities={severities} />;
 };

--- a/client/src/app/pages/sbom-list/components/SbomVulnerabilities.tsx
+++ b/client/src/app/pages/sbom-list/components/SbomVulnerabilities.tsx
@@ -1,26 +1,12 @@
 import type React from "react";
 
-import type { SbomAdvisorySummary } from "@app/client";
+import type { RequestedFieldHashMapHashMap } from "@app/client";
 import { VulnerabilityGallery } from "@app/components/VulnerabilityGallery";
-import type { ExtendedSeverity } from "@app/api/models";
 
 interface SBOMVulnerabilitiesProps {
-  advisories?: SbomAdvisorySummary | null;
+  advisories?: RequestedFieldHashMapHashMap;
 }
-
-const DEFAULT_SEVERITIES: { [key in ExtendedSeverity]: number } = {
-  unknown: 0,
-  none: 0,
-  low: 0,
-  medium: 0,
-  high: 0,
-  critical: 0,
-};
 
 export const SBOMVulnerabilities: React.FC<SBOMVulnerabilitiesProps> = ({
   advisories,
-}) => {
-  const severities = { ...DEFAULT_SEVERITIES, ...advisories };
-
-  return <VulnerabilityGallery severities={severities} />;
-};
+}) => <VulnerabilityGallery severities={advisories ?? {}} />;

--- a/client/src/app/pages/sbom-list/sbom-context.ts
+++ b/client/src/app/pages/sbom-list/sbom-context.ts
@@ -2,7 +2,11 @@ import React from "react";
 
 import type { AxiosError } from "axios";
 
-import type { SbomHead, SourceDocument } from "@app/client";
+import type {
+  SbomAdvisorySummary,
+  SbomHead,
+  SourceDocument,
+} from "@app/client";
 import type { BulkSelectionValues } from "@app/hooks/selection";
 import type { ITableControls } from "@app/hooks/table-controls";
 
@@ -16,6 +20,7 @@ interface ISbomSearchContext {
           name: string;
           version?: string | null;
         }>;
+        advisories?: SbomAdvisorySummary | null;
       },
     | "name"
     | "version"

--- a/client/src/app/pages/sbom-list/sbom-context.ts
+++ b/client/src/app/pages/sbom-list/sbom-context.ts
@@ -3,7 +3,7 @@ import React from "react";
 import type { AxiosError } from "axios";
 
 import type {
-  SbomAdvisorySummary,
+  RequestedFieldHashMapHashMap,
   SbomHead,
   SourceDocument,
 } from "@app/client";
@@ -20,7 +20,7 @@ interface ISbomSearchContext {
           name: string;
           version?: string | null;
         }>;
-        advisories?: SbomAdvisorySummary | null;
+        advisories?: RequestedFieldHashMapHashMap;
       },
     | "name"
     | "version"

--- a/client/src/app/pages/sbom-list/sbom-provider.tsx
+++ b/client/src/app/pages/sbom-list/sbom-provider.tsx
@@ -133,6 +133,8 @@ export const SbomSearchProvider: React.FunctionComponent<ISbomProvider> = ({
     (tableControlState.filterState.filterValues.labels ?? []).map((label) =>
       splitStringAsKeyValue(label),
     ),
+    false,
+    true,
   );
 
   const tableControls = useTableControlProps({

--- a/client/src/app/pages/sbom-list/sbom-table.tsx
+++ b/client/src/app/pages/sbom-list/sbom-table.tsx
@@ -219,7 +219,7 @@ export const SbomTable: React.FC = () => {
                       width={20}
                       {...getTdProps({ columnKey: "vulnerabilities" })}
                     >
-                      <SBOMVulnerabilities sbomId={item.id} />
+                      <SBOMVulnerabilities advisories={item.advisories} />
                     </Td>
                     <Td isActionCell>
                       <ActionsColumn

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -61,11 +61,12 @@ export const useFetchSBOMs = (
   params: HubRequestParams = {},
   labels: Label[] = [],
   disableQuery = false,
+  advisories = false,
 ) => {
   const labelQuery = labelRequestParamsQuery(labels);
 
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: [SBOMsQueryKey, groupId, params, labelQuery],
+    queryKey: [SBOMsQueryKey, groupId, params, labelQuery, advisories],
     queryFn: () => {
       const { q, ...rest } = requestParamsQuery(params);
       return listSboms({
@@ -74,6 +75,7 @@ export const useFetchSBOMs = (
           ...rest,
           group: groupId ? [groupId] : [],
           q: [q, labelQuery].filter((e) => e).join("&"),
+          advisories,
         },
       });
     },


### PR DESCRIPTION
## Summary

* Consume the new `?advisories=true` query parameter on the SBOM list endpoint to display severity counts per row
* Eliminates N+1 requests to `GET /sbom/{id}/advisory` (~4s each) that were made per table row

## Dependencies

Depends on backend PR: https://github.com/guacsec/trustify/pull/2437 which adds the `?advisories=true` query parameter to `GET /v3/sbom`.

## Changes

* `SbomVulnerabilities.tsx` - rewritten to accept pre-fetched advisory summary instead of fetching per row
* `sboms.ts` - pass `advisories: true` in the list query
* `sbom-table.tsx` - pass `item.advisories` to the component instead of `item.id`
* `sbom-context.ts` - add `advisories` field to the item type
* `types.gen.ts` - not committed (gitignored), will be regenerated from the updated OpenAPI spec

## Test plan

- [ ] SBOM list page loads severity badges without per-row API calls
- [ ] Severity counts match those from individual `GET /sbom/{id}/advisory` responses
- [ ] Page load time significantly reduced (from ~40s N+1 to single batch query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize SBOM list vulnerability display by consuming pre-fetched advisory summaries instead of per-row advisory API calls.

New Features:
- Display SBOM vulnerability severities from advisory summaries returned by the SBOM list endpoint.

Enhancements:
- Extend SBOM list items with optional advisory summary data and propagate it through the table context to the vulnerability gallery component.
- Include the advisories flag in SBOM list queries to retrieve aggregated advisory severity data in a single request.