### PR TITLE
chore(eslint): enable @eslint-react/no-nested-component-definitions rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,7 +42,6 @@ export default defineConfig([
       "@eslint-react/no-unnecessary-use-prefix": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "@eslint-react/exhaustive-deps": "off",
-      "@eslint-react/no-nested-component-definitions": "off",
       "@tanstack/query/prefer-query-options": "off",
       "@tanstack/query/exhaustive-deps": "off",
       "@tanstack/query/no-void-query-fn": "off",


### PR DESCRIPTION
## Summary
- Enable the `@eslint-react/no-nested-component-definitions` ESLint rule by removing its `"off"` override
- Zero existing violations — this is a no-op change that prevents future regressions

Part of #1128 (PR 1 of 8).

## Test plan
- [x] `npm run lint` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update ESLint configuration to stop overriding @eslint-react/no-nested-component-definitions as off.