### PR TITLE
chore(eslint): enable @tanstack/query/no-void-query-fn rule

### DIFF
--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -92,11 +92,8 @@ export const useFetchSBOMs = (
 
 export const sbomByIdQueryOptions = (id: string | undefined) => ({
   queryKey: [SBOMsQueryKey, id] as const,
-  queryFn: () => {
-    return id === undefined
-      ? Promise.resolve(undefined)
-      : getSbom({ client, path: { id: id } });
-  },
+  queryFn: () => getSbom({ client, path: { id: id! } }),
+  enabled: !!id,
 });
 
 export const useFetchSBOMById = (

--- a/client/src/app/queries/vulnerabilities.ts
+++ b/client/src/app/queries/vulnerabilities.ts
@@ -55,7 +55,7 @@ export const useFetchVulnerabilitiesByPackageIds = (ids: string[]) => {
         client,
         body: { purls: ids },
       });
-      return response.data ?? {};
+      return response.data ?? null;
     },
   };
 

--- a/client/src/app/queries/vulnerabilities.ts
+++ b/client/src/app/queries/vulnerabilities.ts
@@ -55,7 +55,7 @@ export const useFetchVulnerabilitiesByPackageIds = (ids: string[]) => {
         client,
         body: { purls: ids },
       });
-      return response.data;
+      return response.data ?? {};
     },
   };
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,7 +45,6 @@ export default defineConfig([
       "@eslint-react/no-nested-component-definitions": "off",
       "@tanstack/query/prefer-query-options": "off",
       "@tanstack/query/exhaustive-deps": "off",
-      "@tanstack/query/no-void-query-fn": "off",
     },
     ignores: [
       "client/config/**",


### PR DESCRIPTION
## Summary
- Enable the `@tanstack/query/no-void-query-fn` ESLint rule by fixing 2 violations and removing the `"off"` override
- `sboms.ts`: Move `enabled: !!id` into `sbomByIdQueryOptions` so the queryFn never runs without an id, eliminating the `Promise.resolve(undefined)` branch
- `vulnerabilities.ts`: Add nullish fallback (`?? {}`) on `response.data` to ensure the queryFn always returns a non-void value

Part of #1128 (PR 2 of 8).

## Test plan
- [x] `npm run lint` passes with zero errors
- [x] `npx tsc --noEmit` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable the TanStack Query ESLint rule that forbids void query functions by ensuring affected queries always return non-void values and removing the rule override.

Bug Fixes:
- Ensure the SBOM-by-ID query is only executed when an ID is present, preventing a void-returning branch in its query function.
- Ensure the vulnerabilities-by-package-IDs query always returns a non-void object by defaulting missing response data to an empty object.

Build:
- Update ESLint configuration to enforce @tanstack/query/no-void-query-fn instead of disabling it.