### PR TITLE
chore(eslint): enable @tanstack/query/exhaustive-deps rule

### DIFF
--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -60,12 +60,12 @@ export const useFetchAdvisories = (
   labels: Label[] = [],
   disableQuery = false,
 ) => {
-  const { q, ...rest } = requestParamsQuery(params);
   const labelQuery = labelRequestParamsQuery(labels);
 
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: [AdvisoriesQueryKey, params, labelQuery],
     queryFn: () => {
+      const { q, ...rest } = requestParamsQuery(params);
       return listAdvisories({
         client,
         query: {

--- a/client/src/app/queries/sbom-groups.ts
+++ b/client/src/app/queries/sbom-groups.ts
@@ -67,20 +67,20 @@ export const useFetchSBOMGroups = (
   > = {},
   enabled = true,
 ) => {
-  const { q, ...rest } = requestParamsQuery(params);
-  const parentQuery = parentId ? `parent=${parentId}` : "";
-
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: [SBOMGroupsQueryKey, parentId, { params, extraQueryParams }],
-    queryFn: () =>
-      listSbomGroups({
+    queryFn: () => {
+      const { q, ...rest } = requestParamsQuery(params);
+      const parentQuery = parentId ? `parent=${parentId}` : "";
+      return listSbomGroups({
         client,
         query: {
           ...rest,
           ...extraQueryParams,
           q: [q, parentQuery].filter((e) => e).join("&"),
         },
-      }),
+      });
+    },
     enabled,
   });
 

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -62,20 +62,21 @@ export const useFetchSBOMs = (
   labels: Label[] = [],
   disableQuery = false,
 ) => {
-  const { q, ...rest } = requestParamsQuery(params);
   const labelQuery = labelRequestParamsQuery(labels);
 
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: [SBOMsQueryKey, groupId, params, labelQuery],
-    queryFn: () =>
-      listSboms({
+    queryFn: () => {
+      const { q, ...rest } = requestParamsQuery(params);
+      return listSboms({
         client,
         query: {
           ...rest,
           group: groupId ? [groupId] : [],
           q: [q, labelQuery].filter((e) => e).join("&"),
         },
-      }),
+      });
+    },
     enabled: !disableQuery,
   });
   return {

--- a/client/src/app/queries/vulnerabilities.ts
+++ b/client/src/app/queries/vulnerabilities.ts
@@ -41,32 +41,27 @@ export const useFetchVulnerabilities = (
 };
 
 export const useFetchVulnerabilitiesByPackageIds = (ids: string[]) => {
-  const chunks = {
-    ids: ids.reduce<string[][]>((chunks, item, index) => {
-      if (index % 100 === 0) {
-        chunks.push([item]);
-      } else {
-        chunks[chunks.length - 1].push(item);
-      }
-      return chunks;
-    }, []),
-    dataResolver: async (ids: string[]) => {
-      const response = await analyzeV3({
-        client,
-        body: { purls: ids },
-      });
-      return response.data;
-    },
-  };
+  const chunkedIds = ids.reduce<string[][]>((chunks, item, index) => {
+    if (index % 100 === 0) {
+      chunks.push([item]);
+    } else {
+      chunks[chunks.length - 1].push(item);
+    }
+    return chunks;
+  }, []);
 
   const userQueries = useQueries({
-    queries: chunks.ids.map((ids) => {
-      return {
-        queryKey: [VulnerabilitiesQueryKey, ids],
-        queryFn: () => chunks.dataResolver(ids),
-        retry: false,
-      };
-    }),
+    queries: chunkedIds.map((chunkIds) => ({
+      queryKey: [VulnerabilitiesQueryKey, chunkIds],
+      queryFn: async () => {
+        const response = await analyzeV3({
+          client,
+          body: { purls: chunkIds },
+        });
+        return response.data;
+      },
+      retry: false,
+    })),
   });
 
   const isFetching = userQueries.some(({ isFetching }) => isFetching);

--- a/client/src/app/queries/vulnerabilities.ts
+++ b/client/src/app/queries/vulnerabilities.ts
@@ -58,7 +58,7 @@ export const useFetchVulnerabilitiesByPackageIds = (ids: string[]) => {
           client,
           body: { purls: chunkIds },
         });
-        return response.data;
+        return response.data ?? null;
       },
       retry: false,
     })),

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,7 +44,6 @@ export default defineConfig([
       "@eslint-react/exhaustive-deps": "off",
       "@eslint-react/no-nested-component-definitions": "off",
       "@tanstack/query/prefer-query-options": "off",
-      "@tanstack/query/exhaustive-deps": "off",
       "@tanstack/query/no-void-query-fn": "off",
     },
     ignores: [


### PR DESCRIPTION
## Summary
- Enable the `@tanstack/query/exhaustive-deps` ESLint rule by fixing 4 violations and removing the `"off"` override
- **advisories.ts, sboms.ts, sbom-groups.ts**: Move `requestParamsQuery()` destructuring inside `queryFn` so `rest`/`q` are local variables instead of closured dependencies missing from `queryKey`
- **vulnerabilities.ts**: Inline the `analyzeV3` call directly in `queryFn`, eliminating the `chunks` object closure. Rename the iteration variable to `chunkIds` for clarity

Part of #1128 (PR 3 of 8). Depends on #1131.

## Test plan
- [x] `npm run lint` passes with zero errors
- [x] `npx tsc --noEmit` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable TanStack Query exhaustive-deps lint rule by updating query functions to avoid closures over undeclared dependencies.

Enhancements:
- Refactor vulnerabilities package ID query to chunk IDs locally and inline the analyzeV3 call per query.
- Adjust SBOM groups, SBOMs, and advisories queries so request parameter derivation occurs inside queryFn, matching queryKey dependencies.

Build:
- Remove the @tanstack/query/exhaustive-deps rule override from the ESLint configuration to enforce the rule project-wide.