### PR TITLE
chore: address auto merge in release/* branches

### DIFF
--- a/.github/workflows/auto-merge-openapi.yaml
+++ b/.github/workflows/auto-merge-openapi.yaml
@@ -166,9 +166,14 @@ jobs:
           EOF
           )"
 
-      - name: Enable auto-merge
+      - name: Merge PR
         env:
           GH_TOKEN: ${{ secrets.BOT_APPROVE_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          gh pr merge "$PR_NUMBER" --repo "${{ github.repository }}" --auto
+          if [ "$BASE_REF" = "main" ]; then
+            gh pr merge "$PR_NUMBER" --repo "${{ github.repository }}" --auto
+          else
+            gh pr merge "$PR_NUMBER" --repo "${{ github.repository }}" --squash
+          fi


### PR DESCRIPTION
## Summary
This PR makes sure the auto merge works in release/8 branches just like it already does in the main branch

Auto merge works fine for PRs that target the main branch but currently fails on release/* branches. E.g. https://github.com/guacsec/trustify-ui/pull/1129

The reason is that both main and release/* branches have different merge strategy, the main branch has the merge queue enabled while the release/* don't

## Summary by Sourcery

CI:
- Adjust auto-merge workflow to use merge queue on main and squash merges on non-main (e.g., release/*) branches.