### PR TITLE
fix: sbom Search by name instead of full search

### DIFF
--- a/client/src/app/pages/sbom-list/sbom-context.ts
+++ b/client/src/app/pages/sbom-list/sbom-context.ts
@@ -25,7 +25,7 @@ interface ISbomSearchContext {
     | "labels"
     | "vulnerabilities",
     "name" | "published",
-    "" | "published" | "labels" | "license",
+    "name" | "published" | "labels" | "license",
     string
   >;
 

--- a/client/src/app/pages/sbom-list/sbom-provider.tsx
+++ b/client/src/app/pages/sbom-list/sbom-provider.tsx
@@ -72,7 +72,7 @@ export const SbomSearchProvider: React.FunctionComponent<ISbomProvider> = ({
     isFilterEnabled: true,
     filterCategories: [
       {
-        categoryKey: FILTER_TEXT_CATEGORY_KEY,
+        categoryKey: "name",
         title: "Filter text",
         placeholderText: "Search",
         type: FilterType.search,

--- a/client/src/app/pages/search/components/SearchMenu.tsx
+++ b/client/src/app/pages/search/components/SearchMenu.tsx
@@ -63,6 +63,11 @@ function useAllEntities(filterText: string, disableSearch: boolean) {
     page: { pageNumber: 1, itemsPerPage: 5 },
   };
 
+  const sbomParams: HubRequestParams = {
+    filters: [{ field: "name", operator: "~", value: filterText }],
+    page: { pageNumber: 1, itemsPerPage: 5 },
+  };
+
   const {
     isFetching: isFetchingAdvisories,
     result: { data: advisories },
@@ -76,7 +81,7 @@ function useAllEntities(filterText: string, disableSearch: boolean) {
   const {
     isFetching: isFetchingSBOMs,
     result: { data: sboms },
-  } = useFetchSBOMs(null, { ...params }, [], disableSearch);
+  } = useFetchSBOMs(null, { ...sbomParams }, [], disableSearch);
 
   const {
     isFetching: isFetchingVulnerabilities,
@@ -170,8 +175,7 @@ export const SearchMenu: React.FC<ISearchMenu> = ({ onChangeSearch }) => {
   // (no useMemo in the useUrlParams → useFilterState → context chain), but the
   // extracted string only changes when the URL filter param actually changes.
   const appliedSearchValue =
-    sbomTableControls.filterState.filterValues[FILTER_TEXT_CATEGORY_KEY]?.[0] ??
-    "";
+    sbomTableControls.filterState.filterValues["name"]?.[0] ?? "";
 
   const [searchValue, setSearchValue] = React.useState("");
   const [isSearchValueDirty, setIsSearchValueDirty] = React.useState(false);

--- a/client/src/app/pages/search/components/SearchTabs.tsx
+++ b/client/src/app/pages/search/components/SearchTabs.tsx
@@ -48,7 +48,7 @@ export interface SearchTabsProps {
     >;
     sbomFilterPanelProps: IFilterPanelProps<
       SbomSummary,
-      "" | "published" | "labels" | "license"
+      "name" | "published" | "labels" | "license"
     >;
     vulnerabilityFilterPanelProps: IFilterPanelProps<
       VulnerabilitySummary,
@@ -117,7 +117,7 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
           <CardBody style={{ width: 241 }}>
             {isTabActive("sboms") ? (
               <FilterPanel
-                omitFilterCategoryKeys={[""]}
+                omitFilterCategoryKeys={["name"]}
                 {...sbomFilterPanelProps}
               />
             ) : isTabActive("packages") ? (

--- a/client/src/app/pages/search/search.tsx
+++ b/client/src/app/pages/search/search.tsx
@@ -92,7 +92,7 @@ export const Search: React.FC<SearchPageProps> = ({ searchBodyOverride }) => {
     if (searchValue === undefined) return;
     sbomTableControls.filterState.setFilterValues({
       ...sbomTableControls.filterState.filterValues,
-      [FILTER_TEXT_CATEGORY_KEY]: [searchValue],
+      ["name"]: [searchValue],
     });
     packageTableControls.filterState.setFilterValues({
       ...packageTableControls.filterState.filterValues,


### PR DESCRIPTION
## Summary
Fixes https://redhat.atlassian.net/browse/TC-5046

The Search page (/search) was sending SBOM API requests as:

```
  GET /api/v3/sbom?q=~INPUT_TEXT
```

  This performs a full-text search across all fields. As Requested in the jira linked above, for performance reasons we should change it to:

```
  GET /api/v3/sbom?q=name~INPUT_TEXT
```

  What changed

  - Main search submission: When the user types in the search bar and presses Enter, the SBOM endpoint now receives q=name~INPUT_TEXT instead of q=~INPUT_TEXT
  - Autocomplete dropdown: The real-time SBOM suggestions while typing also use q=name~INPUT_TEXT
  - Sidebar filter: The "Filter text" filter is hidden from the left sidebar on the SBOM tab, since the top search bar already handles it
  - Other tabs unaffected: Package, Vulnerability, and Advisory endpoints still use full-text search (q=~INPUT_TEXT) as before


## Related Issues
https://github.com/guacsec/trustify/issues/2440

## Summary by Sourcery

Update SBOM search to query by name instead of full-text and align UI filters with the new search behavior.

Bug Fixes:
- Change SBOM API queries on the search page and autocomplete to use a name-based filter instead of full-text search, addressing performance concerns.

Enhancements:
- Align SBOM table filter state and filter panel configuration with the new name-based search field, including updating filter keys and omitted categories.