### PR TITLE
perf: optimize API calls with total and limit query params

### DIFF
--- a/client/src/app/components/WithPackagesByLicense.tsx
+++ b/client/src/app/components/WithPackagesByLicense.tsx
@@ -18,7 +18,8 @@ export const WithPackagesByLicense: React.FC<WithPackagesByLicenseProps> = ({
 }) => {
   const { result, isFetching, fetchError } = useFetchPackages({
     filters: [{ field: "license", operator: "=", value: licenseId }],
-    page: { itemsPerPage: 1, pageNumber: 1 },
+    page: { itemsPerPage: 0, pageNumber: 1 },
+    total: true,
   });
 
   return <>{children(result?.total, isFetching, fetchError)}</>;

--- a/client/src/app/components/WithSBOMsByLicense.tsx
+++ b/client/src/app/components/WithSBOMsByLicense.tsx
@@ -20,7 +20,8 @@ export const WithSBOMsByLicense: React.FC<WithSBOMsByLicenseProps> = ({
     null,
     {
       filters: [{ field: "license", operator: "=", value: licenseId }],
-      page: { itemsPerPage: 1, pageNumber: 1 },
+      page: { itemsPerPage: 0, pageNumber: 1 },
+      total: true,
     },
     [],
   );

--- a/client/src/app/pages/home/components/WhatNeedsAttention.tsx
+++ b/client/src/app/pages/home/components/WhatNeedsAttention.tsx
@@ -39,6 +39,7 @@ const getLastSevenDaysRequestParams = (): HubRequestParams => {
   return {
     page: { pageNumber: 1, itemsPerPage: MAX_ATTENTION_ITEMS },
     sort: { field: "base_score", direction: "desc" },
+    total: false,
     filters: [
       {
         field: "published",

--- a/client/src/app/pages/search/components/SearchMenu.tsx
+++ b/client/src/app/pages/search/components/SearchMenu.tsx
@@ -61,11 +61,13 @@ function useAllEntities(filterText: string, disableSearch: boolean) {
       { field: FILTER_TEXT_CATEGORY_KEY, operator: "~", value: filterText },
     ],
     page: { pageNumber: 1, itemsPerPage: 5 },
+    total: false,
   };
 
   const sbomParams: HubRequestParams = {
     filters: [{ field: "name", operator: "~", value: filterText }],
     page: { pageNumber: 1, itemsPerPage: 5 },
+    total: false,
   };
 
   const {


### PR DESCRIPTION
## Summary

* **Fix bug** in `WithPackagesByLicense` and `WithSBOMsByLicense`: these components read `result.total` to display counts but never passed `total: true` to the server, so the count was always 0/undefined. Now requests `total: true` with `limit=0` (no items returned, only the count).
* **Skip unnecessary total computation** in `SearchMenu` autocomplete (4 concurrent API calls) and `WhatNeedsAttention` dashboard card by explicitly passing `total: false`.

## Details

The API supports two performance-relevant query params:
- `total=false` — skips the expensive count query when only items are needed
- `limit=0` with `total=true` — returns only the count without fetching any items

| File | Before | After |
|------|--------|-------|
| `WithPackagesByLicense.tsx` | `limit=1`, no `total` (bug: count always 0) | `limit=0`, `total=true` |
| `WithSBOMsByLicense.tsx` | `limit=1`, no `total` (bug: count always 0) | `limit=0`, `total=true` |
| `SearchMenu.tsx` | `total` omitted (4 autocomplete queries) | `total=false` |
| `WhatNeedsAttention.tsx` | `total` omitted | `total=false` |

## Test plan

- [ ] Verify license list page shows correct package and SBOM counts per license
- [ ] Verify search autocomplete still works and shows suggestions
- [ ] Verify home dashboard "Highest vulnerabilities" card renders correctly
- [ ] Verify home dashboard portfolio metrics (total SBOMs/Advisories) still display

🤖 Generated with [Claude Code](https://claude.com/claude-code)