### PR TITLE
feat: use PATCH endpoint for SBOM group assignment

### DIFF
--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -15,7 +15,7 @@ import {
   type IngestResult,
   type Labels,
   type SbomHead,
-  bulkUpdateSbomGroupAssignments,
+  patchSbomGroupAssignments,
   deleteSbom,
   downloadSbom,
   getSbom,
@@ -305,11 +305,11 @@ export const useAddSBOMsToGroupsMutation = (
   return useMutation({
     mutationFn: async (payload: { group: Group; sboms: SbomHead[] }) => {
       const { sboms, group } = payload;
-      const response = await bulkUpdateSbomGroupAssignments({
+      const response = await patchSbomGroupAssignments({
         client,
         body: {
-          group_ids: [group.id],
           sbom_ids: sboms.map((e) => e.id),
+          add: [group.id],
         },
       });
       return response.data;


### PR DESCRIPTION
## Summary

* Switch `useAddSBOMsToGroupsMutation` from the PUT bulk assignment endpoint to the new PATCH endpoint
* The PUT endpoint replaces all group assignments, so adding an SBOM to a new group removes it from previous groups
* The PATCH endpoint preserves existing assignments, only adding/removing the specified groups

Depends on: trustification/trustify#2450
Fixes: TC-5036

## Test plan

- [ ] Regenerate OpenAPI client after backend PR is merged
- [ ] Verify "Add to group" preserves existing group assignments
- [ ] Verify adding an SBOM to multiple groups works correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update SBOM group assignment client hook to call the PATCH endpoint with additive group IDs instead of the bulk replacement PUT endpoint.