### PR TITLE
fix: search packages by name

### DIFF
--- a/client/src/app/pages/package-list/package-context.ts
+++ b/client/src/app/pages/package-list/package-context.ts
@@ -22,7 +22,7 @@ interface IPackageSearchContext {
     | "qualifiers"
     | "vulnerabilities",
     "name" | "namespace" | "version",
-    "" | "type" | "arch" | "license",
+    "name" | "type" | "arch" | "license",
     string
   >;
 

--- a/client/src/app/pages/package-list/package-provider.tsx
+++ b/client/src/app/pages/package-list/package-provider.tsx
@@ -61,7 +61,7 @@ export const PackageSearchProvider: React.FunctionComponent<
     isFilterEnabled: true,
     filterCategories: [
       {
-        categoryKey: FILTER_TEXT_CATEGORY_KEY,
+        categoryKey: "name",
         title: "Filter text",
         placeholderText: "Search",
         type: FilterType.search,

--- a/client/src/app/pages/search/components/SearchMenu.tsx
+++ b/client/src/app/pages/search/components/SearchMenu.tsx
@@ -70,6 +70,12 @@ function useAllEntities(filterText: string, disableSearch: boolean) {
     total: false,
   };
 
+  const packageParams: HubRequestParams = {
+    filters: [{ field: "name", operator: "~", value: filterText }],
+    page: { pageNumber: 1, itemsPerPage: 5 },
+    total: false,
+  };
+
   const {
     isFetching: isFetchingAdvisories,
     result: { data: advisories },
@@ -78,7 +84,7 @@ function useAllEntities(filterText: string, disableSearch: boolean) {
   const {
     isFetching: isFetchingPackages,
     result: { data: packages },
-  } = useFetchPackages({ ...params }, disableSearch);
+  } = useFetchPackages({ ...packageParams }, disableSearch);
 
   const {
     isFetching: isFetchingSBOMs,

--- a/client/src/app/pages/search/components/SearchTabs.tsx
+++ b/client/src/app/pages/search/components/SearchTabs.tsx
@@ -44,7 +44,7 @@ export interface SearchTabsProps {
     >;
     packageFilterPanelProps: IFilterPanelProps<
       PackageTableData,
-      "" | "type" | "arch" | "license"
+      "name" | "type" | "arch" | "license"
     >;
     sbomFilterPanelProps: IFilterPanelProps<
       SbomSummary,
@@ -122,7 +122,7 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
               />
             ) : isTabActive("packages") ? (
               <FilterPanel
-                omitFilterCategoryKeys={[""]}
+                omitFilterCategoryKeys={["name"]}
                 {...packageFilterPanelProps}
               />
             ) : isTabActive("vulnerabilities") ? (

--- a/client/src/app/pages/search/search.tsx
+++ b/client/src/app/pages/search/search.tsx
@@ -96,7 +96,7 @@ export const Search: React.FC<SearchPageProps> = ({ searchBodyOverride }) => {
     });
     packageTableControls.filterState.setFilterValues({
       ...packageTableControls.filterState.filterValues,
-      [FILTER_TEXT_CATEGORY_KEY]: [searchValue],
+      ["name"]: [searchValue],
     });
     vulnerabilityTableControls.filterState.setFilterValues({
       ...vulnerabilityTableControls.filterState.filterValues,


### PR DESCRIPTION
## Summary
Fixes: https://redhat.atlassian.net/browse/TC-5096

Complement of https://github.com/guacsec/trustify-ui/pull/1134

The Search page (/search) was sending Package API requests as:

```
  GET /api/v3/purl?q=~INPUT_TEXT
```

  This performs a full-text search across all fields. As Requested in the jira linked above, for performance reasons we should change it to:

```
  GET /api/v3/purl?q=name~INPUT_TEXT
```

## Summary by Sourcery

Update package search to filter by package name instead of full-text search for improved performance and consistency across search views.

Bug Fixes:
- Restrict package search API requests to the name field to avoid expensive full-text queries and align with backend expectations.

Enhancements:
- Align package filter configuration and UI filter categories to use an explicit name filter key in search and package list pages.