### PR TITLE
fix(ci): resolve bot PR failures for commitlint and server build

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -2,6 +2,7 @@ name: Commitlint
 on: [pull_request]
 jobs:
   commitlint:
+    if: github.actor != 'trustify-ci-bot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -29,7 +29,7 @@ RUN sed -i 's/trustify-ui = { git = "https:\/\/github.com\/guacsec\/trustify-ui.
 FROM registry.access.redhat.com/ubi9/ubi:latest AS server-builder
 
 # Dependencies
-RUN dnf install -y openssl-devel gcc
+RUN dnf install -y openssl-devel gcc clang-libs
 
 RUN mkdir /stage/ && \
     dnf install --installroot /stage/ --setop install_weak_deps=false --nodocs -y zlib openssl && \


### PR DESCRIPTION
## Summary
* Skip commitlint for `trustify-ci-bot[bot]` PRs — the bot's merge/sign-off commits don't follow conventional commit format, causing spurious failures
* Add `clang-libs` to `Dockerfile.server` — the `bindgen` crate (v0.72.1) now requires `libclang.so` at build time

Fixes the CI failures on #1146.

## Test plan
- [ ] Re-run CI on #1146 after merge to confirm both checks pass
- [ ] Verify commitlint still runs on human-authored PRs

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Adjust CI to avoid commitlint failures on bot-authored pull requests and address server build dependencies.

Build:
- Update the server Dockerfile to include clang runtime libraries required for bindgen/libclang at build time.

CI:
- Add a commitlint GitHub Actions workflow that runs on pull requests but is skipped for the trustify-ci-bot[bot] user.