### PR TITLE
perf: use pre-fetched advisory severity summary on SBOM list [Backport release/0.5.z]

### DIFF
--- a/client/src/app/components/VulnerabilityGallery.tsx
+++ b/client/src/app/components/VulnerabilityGallery.tsx
@@ -8,15 +8,16 @@ import type { ExtendedSeverity } from "@app/api/models";
 import { SeverityShieldAndText } from "@app/components/SeverityShieldAndText";
 
 interface VulnerabilityGalleryProps {
-  severities: { [key in ExtendedSeverity]: number };
+  severities: Partial<{ [key in ExtendedSeverity]: number }>;
 }
 
 export const VulnerabilityGallery: React.FC<VulnerabilityGalleryProps> = ({
   severities,
 }) => {
-  const severityCount = Object.values(severities).reduce((prev, acc) => {
-    return prev + acc;
-  }, 0);
+  const severityCount = Object.values(severities).reduce(
+    (prev, acc) => prev + (acc ?? 0),
+    0,
+  );
 
   return (
     <Flex

--- a/client/src/app/pages/sbom-list/components/SbomVulnerabilities.tsx
+++ b/client/src/app/pages/sbom-list/components/SbomVulnerabilities.tsx
@@ -1,31 +1,12 @@
 import type React from "react";
 
-import { Skeleton } from "@patternfly/react-core";
-
-import { LoadingWrapper } from "@app/components/LoadingWrapper";
-import { TableCellError } from "@app/components/TableCellError";
+import type { RequestedFieldHashMapHashMap } from "@app/client";
 import { VulnerabilityGallery } from "@app/components/VulnerabilityGallery";
-import { useVulnerabilitiesOfSbom } from "@app/hooks/domain-controls/useVulnerabilitiesOfSbom";
 
 interface SBOMVulnerabilitiesProps {
-  sbomId: string;
+  advisories?: RequestedFieldHashMapHashMap;
 }
 
 export const SBOMVulnerabilities: React.FC<SBOMVulnerabilitiesProps> = ({
-  sbomId,
-}) => {
-  const { data, isFetching, fetchError } = useVulnerabilitiesOfSbom(sbomId);
-
-  return (
-    <LoadingWrapper
-      isFetching={isFetching}
-      fetchError={fetchError}
-      isFetchingState={<Skeleton screenreaderText="Loading contents" />}
-      fetchErrorState={(error) => <TableCellError error={error} />}
-    >
-      <VulnerabilityGallery
-        severities={data.summary.vulnerabilityStatus.affected.severities}
-      />
-    </LoadingWrapper>
-  );
-};
+  advisories,
+}) => <VulnerabilityGallery severities={advisories ?? {}} />;

--- a/client/src/app/pages/sbom-list/sbom-context.ts
+++ b/client/src/app/pages/sbom-list/sbom-context.ts
@@ -2,7 +2,11 @@ import React from "react";
 
 import type { AxiosError } from "axios";
 
-import type { SbomHead, SourceDocument } from "@app/client";
+import type {
+  RequestedFieldHashMapHashMap,
+  SbomHead,
+  SourceDocument,
+} from "@app/client";
 import type { BulkSelectionValues } from "@app/hooks/selection";
 import type { ITableControls } from "@app/hooks/table-controls";
 
@@ -16,6 +20,7 @@ interface ISbomSearchContext {
           name: string;
           version?: string | null;
         }>;
+        advisories?: RequestedFieldHashMapHashMap;
       },
     | "name"
     | "version"

--- a/client/src/app/pages/sbom-list/sbom-provider.tsx
+++ b/client/src/app/pages/sbom-list/sbom-provider.tsx
@@ -133,6 +133,8 @@ export const SbomSearchProvider: React.FunctionComponent<ISbomProvider> = ({
     (tableControlState.filterState.filterValues.labels ?? []).map((label) =>
       splitStringAsKeyValue(label),
     ),
+    false,
+    true,
   );
 
   const tableControls = useTableControlProps({

--- a/client/src/app/pages/sbom-list/sbom-table.tsx
+++ b/client/src/app/pages/sbom-list/sbom-table.tsx
@@ -219,7 +219,7 @@ export const SbomTable: React.FC = () => {
                       width={20}
                       {...getTdProps({ columnKey: "vulnerabilities" })}
                     >
-                      <SBOMVulnerabilities sbomId={item.id} />
+                      <SBOMVulnerabilities advisories={item.advisories} />
                     </Td>
                     <Td isActionCell>
                       <ActionsColumn

--- a/client/src/app/queries/sboms.ts
+++ b/client/src/app/queries/sboms.ts
@@ -61,12 +61,13 @@ export const useFetchSBOMs = (
   params: HubRequestParams = {},
   labels: Label[] = [],
   disableQuery = false,
+  advisories = false,
 ) => {
   const { q, ...rest } = requestParamsQuery(params);
   const labelQuery = labelRequestParamsQuery(labels);
 
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: [SBOMsQueryKey, groupId, params, labelQuery],
+    queryKey: [SBOMsQueryKey, groupId, params, labelQuery, advisories],
     queryFn: () =>
       listSboms({
         client,
@@ -74,6 +75,7 @@ export const useFetchSBOMs = (
           ...rest,
           group: groupId ? [groupId] : [],
           q: [q, labelQuery].filter((e) => e).join("&"),
+          advisories,
         },
       }),
     enabled: !disableQuery,


### PR DESCRIPTION
## Summary
- Backport of #1127 to `release/0.5.z`
- Uses pre-fetched advisory severity summary on the SBOM list page instead of fetching per-row, improving performance

Cherry-picked from fb9c2cf05c3d6442db377a885f9b03a03618d109

## Summary by Sourcery

Improve SBOM list performance by switching vulnerability display to use pre-fetched advisory severity summaries passed through the SBOM query and context, rather than fetching vulnerabilities individually for each SBOM row.

Enhancements:
- Use pre-fetched advisory severity summaries on the SBOM list instead of per-row vulnerability fetching to improve performance
- Propagate advisory summary data through SBOM search context, provider, and table to drive vulnerability displays
- Relax VulnerabilityGallery props to support partial severity maps and safely handle missing values