### PR TITLE
docs: add Playwright page object design conventions

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -307,6 +307,8 @@ When the backend OpenAPI spec changes:
 - Page Object Model pattern: each page has a class (e.g., `SbomListPage`) with a static `build()` factory, encapsulating navigation and element access
 - Shared page objects: `Table`, `Toolbar`, `Pagination`, `Navigation` in `e2e/tests/ui/pages/`
 - Tags for test tiers: `{ tag: "@tier1" }`
+- **No explicit timeouts in shared page objects:** Playwright provides automatic waiting for elements, assertions, and actions. Shared classes (`Table`, `Toolbar`, `Pagination`, `Navigation`) must not add explicit `timeout` parameters. If a component triggers async re-rendering, the wait belongs in that component's page object, not in shared infrastructure.
+- **Composition over conditional expansion:** Page object methods should do one thing. For example, `clearAllFilters()` clears filters — checking whether filters exist is the caller's responsibility. Do not add conditional guards inside action methods.
 - Run e2e: `npm run e2e:test:ui` (full), `npm run e2e:test:api` (API only)
 
 ## Commit Messages


### PR DESCRIPTION
## Summary

Add two E2E testing conventions to CONVENTIONS.md under the Playwright section:
- No explicit timeouts in shared page objects (Playwright auto-waiting handles element readiness)
- Composition over conditional expansion in page object methods (single responsibility)

Implements [TC-5191](https://redhat.atlassian.net/browse/TC-5191)

[TC-5191]: https://redhat.atlassian.net/browse/TC-5191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Document Playwright page object design conventions for shared UI components.

Documentation:
- Add guidance to avoid explicit timeouts in shared Playwright page objects and delegate async waits to page-specific objects.
- Clarify that page object methods should follow single-responsibility principles, favoring composition over conditional logic in action methods.