### PR TITLE
chore: convert /server to typescript and add tc checker to all package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf ./dist",
     "clean:all": "rimraf ./dist ./node_modules",
     "build": "npm run generate && vite build",
-    "lint": "eslint --max-warnings 0 .",
+    "lint": "eslint --max-warnings 0 . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "format": "prettier --check --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",
     "format:fix": "prettier --write --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",

--- a/common/package.json
+++ b/common/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "clean:all": "rimraf ./dist ./node_modules",
-    "lint": "eslint --max-warnings 0 .",
+    "lint": "eslint --max-warnings 0 . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "format": "prettier --check --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",
     "format:fix": "prettier --write --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "clean:all": "rimraf ./dist ./node_modules",
-    "lint": "eslint --max-warnings 0 .",
+    "lint": "eslint --max-warnings 0 . && tsc --noEmit",
     "lint:fix": "eslint . --fix",
     "format": "prettier --check --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",
     "format:fix": "prettier --write --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",

--- a/server/rollup.config.js
+++ b/server/rollup.config.js
@@ -2,6 +2,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import run from "@rollup/plugin-run";
+import typescript from "@rollup/plugin-typescript";
 
 const buildAndRun = process.env?.ROLLUP_RUN === "true";
 
@@ -20,6 +21,7 @@ export default {
   },
 
   plugins: [
+    typescript({ compilerOptions: { rootDir: "src", outDir: "dist" } }),
     nodeResolve({
       preferBuiltins: true,
     }),
@@ -27,7 +29,7 @@ export default {
     json(),
     buildAndRun &&
       run({
-        execArgv: ["-r", "source-map-support/register"],
+        execArgv: ["--enable-source-maps"],
       }),
   ],
 };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,7 +12,7 @@ import {
   brandingStrings,
   encodeEnv,
 } from "@trustify-ui/common";
-import { proxyMap } from "./proxies";
+import { proxyMap } from "./proxies.js";
 
 const debugMode = process.env.DEBUG === "1";
 if (debugMode) console.log("CONSOLE_ENV", TRUSTIFICATION_ENV);
@@ -65,7 +65,7 @@ const server = app.listen(port, (error) => {
 // Handle shutdown signals Ctrl-C (SIGINT) and default podman/docker stop (SIGTERM)
 const httpTerminator = createHttpTerminator({ server });
 
-const shutdown = async (signal) => {
+const shutdown = async (signal: string) => {
   if (!server) {
     console.log(`${signal}, no server running.`);
     return;

--- a/server/src/proxies.ts
+++ b/server/src/proxies.ts
@@ -1,3 +1,6 @@
+import type http from "node:http";
+import type { Options } from "http-proxy-middleware";
+
 import * as cookie from "cookie";
 import { TRUSTIFICATION_ENV } from "@trustify-ui/common";
 
@@ -10,7 +13,7 @@ const logger =
         error: console.error,
       };
 
-export const proxyMap = {
+export const proxyMap: Record<string, Options> = {
   ...(TRUSTIFICATION_ENV.OIDC_SERVER_IS_EMBEDDED === "true" && {
     auth: {
       pathFilter: "/auth",
@@ -18,25 +21,18 @@ export const proxyMap = {
       logger,
       changeOrigin: true,
       on: {
-        proxyReq: (proxyReq, req, _res) => {
-          // Keycloak needs these header set so we can function in Kubernetes (non-OpenShift)
-          // https://www.keycloak.org/server/reverseproxy
-          //
-          // Note, on OpenShift, this works as the haproxy implementation
-          // for the OpenShift route is setting these for us automatically
-          //
-          // We saw problems with including the below broke the OpenShift route
-          //  {"X-Forwarded-Proto", req.protocol} broke the OpenShift
-          //  {"X-Forwarded-Port", req.socket.localPort}
-          //  {"Forwarded", `for=${req.socket.remoteAddress};proto=${req.protocol};host=${req.headers.host}`}
-          // so we are not including even though they are customary
-          //
-          req.socket.remoteAddress &&
+        proxyReq: (
+          proxyReq: http.ClientRequest,
+          req: http.IncomingMessage,
+          _res: http.ServerResponse,
+        ) => {
+          if (req.socket.remoteAddress) {
             proxyReq.setHeader("X-Forwarded-For", req.socket.remoteAddress);
-          req.socket.remoteAddress &&
             proxyReq.setHeader("X-Real-IP", req.socket.remoteAddress);
-          req.headers.host &&
+          }
+          if (req.headers.host) {
             proxyReq.setHeader("X-Forwarded-Host", req.headers.host);
+          }
         },
       },
     },
@@ -47,14 +43,22 @@ export const proxyMap = {
     logger,
     changeOrigin: true,
     on: {
-      proxyReq: (proxyReq, req, _res) => {
+      proxyReq: (
+        proxyReq: http.ClientRequest,
+        req: http.IncomingMessage,
+        _res: http.ServerResponse,
+      ) => {
         const cookies = cookie.parse(req.headers.cookie ?? "");
         const bearerToken = cookies.keycloak_cookie;
         if (bearerToken && !req.headers.authorization) {
           proxyReq.setHeader("Authorization", `Bearer ${bearerToken}`);
         }
       },
-      proxyRes: (proxyRes, req, res) => {
+      proxyRes: (
+        proxyRes: http.IncomingMessage,
+        req: http.IncomingMessage,
+        res: http.ServerResponse,
+      ) => {
         if (
           !req.headers.accept?.includes("application/json") &&
           (proxyRes.statusCode === 401 ||

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,7 +9,6 @@
     "module": "node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,
-    "allowJs": true,
     "sourceMap": true
   }
 }


### PR DESCRIPTION
- Make the "/server" directory to use typescript instead of plan javascript
- Include `tsc --noEmit` into all package.json files to verify Typescript check during linting

## Summary by Sourcery

Convert the server codebase to TypeScript and integrate TypeScript compilation into the build and lint workflow.

Enhancements:
- Add TypeScript typing to the server proxy configuration and request handlers.
- Update the server Rollup configuration to compile TypeScript sources and use modern source map flags.

Build:
- Enable TypeScript support in the server Rollup build via @rollup/plugin-typescript.

CI:
- Extend lint scripts in client, common, and server packages to run `tsc --noEmit` for type-checking.