### PR TITLE
chore: use tsconfig.app.json in client ts check

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf ./dist",
     "clean:all": "rimraf ./dist ./node_modules",
     "build": "npm run generate && vite build",
-    "lint": "eslint --max-warnings 0 . && tsc --noEmit",
+    "lint": "eslint --max-warnings 0 . && tsc --noEmit -p tsconfig.app.json",
     "lint:fix": "eslint . --fix",
     "format": "prettier --check --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",
     "format:fix": "prettier --write --ignore-path ../.prettierignore './src/**/*.{ts,tsx,js,json}'",

--- a/client/src/app/Constants.ts
+++ b/client/src/app/Constants.ts
@@ -1,5 +1,5 @@
 import type { AxiosError } from "axios";
-import type { AdvisorySummary, SbomHead } from "./client";
+import type { AdvisoryHead, AdvisorySummary, SbomHead } from "./client";
 import ENV from "./env";
 
 export const FILTER_TEXT_CATEGORY_KEY = "";
@@ -91,7 +91,7 @@ export const sbomDeletedSuccessMessage = (sbom: SbomHead) =>
 export const sbomDeletedErrorMessage = (_error: AxiosError) =>
   "Error occurred while deleting the SBOM";
 
-export const advisoryDeletedSuccessMessage = (sbom: AdvisorySummary) =>
+export const advisoryDeletedSuccessMessage = (sbom: AdvisoryHead) =>
   `The Advisory ${sbom.document_id} was deleted`;
 
 export const advisoryDeletedErrorMessage = (_error: AxiosError) =>

--- a/client/src/app/pages/advisory-details/advisory-details.tsx
+++ b/client/src/app/pages/advisory-details/advisory-details.tsx
@@ -33,7 +33,7 @@ import {
 } from "@app/Constants";
 import { PathParam, Paths, useRouteParams } from "@app/Routes";
 import { ExtendedSeverity } from "@app/api/models";
-import { type AdvisorySummary } from "@app/client";
+import { AdvisoryHead } from "@app/client";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { DocumentMetadata } from "@app/components/DocumentMetadata";
 import { LoadingWrapper } from "@app/components/LoadingWrapper";
@@ -100,7 +100,7 @@ export const AdvisoryDetails: React.FC = () => {
   // Delete action
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
 
-  const onDeleteAdvisorySuccess = (advisory: AdvisorySummary) => {
+  const onDeleteAdvisorySuccess = (advisory: AdvisoryHead) => {
     setIsDeleteDialogOpen(false);
     pushNotification({
       title: advisoryDeletedSuccessMessage(advisory),
@@ -401,7 +401,7 @@ export const AdvisoryDetails: React.FC = () => {
         onClose={() => setIsDeleteDialogOpen(false)}
         onConfirm={() => {
           if (advisory) {
-            deleteAdvisory(advisory.uuid);
+            deleteAdvisory(advisory);
           }
         }}
       />

--- a/client/src/app/pages/advisory-list/advisory-table.tsx
+++ b/client/src/app/pages/advisory-list/advisory-table.tsx
@@ -24,7 +24,7 @@ import {
   type ExtendedSeverity,
   extendedSeverityFromSeverity,
 } from "@app/api/models";
-import type { AdvisorySummary } from "@app/client";
+import type { AdvisoryHead, AdvisorySummary } from "@app/client";
 import { ConfirmDialog } from "@app/components/ConfirmDialog.tsx";
 import { LabelsAsList } from "@app/components/LabelsAsList.tsx";
 import { NotificationsContext } from "@app/components/NotificationsContext";
@@ -83,7 +83,7 @@ export const AdvisoryTable: React.FC = () => {
   const [advisoryToDelete, setAdvisoryToDelete] =
     React.useState<AdvisorySummary | null>(null);
 
-  const onDeleteAdvisorySuccess = (advisory: AdvisorySummary) => {
+  const onDeleteAdvisorySuccess = (advisory: AdvisoryHead) => {
     setAdvisoryToDelete(null);
     pushNotification({
       title: `The Advisory ${advisory.identifier} was deleted`,
@@ -284,7 +284,7 @@ export const AdvisoryTable: React.FC = () => {
         onClose={() => setAdvisoryToDelete(null)}
         onConfirm={() => {
           if (advisoryToDelete) {
-            deleteAdvisory(advisoryToDelete.uuid);
+            deleteAdvisory(advisoryToDelete);
           }
         }}
       />

--- a/client/src/app/pages/advisory-upload/advisory-upload.tsx
+++ b/client/src/app/pages/advisory-upload/advisory-upload.tsx
@@ -22,7 +22,7 @@ import { Paths } from "@app/Routes";
 import { getAxiosErrorMessage } from "@app/utils/utils";
 
 export const AdvisoryUpload: React.FC = () => {
-  const { isReadOnly } = React.useContext(ReadOnlyContext);
+  const { areMutationsDisabled } = React.useContext(ReadOnlyContext);
   const { uploads, handleUpload, handleRemoveUpload } = useUploadAdvisory();
 
   return (
@@ -36,7 +36,7 @@ export const AdvisoryUpload: React.FC = () => {
           <BreadcrumbItem isActive>Upload Advisory</BreadcrumbItem>
         </Breadcrumb>
       </PageSection>
-      {isReadOnly ? (
+      {areMutationsDisabled ? (
         <PageSection>
           <EmptyState
             headingLevel="h1"

--- a/client/src/app/pages/home/components/WhatNeedsAttention.tsx
+++ b/client/src/app/pages/home/components/WhatNeedsAttention.tsx
@@ -114,7 +114,7 @@ export const VulnerabilityAttentionSection: React.FC = () => {
                                   default: "justifyContentSpaceBetween",
                                 }}
                                 spaceItems={{ default: "spaceItemsSm" }}
-                                wrap={{ default: "wrap" }}
+                                flexWrap={{ default: "wrap" }}
                               >
                                 <FlexItem>
                                   <SeverityShieldAndText

--- a/client/src/app/pages/importer-list/importer-list.tsx
+++ b/client/src/app/pages/importer-list/importer-list.tsx
@@ -36,10 +36,7 @@ import {
   type ConfirmDialogProps,
 } from "@app/components/ConfirmDialog";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import {
-  readOnlyActionProps,
-  ReadOnlyContext,
-} from "@app/components/ReadOnlyContext";
+import { ReadOnlyContext } from "@app/components/ReadOnlyContext";
 import {
   useFetchImporterReports,
   useFetchImporters,

--- a/client/src/app/pages/package-details/package-details.tsx
+++ b/client/src/app/pages/package-details/package-details.tsx
@@ -47,10 +47,10 @@ export const PackageDetails: React.FC = () => {
     tabKeys: ["vulnerabilities", "sboms"],
   });
 
-  const vulnerabilitiesTabRef = React.useRef<HTMLElement>();
-  const sbomsTabRef = React.useRef<HTMLElement>();
+  const vulnerabilitiesTabRef = React.useRef<HTMLElement>(null);
+  const sbomsTabRef = React.useRef<HTMLElement>(null);
 
-  const sbomsPopupRef = React.useRef<HTMLElement>();
+  const sbomsPopupRef = React.useRef<HTMLElement>(null);
 
   return (
     <>

--- a/client/src/app/pages/sbom-details/sbom-details.tsx
+++ b/client/src/app/pages/sbom-details/sbom-details.tsx
@@ -100,13 +100,13 @@ export const SbomDetails: React.FC = () => {
     tabKeys: ["info", "packages", "vulnerabilities", "models"],
   });
 
-  const infoTabRef = React.useRef<HTMLElement>();
-  const packagesTabRef = React.useRef<HTMLElement>();
-  const vulnerabilitiesTabRef = React.useRef<HTMLElement>();
-  const modelsTabRef = React.useRef<HTMLElement>();
+  const infoTabRef = React.useRef<HTMLElement>(null);
+  const packagesTabRef = React.useRef<HTMLElement>(null);
+  const vulnerabilitiesTabRef = React.useRef<HTMLElement>(null);
+  const modelsTabRef = React.useRef<HTMLElement>(null);
 
   // Tabs popover refs
-  const vulnerabilitiesTabPopoverRef = React.useRef<HTMLElement>();
+  const vulnerabilitiesTabPopoverRef = React.useRef<HTMLElement>(null);
 
   return (
     <>

--- a/client/src/app/pages/sbom-list/sbom-table.tsx
+++ b/client/src/app/pages/sbom-list/sbom-table.tsx
@@ -20,10 +20,7 @@ import type { SbomHead } from "@app/client";
 import { ConfirmDialog } from "@app/components/ConfirmDialog";
 import { LabelsAsList } from "@app/components/LabelsAsList";
 import { NotificationsContext } from "@app/components/NotificationsContext";
-import {
-  readOnlyActionProps,
-  ReadOnlyContext,
-} from "@app/components/ReadOnlyContext";
+import { ReadOnlyContext } from "@app/components/ReadOnlyContext";
 import { SimplePagination } from "@app/components/SimplePagination";
 import {
   ConditionalTableBody,

--- a/client/src/app/pages/sbom-list/sbom-toolbar.tsx
+++ b/client/src/app/pages/sbom-list/sbom-toolbar.tsx
@@ -6,17 +6,13 @@ import {
   Toolbar,
   ToolbarContent,
   ToolbarItem,
-  Tooltip,
 } from "@patternfly/react-core";
 
 import type { Group } from "@app/client";
 import { FilterToolbar } from "@app/components/FilterToolbar";
 import { KebabDropdown } from "@app/components/KebabDropdown";
 import { ReadOnlyButton } from "@app/components/ReadOnlyButton";
-import {
-  READ_ONLY_TOOLTIP,
-  ReadOnlyContext,
-} from "@app/components/ReadOnlyContext";
+import { ReadOnlyContext } from "@app/components/ReadOnlyContext";
 import { SimplePagination } from "@app/components/SimplePagination";
 import { ToolbarBulkSelector } from "@app/components/ToolbarBulkSelector";
 import { Paths } from "@app/Routes";

--- a/client/src/app/pages/sbom-upload/sbom-upload.tsx
+++ b/client/src/app/pages/sbom-upload/sbom-upload.tsx
@@ -22,7 +22,7 @@ import { Paths } from "@app/Routes";
 import { getAxiosErrorMessage } from "@app/utils/utils";
 
 export const SbomUpload: React.FC = () => {
-  const { isReadOnly } = React.useContext(ReadOnlyContext);
+  const { areMutationsDisabled } = React.useContext(ReadOnlyContext);
   const { uploads, handleUpload, handleRemoveUpload } = useUploadSBOM();
 
   return (
@@ -36,7 +36,7 @@ export const SbomUpload: React.FC = () => {
           <BreadcrumbItem isActive>Upload SBOM</BreadcrumbItem>
         </Breadcrumb>
       </PageSection>
-      {isReadOnly ? (
+      {areMutationsDisabled ? (
         <PageSection>
           <EmptyState
             headingLevel="h1"

--- a/client/src/app/pages/search/components/SearchTabs.tsx
+++ b/client/src/app/pages/search/components/SearchTabs.tsx
@@ -105,10 +105,10 @@ export const SearchTabs: React.FC<SearchTabsProps> = ({
     tabKeys: ["sboms", "packages", "vulnerabilities", "advisories"],
   });
 
-  const sbomPopoverRef = React.useRef<HTMLElement>();
-  const packagePopoverRef = React.useRef<HTMLElement>();
-  const vulnerabilityPopoverRef = React.useRef<HTMLElement>();
-  const advisoryPopoverRef = React.useRef<HTMLElement>();
+  const sbomPopoverRef = React.useRef<HTMLElement>(null);
+  const packagePopoverRef = React.useRef<HTMLElement>(null);
+  const vulnerabilityPopoverRef = React.useRef<HTMLElement>(null);
+  const advisoryPopoverRef = React.useRef<HTMLElement>(null);
 
   return (
     <Split hasGutter>

--- a/client/src/app/pages/vulnerability-details/vulnerability-details.tsx
+++ b/client/src/app/pages/vulnerability-details/vulnerability-details.tsx
@@ -51,8 +51,8 @@ export const VulnerabilityDetails: React.FC = () => {
     tabKeys: ["sboms", "advisories"],
   });
 
-  const sbomsTabRef = React.useRef<HTMLElement>();
-  const advisoriesTabRef = React.useRef<HTMLElement>();
+  const sbomsTabRef = React.useRef<HTMLElement>(null);
+  const advisoriesTabRef = React.useRef<HTMLElement>(null);
 
   return (
     <>

--- a/client/src/app/queries/advisories.ts
+++ b/client/src/app/queries/advisories.ts
@@ -10,6 +10,7 @@ import type { HubRequestParams, Label } from "@app/api/models";
 import { client } from "@app/axios-config/apiInit";
 import {
   type AdvisoryDetails,
+  AdvisoryHead,
   type Labels,
   deleteAdvisory,
   downloadAdvisory,
@@ -107,17 +108,16 @@ export const useFetchAdvisoryById = (id: string) => {
 };
 
 export const useDeleteAdvisoryMutation = (
-  onSuccess: (payload: AdvisoryDetails, id: string) => void,
+  onSuccess: (payload: AdvisoryHead) => void,
   onError: (err: AxiosError) => void,
 ) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (id: string) => {
-      const response = await deleteAdvisory({ client, path: { key: id } });
-      return response.data as AdvisoryDetails;
+    mutationFn: async (payload: AdvisoryHead) => {
+      await deleteAdvisory({ client, path: { key: payload.uuid } });
     },
-    onSuccess: async (response, id) => {
-      onSuccess(response, id);
+    onSuccess: async (_response, payload) => {
+      onSuccess(payload);
       await queryClient.invalidateQueries({ queryKey: [AdvisoriesQueryKey] });
     },
     onError: async (err: AxiosError) => {


### PR DESCRIPTION
## Summary
- `client/package.json` now uses `-p tsconfig.app.json` otherwise the typescript checks in the client won't be triggered
- After enabling the option above some typescript checks were raised hence fixing them in this PR.

## Summary by Sourcery

Strengthen client-side TypeScript linting by targeting tsconfig.app.json and fix resulting type and layout issues across advisory flows, upload/read-only handling, ref initialization, and home page layout.

Bug Fixes:
- Align advisory deletion flows and success messaging with the AdvisoryHead type to satisfy stricter TypeScript checks.
- Initialize React ref hooks with explicit null defaults to resolve TypeScript strictness issues.
- Update read-only handling in upload and list pages to use the areMutationsDisabled flag instead of removed helpers and props.
- Correct layout props in the home attention section to use the flexWrap prop expected by the Flex component.

Enhancements:
- Tighten client linting by running TypeScript checks against tsconfig.app.json.
- Simplify ReadOnlyContext usage across SBOM and importer list components by removing unused tooltip and helper imports.

Build:
- Update the client lint script to run tsc with tsconfig.app.json for type checking.