### PR TITLE
chore(lint): enable @typescript-eslint/no-unused-vars

### DIFF
--- a/e2e/tests/ui/pages/utils.ts
+++ b/e2e/tests/ui/pages/utils.ts
@@ -17,27 +17,27 @@ export type FilterValueType<TFilter extends Record<string, TFilterValue>> = {
 export function isStringFilter<
   K extends string,
   T extends Record<K, TFilterValue>,
->(type: T[K], value: unknown): value is string {
+>(type: T[K], _value: unknown): _value is string {
   return type === "string";
 }
 
 export function isDateRangeFilter<
   K extends string,
   T extends Record<K, TFilterValue>,
->(type: T[K], value: unknown): value is TDateRange {
+>(type: T[K], _value: unknown): _value is TDateRange {
   return type === "dateRange";
 }
 
 export function isMultiSelectFilter<
   K extends string,
   T extends Record<K, TFilterValue>,
->(type: T[K], value: unknown): value is TMultiValue {
+>(type: T[K], _value: unknown): _value is TMultiValue {
   return type === "multiSelect";
 }
 
 export function isTypeaheadFilter<
   K extends string,
   T extends Record<K, TFilterValue>,
->(type: T[K], value: unknown): value is TMultiValue {
+>(type: T[K], _value: unknown): _value is TMultiValue {
   return type === "typeahead";
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,7 +38,15 @@ export default defineConfig([
       "@eslint-react/no-context-provider": "off",
       "@eslint-react/naming-convention-ref-name": "off",
       "@eslint-react/no-array-index-key": "off",
-      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
       "@eslint-react/exhaustive-deps": "off",
       "@tanstack/query/prefer-query-options": "off",
     },


### PR DESCRIPTION
## Summary

- Re-enables `@typescript-eslint/no-unused-vars` in `eslint.config.mjs` with standard `^_` ignore patterns for intentionally unused bindings (`argsIgnorePattern`, `varsIgnorePattern`, `caughtErrorsIgnorePattern`, `ignoreRestSiblings`).
- Fixes the remaining violations in `e2e/tests/ui/pages/utils.ts` by renaming type-guard parameters from `value` to `_value`.

Partially addresses https://github.com/guacsec/trustify-ui/issues/1128 — this is Phase 1 of the incremental ESLint rule re-enablement tracked in that issue (PR 6 in the issue sequence).

## Test plan

- [x] `npx eslint --max-warnings 0 client common e2e server`
- [ ] `npm run lint` (full workspace lint + typecheck)


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Enable TypeScript ESLint unused variable checks and adjust existing type guard utilities to comply with the rule.

Enhancements:
- Configure @typescript-eslint/no-unused-vars with ignore patterns for intentionally unused arguments, variables, and caught errors.
- Update UI E2E page filter type guard functions to mark unused value parameters as intentionally ignored.