### PR TITLE
Resource Optimization: Optimize PatternFly CSS bundle size

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "@patternfly/react-tokens": "^6.4.0",
     "@tanstack/react-query": "^5.90.11",
     "@tanstack/react-query-devtools": "^5.61.0",
+    "@tsd-ui/core": "^0.3.2",
     "axios": "^1.16.0",
     "dayjs": "^1.11.18",
     "echarts": "^6.1.0",
@@ -43,7 +44,6 @@
     "react-markdown": "^8.0.7",
     "react-oidc-context": "^3.3.0",
     "react-router-dom": "^7.8.1",
-    "@tsd-ui/core": "^0.3.2",
     "usehooks-ts": "^3.1.1",
     "victory": "^37.3.4",
     "yup": "^0.32.11"
@@ -58,6 +58,7 @@
     "@vitejs/plugin-react": "^5.1.4",
     "jsdom": "^28.0.0",
     "json-schema-to-typescript": "^15.0.4",
+    "purgecss": "^8.0.0",
     "vite": "^8.1.2",
     "vite-plugin-ejs": "^2.0.0",
     "vite-plugin-istanbul": "^9.0.1",

--- a/client/plugins/vite-plugin-purgecss.ts
+++ b/client/plugins/vite-plugin-purgecss.ts
@@ -26,8 +26,6 @@ export function purgeCSSPlugin(options: PurgeCSSPluginOptions = {}): Plugin {
         .map((asset) => asset.source as string)
         .join("\n");
 
-      const rawContent = jsContent + "\n" + htmlContent;
-
       const cssAssets = Object.entries(bundle).filter(
         ([key, asset]) =>
           key.endsWith(".css") &&
@@ -37,7 +35,10 @@ export function purgeCSSPlugin(options: PurgeCSSPluginOptions = {}): Plugin {
 
       for (const [, asset] of cssAssets) {
         const purged = await new PurgeCSS().purge({
-          content: [{ raw: rawContent, extension: "js" }],
+          content: [
+            { raw: jsContent, extension: "js" },
+            { raw: htmlContent, extension: "html" },
+          ],
           css: [{ raw: asset.source as string }],
           safelist: {
             standard: options.safelist ?? [],

--- a/client/plugins/vite-plugin-purgecss.ts
+++ b/client/plugins/vite-plugin-purgecss.ts
@@ -1,0 +1,54 @@
+import type { Plugin, Rollup } from "vite";
+import { PurgeCSS } from "purgecss";
+
+interface PurgeCSSPluginOptions {
+  safelist?: (string | RegExp)[];
+}
+
+export function purgeCSSPlugin(options: PurgeCSSPluginOptions = {}): Plugin {
+  return {
+    name: "vite-plugin-purgecss",
+    apply: "build",
+    enforce: "post",
+
+    async generateBundle(_, bundle) {
+      const jsContent = Object.values(bundle)
+        .filter((asset): asset is Rollup.OutputChunk => asset.type === "chunk")
+        .map((chunk) => chunk.code)
+        .join("\n");
+
+      const htmlContent = Object.values(bundle)
+        .filter(
+          (asset): asset is Rollup.OutputAsset =>
+            asset.type === "asset" && typeof asset.source === "string",
+        )
+        .filter((asset) => asset.fileName.endsWith(".html"))
+        .map((asset) => asset.source as string)
+        .join("\n");
+
+      const rawContent = jsContent + "\n" + htmlContent;
+
+      const cssAssets = Object.entries(bundle).filter(
+        ([key, asset]) =>
+          key.endsWith(".css") &&
+          asset.type === "asset" &&
+          typeof asset.source === "string",
+      ) as [string, Rollup.OutputAsset][];
+
+      for (const [, asset] of cssAssets) {
+        const purged = await new PurgeCSS().purge({
+          content: [{ raw: rawContent, extension: "js" }],
+          css: [{ raw: asset.source as string }],
+          safelist: {
+            standard: options.safelist ?? [],
+            deep: [/^pf-t--/],
+          },
+        });
+
+        if (purged.length > 0) {
+          asset.source = purged[0].css;
+        }
+      }
+    },
+  };
+}

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -14,5 +14,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts", "test-setup.ts"]
+  "include": ["vite.config.ts", "test-setup.ts", "plugins/**/*.ts"]
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -17,6 +17,8 @@ import {
   encodeEnv,
 } from "@trustify-ui/common";
 
+import { purgeCSSPlugin } from "./plugins/vite-plugin-purgecss";
+
 const require = createRequire(import.meta.url);
 export const brandingAssetPath = () =>
   require
@@ -30,6 +32,9 @@ const faviconPath = path.resolve(brandingPath, "favicon.ico");
 export default defineConfig({
   plugins: [
     react(),
+    purgeCSSPlugin({
+      safelist: [/^pf-v6-u-/, "pf-v6-c-content", "pf-v6-c-icon"],
+    }),
     ...(process.env.COVERAGE === "true"
       ? [
           istanbul({

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
         "@vitejs/plugin-react": "^5.1.4",
         "jsdom": "^28.0.0",
         "json-schema-to-typescript": "^15.0.4",
+        "purgecss": "^8.0.0",
         "vite": "^8.1.2",
         "vite-plugin-ejs": "^2.0.0",
         "vite-plugin-istanbul": "^9.0.1",
@@ -5212,6 +5213,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/cssstyle": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
@@ -9659,6 +9673,20 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
@@ -9836,6 +9864,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/purgecss": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-8.0.0.tgz",
+      "integrity": "sha512-QFJyps9y5oHeXnNA3Ql1EaAqWBivNwQn19Pw1lt9RxfB+4e+bIyqCyuombk79D6Fxe+lPXggVfI1WtRGEBwgbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "fast-glob": "^3.3.2",
+        "postcss": "^8.4.47",
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "bin": {
+        "purgecss": "bin/purgecss.js"
+      }
+    },
+    "node_modules/purgecss/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/qs": {


### PR DESCRIPTION
## Summary
Implemented Purge CSS plugin

## Related Issues
Relates to [TC-5105](https://redhat.atlassian.net/browse/TC-5105)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] Other (describe below)

## Testing
- [ ] All tests pass (`npm test`)
- [ ] No lint errors (`npm run lint`)
- [ ] No type errors (TypeScript compiles cleanly)
- [ ] New/changed UI behavior visually verified in browser
- [ ] Mock data updated if API types changed

## Screenshots

Bundle size before plugin:
<img width="606" height="103" alt="Screenshot 2026-07-17 at 12 58 39" src="https://github.com/user-attachments/assets/9ea32994-58bd-4517-a379-f58ca1be4b38" />

Bundle size after plugin:
<img width="582" height="100" alt="Screenshot 2026-07-17 at 12 59 59" src="https://github.com/user-attachments/assets/bb9dbf70-23f2-4f2e-869d-209eb1cc6dc2" />


[TC-5105]: https://redhat.atlassian.net/browse/TC-5105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Integrate a PurgeCSS-based Vite plugin to reduce the built CSS bundle size while preserving necessary PatternFly classes.

New Features:
- Add a custom Vite PurgeCSS plugin that strips unused CSS from build outputs and safelists required PatternFly utility and component classes.

Enhancements:
- Wire the PurgeCSS plugin into the client Vite configuration for production builds to optimize CSS bundle size.
- Add PurgeCSS as a dev dependency and clean up the placement of the @tsd-ui/core dependency in the client package manifest.