### PR TITLE
chore: add github test for Dockerfile.server

### DIFF
--- a/.github/workflows/ci-server-image-build.yaml
+++ b/.github/workflows/ci-server-image-build.yaml
@@ -1,0 +1,45 @@
+name: CI (test server image build)
+
+on:
+  pull_request:
+    branches:
+      - "main"
+      - "release/*"
+    paths:
+      - "Dockerfile.server"
+
+  schedule:
+    - cron: "35 5 * * *"
+
+  workflow_dispatch:
+
+jobs:
+  discover-envs:
+    runs-on: ubuntu-latest
+    outputs:
+      server_branch: ${{ steps.set-outputs.outputs.server_branch }}
+    steps:
+      - name: Extract server branch from PR target
+        id: set-outputs
+        env:
+          base_ref: ${{ github.event.pull_request.base.ref || github.ref }}
+        run: |
+          branch=$(echo "${base_ref#refs/heads/}")
+          echo "server_branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "Server branch: $branch"
+
+  test-server-image-build:
+    runs-on: ubuntu-latest
+    needs: discover-envs
+
+    concurrency:
+      group: test-server-image-build-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Test build server image
+        run: |
+          docker build . -t trustd:pr-test -f Dockerfile.server \
+            --build-arg server_branch=${{ needs.discover-envs.outputs.server_branch }}

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -29,7 +29,7 @@ RUN sed -i 's/trustify-ui = { git = "https:\/\/github.com\/guacsec\/trustify-ui.
 FROM registry.access.redhat.com/ubi10/ubi:latest AS server-builder
 
 # Dependencies
-RUN dnf install -y openssl-devel gcc clang-libs
+RUN dnf install -y openssl-devel gcc clang
 
 RUN mkdir /stage/ && \
     dnf install --installroot /stage/ --setop install_weak_deps=false --nodocs -y zlib openssl krb5-libs libzstd lz4-libs libxml2 && \

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Trustify UI Component
 
 # Build and Test Status
 
-| branch | last merge CI | last merge image build | nightly CI |
-| :----- | :------------ | :--------------------- | :--------- |
-| main   | [![CI (repo level)](https://github.com/guacsec/trustify-ui/actions/workflows/ci-repo.yaml/badge.svg?branch=main&event=push)](https://github.com/guacsec/trustify-ui/actions/workflows/ci-repo.yaml?query=branch%3Amain+event%3Apush)           | [![Multiple Architecture Image Build](https://github.com/guacsec/trustify-ui/actions/workflows/image-build.yaml/badge.svg?branch=main&event=push)](https://github.com/guacsec/trustify-ui/actions/workflows/image-build.yaml?query=branch%3Amain+event%3Apush)                    | [![Nightly CI (repo level @main)](https://github.com/guacsec/trustify-ui/actions/workflows/nightly-ci-repo.yaml/badge.svg?branch=main&event=schedule)](https://github.com/guacsec/trustify-ui/actions/workflows/nightly-ci-repo.yaml?query=branch%3Amain+event%3Aschedule)       |
+| branch | last merge CI | last merge image build | nightly CI | nightly server build |
+| :----- | :------------ | :--------------------- | :--------- | :------------------- |
+| main   | [![CI (repo level)](https://github.com/guacsec/trustify-ui/actions/workflows/ci-repo.yaml/badge.svg?branch=main&event=push)](https://github.com/guacsec/trustify-ui/actions/workflows/ci-repo.yaml?query=branch%3Amain+event%3Apush)           | [![Multiple Architecture Image Build](https://github.com/guacsec/trustify-ui/actions/workflows/image-build.yaml/badge.svg?branch=main&event=push)](https://github.com/guacsec/trustify-ui/actions/workflows/image-build.yaml?query=branch%3Amain+event%3Apush)                    | [![Nightly CI (repo level @main)](https://github.com/guacsec/trustify-ui/actions/workflows/nightly-ci-repo.yaml/badge.svg?branch=main&event=schedule)](https://github.com/guacsec/trustify-ui/actions/workflows/nightly-ci-repo.yaml?query=branch%3Amain+event%3Aschedule)       | [![CI (test server image build)](https://github.com/guacsec/trustify-ui/actions/workflows/ci-server-image-build.yaml/badge.svg?branch=main&event=schedule)](https://github.com/guacsec/trustify-ui/actions/workflows/ci-server-image-build.yaml?query=branch%3Amain+event%3Aschedule) |
 
 | branch | last merge e2e CI | nightly e2e CI |
 | :----- | :---------------- | :------------- |


### PR DESCRIPTION
## Summary
- Fix `Dockerfile.server` as it was failing in https://github.com/guacsec/trustify-ui/pull/1164
- Add a new github workflow to continuously test the Dockerfile.server so we catch any error early

## Summary by Sourcery

Add automated verification of the server Docker image build and document its status.

New Features:
- Introduce a GitHub Actions workflow to test building the server Docker image on pull requests and on a nightly schedule.

Enhancements:
- Update the server Dockerfile to ensure it builds successfully for the configured server branch.

CI:
- Add a CI workflow that discovers the target server branch and runs a Docker build using Dockerfile.server for validation.

Documentation:
- Extend the README build status table with a badge showing the nightly server image build workflow status.