### PR TITLE
test(e2e): add tests for page title updates, upload route, and search button visibility (#1149)

### DIFF
--- a/e2e/tests/ui/features/@page-title/verify-page-title.feature
+++ b/e2e/tests/ui/features/@page-title/verify-page-title.feature
@@ -1,0 +1,36 @@
+Feature: Page Title Updates
+	As a user
+	I want the browser page title to change based on the page I'm viewing
+	So that I can distinguish between multiple tabs and use browser history effectively
+
+# Related to TC-3370: Page title does not change based on viewed page
+# The ensures page titles update when navigating to different pages
+
+# Verify page titles for main application pages
+Scenario Outline: Verify page title changes when navigating to <page> page
+	When User navigates to "<page>" page
+	Then the page title should contain "<expectedTitle>"
+
+	Examples:
+		| page            | expectedTitle   |
+		| Dashboard       | Home            |
+		| Search          | Search          |
+		| All SBOMs       | SBOMs           |
+		| Advisories      | Advisories      |
+		| Vulnerabilities | Vulnerabilities |
+		| Packages        | Packages        |
+		| Importers       | Importers       |
+
+# Note: Tabs within the Search page all show "Search" in the title
+# because you're still on the Search page - just viewing different result types
+Scenario Outline: Verify page title remains "Search" when switching to <tabName> tab
+	When User navigates to "Search" page
+	And User clicks on "<tabName>" tab
+	Then the page title should contain "Search"
+
+	Examples:
+		| tabName         |
+		| Advisories      |
+		| SBOMs           |
+		| Packages        |
+		| Vulnerabilities |

--- a/e2e/tests/ui/features/@search/search.feature
+++ b/e2e/tests/ui/features/@search/search.feature
@@ -1,0 +1,10 @@
+Feature: Search Page
+	As a user
+	I want the Search page to only display relevant actions
+	So that I am not confused by buttons that don't apply to the current context
+
+# Related to TC-3248: Upload Advisory button should not appear on Search page
+Scenario: Verify Upload Advisory button is not displayed on Search page
+	When User navigates to "Search" page
+	And User clicks on "Advisories" tab
+	Then "Upload Advisory" button should not be displayed

--- a/e2e/tests/ui/features/@search/search.step.ts
+++ b/e2e/tests/ui/features/@search/search.step.ts
@@ -1,0 +1,16 @@
+import { createBdd } from "playwright-bdd";
+
+import { test } from "../../fixtures";
+
+import { expect } from "../../assertions";
+
+export const { Given, When, Then } = createBdd(test);
+
+// TC-3248: Verify Upload Advisory button should not appear on Search page
+Then(
+  "{string} button should not be displayed",
+  async ({ page }, buttonText: string) => {
+    const button = page.getByRole("button", { name: buttonText, exact: true });
+    await expect(button).not.toBeVisible();
+  },
+);

--- a/e2e/tests/ui/features/search.feature
+++ b/e2e/tests/ui/features/search.feature
@@ -66,14 +66,14 @@ Scenario: Search bar should not preview anything when no matches are found
 	When user starts typing a "non-existent name" in the search bar
 	Then The autofill drop down should not show any values
 
-Scenario Outline: User searches for a specific <type> 
+Scenario Outline: User searches for a specific <type>
 	When user types a <type-name> in the search bar
 	And user presses Enter
 	And user toggles the <types> list
-	Then the <types> list should display the specific <type-name> 
-	And the user should be able to filter <types> 
+	Then the <types> list should display the specific <type-name>
+	And the user should be able to filter <types>
 	And user clicks on the "<type>" name
-	And the user should be navigated to the specific "<type>" page 
+	And the user should be navigated to the specific "<type>" page
 
 	Examples:
 	|type|types|type-name|

--- a/e2e/tests/ui/pages/not-found/not-found.spec.ts
+++ b/e2e/tests/ui/pages/not-found/not-found.spec.ts
@@ -26,6 +26,12 @@ test.describe("Not Found page", { tag: "@tier1" }, () => {
     await expectNotFound(page);
   });
 
+  // TC-3218: Verify /upload route shows 404 page
+  test("Shows 404 page for /upload route", async ({ page }) => {
+    await page.goto("/upload");
+    await expectNotFound(page);
+  });
+
   test("Shows 404 page for non-existent advisory", async ({ page }) => {
     await page.goto(`/advisories/${NON_EXISTENT_UUID}`);
     await expectNotFound(page);

--- a/e2e/tests/ui/steps/navigation.ts
+++ b/e2e/tests/ui/steps/navigation.ts
@@ -1,0 +1,27 @@
+import { createBdd } from "playwright-bdd";
+
+import { test } from "../fixtures";
+
+import { expect } from "../assertions";
+import { Navigation } from "../pages/Navigation";
+
+export const { Given, When, Then } = createBdd(test);
+
+When("User navigates to {string} page", async ({ page }, pageName: string) => {
+  const navigation = await Navigation.build(page);
+  await navigation.goToSidebar(
+    pageName as Parameters<Navigation["goToSidebar"]>[0],
+  );
+});
+
+When("User clicks on {string} tab", async ({ page }, tabName: string) => {
+  const tab = page.getByRole("tab", { name: tabName });
+  await tab.click();
+});
+
+Then(
+  "the page title should contain {string}",
+  async ({ page }, expectedText: string) => {
+    await expect.poll(async () => page.title()).toContain(expectedText);
+  },
+);


### PR DESCRIPTION
Backport of https://github.com/guacsec/trustify-ui/pull/1149 to release/0.5.z.

## Summary
<!-- Describe what changed and why -->

## Related Issues
<!-- Fixes #123 or Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] Other (describe below)

## Testing
- [ ] All tests pass (`npm test`)
- [ ] No lint errors (`npm run lint`)
- [ ] No type errors (TypeScript compiles cleanly)
- [ ] New/changed UI behavior visually verified in browser
- [ ] Mock data updated if API types changed

## Screenshots
<!-- If UI changed, add before/after screenshots -->

## Summary by Sourcery

Add new end-to-end coverage for page title behavior, search page button visibility, and upload route 404 handling.

New Features:
- Add BDD feature and step definitions to verify browser page titles across main pages and search tabs.
- Add BDD feature and step to validate that the Upload Advisory button is not shown on the Search page.

Tests:
- Add Playwright tests to ensure /upload route returns the Not Found page.
- Introduce reusable navigation and page title assertion steps for UI E2E tests.
- Tidy existing search feature wording/whitespace in test descriptions.