### PR TITLE
Fix: "View Vulnerability" link not vertically aligned to bottom

### DIFF
--- a/client/src/app/pages/home/components/WhatNeedsAttention.tsx
+++ b/client/src/app/pages/home/components/WhatNeedsAttention.tsx
@@ -89,7 +89,11 @@ export const VulnerabilityAttentionSection: React.FC = () => {
             {attentionVulnerabilities.length > 0 ? (
               <Flex
                 direction={{ default: "column", md: "row" }}
-                alignItems={{ default: "alignItemsStretch" }}
+                alignItems={{
+                  default: "alignItemsStretch",
+                  sm: "alignItemsStretch",
+                  md: "alignItemsStretch",
+                }}
               >
                 {attentionVulnerabilities.map((vulnerability, index) => (
                   <React.Fragment key={vulnerability.identifier}>


### PR DESCRIPTION
## Summary
Just because <Flex> container was written like that:
             

           
```
<Flex
 direction={{ default: "column", md: "row" }}
 alignItems={{ default: "alignItemsStretch" }}
 >
```
              
 When direction was changed from `default:"column"` to `md:"row"` `alignItems` was overwritten with patternfly default fro row

## Related Issues
Fixes [TC-5199](https://redhat.atlassian.net/browse/TC-5199)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] Other (describe below)

## Testing
- [ ] All tests pass (`npm test`)
- [ ] No lint errors (`npm run lint`)
- [ ] No type errors (TypeScript compiles cleanly)
- [ ] New/changed UI behavior visually verified in browser
- [ ] Mock data updated if API types changed

## Screenshots
<img width="1131" height="310" alt="Screenshot 2026-07-21 at 16 22 16" src="https://github.com/user-attachments/assets/ea8f9356-ff82-450a-a47b-d99fd163e1e7" />


[TC-5199]: https://redhat.atlassian.net/browse/TC-5199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Prevent PatternFly default flex alignment from overriding the intended vertical alignment of the vulnerability cards across screen sizes.