### PR TITLE
fix(server): upgrade http-proxy-middleware to 3.0.7 (CVE-2026-55603)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7022,9 +7022,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.15",
@@ -7035,7 +7035,7 @@
         "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/http-proxy-middleware/node_modules/is-plain-object": {
@@ -13427,7 +13427,7 @@
         "cookie-parser": "^1.4.6",
         "ejs": "^3.1.10",
         "express": "^5.1.0",
-        "http-proxy-middleware": "^3.0.5",
+        "http-proxy-middleware": "^3.0.7",
         "http-terminator": "^3.2.0"
       },
       "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,7 @@
     "cookie-parser": "^1.4.6",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
-    "http-proxy-middleware": "^3.0.5",
+    "http-proxy-middleware": "^3.0.7",
     "http-terminator": "^3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Upgrades `http-proxy-middleware` from 3.0.5 to 3.0.7 in the `server` workspace
- Remediates **CVE-2026-55603** (CR/LF injection in `fixRequestBody()` when Content-Type is `multipart/form-data`)
- All RHTPA 2.2.x versions (2.2.0–2.2.6) ship the vulnerable 3.0.5

## References

- **CVE:** [CVE-2026-55603](https://www.cve.org/CVERecord?id=CVE-2026-55603)
- **GHSA:** [GHSA-gcq2-9pq2-cxqm](https://github.com/advisories/GHSA-gcq2-9pq2-cxqm)
- **CVSS:** 7.5 (HIGH)
- **Jira:** [TC-5360](https://redhat.atlassian.net/browse/TC-5360)
- **Tracker:** [TC-4975](https://redhat.atlassian.net/browse/TC-4975)

## Test plan

- [x] `npm run build --workspace=server` passes
- [x] `package-lock.json` resolves to 3.0.7
- [x] No other files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-5360]: https://redhat.atlassian.net/browse/TC-5360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-4975]: https://redhat.atlassian.net/browse/TC-4975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Enhancements:
- Update http-proxy-middleware dependency in the server package.json from 3.0.5 to 3.0.7 to consume the security fix.