### PR TITLE
test(e2e): analysis response to art-images on Atlas

### DIFF
--- a/e2e/tests/api/features/analysis-atlas.ts
+++ b/e2e/tests/api/features/analysis-atlas.ts
@@ -1,0 +1,46 @@
+import { logger } from "../../common/constants";
+import { expect, test } from "../fixtures";
+import { formatTimeElapsed } from "../helpers/general-helpers";
+
+// This is a set of tests that are designed to run against an Atlas instance, as they assume that certain data is already ingested.
+
+const responseTimeout = 1200000; // 20 minutes
+
+test.describe("Analysis / Atlas", () => {
+  test.skip(
+    !process.env.ATLAS_ENV || process.env.ATLAS_ENV !== "true",
+    "Skipping Atlas tests - ATLAS_ENV is not set to true.",
+  );
+
+  test(
+    `Check if response is received for art-images`,
+    {
+      annotation: {
+        type: "issue",
+        description: "https://redhat.atlassian.net/browse/TC-4487",
+      },
+    },
+    async ({ axios }, testInfo) => {
+      testInfo.setTimeout(responseTimeout);
+
+      const startTime = Date.now();
+
+      const plainTestName = "art-images";
+      const urlEncodedName = encodeURIComponent(plainTestName);
+
+      const response = await axios.get(
+        `/api/v3/analysis/latest/component?q=name=${urlEncodedName}&limit=10`,
+      );
+
+      const endTime = Date.now();
+      const formattedTime = formatTimeElapsed(endTime, startTime);
+
+      logger.info(
+        `API call for name "${plainTestName}" took ${formattedTime}.`,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.data).toHaveProperty("items");
+    },
+  );
+});

--- a/e2e/tests/api/features/analysis-latest-atlas.ts
+++ b/e2e/tests/api/features/analysis-latest-atlas.ts
@@ -2,7 +2,7 @@ import { logger } from "../../common/constants";
 import { expect, test } from "../fixtures";
 import { formatTimeElapsed } from "../helpers/general-helpers";
 
-// This is a set of tests that are designed to run againt an Atlas instance, as they assume that certain data is already ingested.
+// This is a set of tests that are designed to run against an Atlas instance, as they assume that certain data is already ingested.
 
 // This is a list of purl which were reported by Atlas as problematic and not returning a response in time.
 const purlsReportedByAtlas = [


### PR DESCRIPTION
This is a single test that tests for [TC-4487](https://redhat.atlassian.net/browse/TC-4487) against an Atlas instance.

[TC-4487]: https://redhat.atlassian.net/browse/TC-4487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add an Atlas-specific e2e API test to verify analysis responses for pre-ingested art-images data.

Tests:
- Add an Atlas-only e2e test that validates the analysis latest API returns a successful response with items for the art-images component.
- Guard new Atlas tests behind the ATLAS_ENV flag and enforce an extended timeout for long-running analysis requests.