### PR TITLE
fix: make csaf schema not dependant of online resources

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
     "start:dev": "npm run generate && vite --port 3000 --host",
     "start": "vite preview",
     "test": "vitest --run",
-    "generate": "openapi-ts -f ./config/openapi-ts.config.ts && json2ts specs/csaf_v2.0_json_schema.json -o src/app/specs/csaf/csaf-v2.0-schema.d.ts",
+    "generate": "openapi-ts -f ./config/openapi-ts.config.ts && json2ts specs/csaf_v2.0_json_schema.json --cwd=specs -o src/app/specs/csaf/csaf-v2.0-schema.d.ts",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/client/specs/csaf_v2.0_json_schema.json
+++ b/client/specs/csaf_v2.0_json_schema.json
@@ -1205,15 +1205,15 @@
               "required": ["products"],
               "properties": {
                 "cvss_v2": {
-                  "$ref": "https://www.first.org/cvss/cvss-v2.0.json"
+                  "$ref": "cvss-v2.0.json"
                 },
                 "cvss_v3": {
                   "oneOf": [
                     {
-                      "$ref": "https://www.first.org/cvss/cvss-v3.0.json"
+                      "$ref": "cvss-v3.0.json"
                     },
                     {
-                      "$ref": "https://www.first.org/cvss/cvss-v3.1.json"
+                      "$ref": "cvss-v3.1.json"
                     }
                   ]
                 },

--- a/client/specs/cvss-v2.0.json
+++ b/client/specs/cvss-v2.0.json
@@ -1,0 +1,127 @@
+{
+  "license": [
+    "Copyright (c) 2017, FIRST.ORG, INC.",
+    "All rights reserved.",
+    "",
+    "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+    "following conditions are met:",
+    "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+    "   disclaimer.",
+    "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+    "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+    "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+    "   products derived from this software without specific prior written permission.",
+    "",
+    "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+    "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+    "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+    "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+    "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+    "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+    "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+  ],
+
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "JSON Schema for Common Vulnerability Scoring System version 2.0",
+  "id": "https://www.first.org/cvss/cvss-v2.0.json?20170531",
+  "type": "object",
+  "definitions": {
+    "accessVectorType": {
+      "type": "string",
+      "enum": ["NETWORK", "ADJACENT_NETWORK", "LOCAL"]
+    },
+    "accessComplexityType": {
+      "type": "string",
+      "enum": ["HIGH", "MEDIUM", "LOW"]
+    },
+    "authenticationType": {
+      "type": "string",
+      "enum": ["MULTIPLE", "SINGLE", "NONE"]
+    },
+    "ciaType": {
+      "type": "string",
+      "enum": ["NONE", "PARTIAL", "COMPLETE"]
+    },
+    "exploitabilityType": {
+      "type": "string",
+      "enum": [
+        "UNPROVEN",
+        "PROOF_OF_CONCEPT",
+        "FUNCTIONAL",
+        "HIGH",
+        "NOT_DEFINED"
+      ]
+    },
+    "remediationLevelType": {
+      "type": "string",
+      "enum": [
+        "OFFICIAL_FIX",
+        "TEMPORARY_FIX",
+        "WORKAROUND",
+        "UNAVAILABLE",
+        "NOT_DEFINED"
+      ]
+    },
+    "reportConfidenceType": {
+      "type": "string",
+      "enum": ["UNCONFIRMED", "UNCORROBORATED", "CONFIRMED", "NOT_DEFINED"]
+    },
+    "collateralDamagePotentialType": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "LOW",
+        "LOW_MEDIUM",
+        "MEDIUM_HIGH",
+        "HIGH",
+        "NOT_DEFINED"
+      ]
+    },
+    "targetDistributionType": {
+      "type": "string",
+      "enum": ["NONE", "LOW", "MEDIUM", "HIGH", "NOT_DEFINED"]
+    },
+    "ciaRequirementType": {
+      "type": "string",
+      "enum": ["LOW", "MEDIUM", "HIGH", "NOT_DEFINED"]
+    },
+    "scoreType": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 10
+    }
+  },
+  "properties": {
+    "version": {
+      "description": "CVSS Version",
+      "type": "string",
+      "enum": ["2.0"]
+    },
+    "vectorString": {
+      "type": "string",
+      "pattern": "^((AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))/)*(AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))$"
+    },
+    "accessVector": { "$ref": "#/definitions/accessVectorType" },
+    "accessComplexity": { "$ref": "#/definitions/accessComplexityType" },
+    "authentication": { "$ref": "#/definitions/authenticationType" },
+    "confidentialityImpact": { "$ref": "#/definitions/ciaType" },
+    "integrityImpact": { "$ref": "#/definitions/ciaType" },
+    "availabilityImpact": { "$ref": "#/definitions/ciaType" },
+    "baseScore": { "$ref": "#/definitions/scoreType" },
+    "exploitability": { "$ref": "#/definitions/exploitabilityType" },
+    "remediationLevel": { "$ref": "#/definitions/remediationLevelType" },
+    "reportConfidence": { "$ref": "#/definitions/reportConfidenceType" },
+    "temporalScore": { "$ref": "#/definitions/scoreType" },
+    "collateralDamagePotential": {
+      "$ref": "#/definitions/collateralDamagePotentialType"
+    },
+    "targetDistribution": { "$ref": "#/definitions/targetDistributionType" },
+    "confidentialityRequirement": {
+      "$ref": "#/definitions/ciaRequirementType"
+    },
+    "integrityRequirement": { "$ref": "#/definitions/ciaRequirementType" },
+    "availabilityRequirement": { "$ref": "#/definitions/ciaRequirementType" },
+    "environmentalScore": { "$ref": "#/definitions/scoreType" }
+  },
+  "required": ["version", "vectorString", "baseScore"]
+}

--- a/client/specs/cvss-v3.0.json
+++ b/client/specs/cvss-v3.0.json
@@ -1,0 +1,173 @@
+{
+  "license": [
+    "Copyright (c) 2017, FIRST.ORG, INC.",
+    "All rights reserved.",
+    "",
+    "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+    "following conditions are met:",
+    "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+    "   disclaimer.",
+    "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+    "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+    "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+    "   products derived from this software without specific prior written permission.",
+    "",
+    "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+    "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+    "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+    "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+    "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+    "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+    "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+  ],
+
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "JSON Schema for Common Vulnerability Scoring System version 3.0",
+  "id": "https://www.first.org/cvss/cvss-v3.0.json?20170531",
+  "type": "object",
+  "definitions": {
+    "attackVectorType": {
+      "type": "string",
+      "enum": ["NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL"]
+    },
+    "modifiedAttackVectorType": {
+      "type": "string",
+      "enum": [
+        "NETWORK",
+        "ADJACENT_NETWORK",
+        "LOCAL",
+        "PHYSICAL",
+        "NOT_DEFINED"
+      ]
+    },
+    "attackComplexityType": {
+      "type": "string",
+      "enum": ["HIGH", "LOW"]
+    },
+    "modifiedAttackComplexityType": {
+      "type": "string",
+      "enum": ["HIGH", "LOW", "NOT_DEFINED"]
+    },
+    "privilegesRequiredType": {
+      "type": "string",
+      "enum": ["HIGH", "LOW", "NONE"]
+    },
+    "modifiedPrivilegesRequiredType": {
+      "type": "string",
+      "enum": ["HIGH", "LOW", "NONE", "NOT_DEFINED"]
+    },
+    "userInteractionType": {
+      "type": "string",
+      "enum": ["NONE", "REQUIRED"]
+    },
+    "modifiedUserInteractionType": {
+      "type": "string",
+      "enum": ["NONE", "REQUIRED", "NOT_DEFINED"]
+    },
+    "scopeType": {
+      "type": "string",
+      "enum": ["UNCHANGED", "CHANGED"]
+    },
+    "modifiedScopeType": {
+      "type": "string",
+      "enum": ["UNCHANGED", "CHANGED", "NOT_DEFINED"]
+    },
+    "ciaType": {
+      "type": "string",
+      "enum": ["NONE", "LOW", "HIGH"]
+    },
+    "modifiedCiaType": {
+      "type": "string",
+      "enum": ["NONE", "LOW", "HIGH", "NOT_DEFINED"]
+    },
+    "exploitCodeMaturityType": {
+      "type": "string",
+      "enum": [
+        "UNPROVEN",
+        "PROOF_OF_CONCEPT",
+        "FUNCTIONAL",
+        "HIGH",
+        "NOT_DEFINED"
+      ]
+    },
+    "remediationLevelType": {
+      "type": "string",
+      "enum": [
+        "OFFICIAL_FIX",
+        "TEMPORARY_FIX",
+        "WORKAROUND",
+        "UNAVAILABLE",
+        "NOT_DEFINED"
+      ]
+    },
+    "confidenceType": {
+      "type": "string",
+      "enum": ["UNKNOWN", "REASONABLE", "CONFIRMED", "NOT_DEFINED"]
+    },
+    "ciaRequirementType": {
+      "type": "string",
+      "enum": ["LOW", "MEDIUM", "HIGH", "NOT_DEFINED"]
+    },
+    "scoreType": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 10
+    },
+    "severityType": {
+      "type": "string",
+      "enum": ["NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL"]
+    }
+  },
+  "properties": {
+    "version": {
+      "description": "CVSS Version",
+      "type": "string",
+      "enum": ["3.0"]
+    },
+    "vectorString": {
+      "type": "string",
+      "pattern": "^CVSS:3[.]0/((AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+    },
+    "attackVector": { "$ref": "#/definitions/attackVectorType" },
+    "attackComplexity": { "$ref": "#/definitions/attackComplexityType" },
+    "privilegesRequired": { "$ref": "#/definitions/privilegesRequiredType" },
+    "userInteraction": { "$ref": "#/definitions/userInteractionType" },
+    "scope": { "$ref": "#/definitions/scopeType" },
+    "confidentialityImpact": { "$ref": "#/definitions/ciaType" },
+    "integrityImpact": { "$ref": "#/definitions/ciaType" },
+    "availabilityImpact": { "$ref": "#/definitions/ciaType" },
+    "baseScore": { "$ref": "#/definitions/scoreType" },
+    "baseSeverity": { "$ref": "#/definitions/severityType" },
+    "exploitCodeMaturity": { "$ref": "#/definitions/exploitCodeMaturityType" },
+    "remediationLevel": { "$ref": "#/definitions/remediationLevelType" },
+    "reportConfidence": { "$ref": "#/definitions/confidenceType" },
+    "temporalScore": { "$ref": "#/definitions/scoreType" },
+    "temporalSeverity": { "$ref": "#/definitions/severityType" },
+    "confidentialityRequirement": {
+      "$ref": "#/definitions/ciaRequirementType"
+    },
+    "integrityRequirement": { "$ref": "#/definitions/ciaRequirementType" },
+    "availabilityRequirement": { "$ref": "#/definitions/ciaRequirementType" },
+    "modifiedAttackVector": {
+      "$ref": "#/definitions/modifiedAttackVectorType"
+    },
+    "modifiedAttackComplexity": {
+      "$ref": "#/definitions/modifiedAttackComplexityType"
+    },
+    "modifiedPrivilegesRequired": {
+      "$ref": "#/definitions/modifiedPrivilegesRequiredType"
+    },
+    "modifiedUserInteraction": {
+      "$ref": "#/definitions/modifiedUserInteractionType"
+    },
+    "modifiedScope": { "$ref": "#/definitions/modifiedScopeType" },
+    "modifiedConfidentialityImpact": {
+      "$ref": "#/definitions/modifiedCiaType"
+    },
+    "modifiedIntegrityImpact": { "$ref": "#/definitions/modifiedCiaType" },
+    "modifiedAvailabilityImpact": { "$ref": "#/definitions/modifiedCiaType" },
+    "environmentalScore": { "$ref": "#/definitions/scoreType" },
+    "environmentalSeverity": { "$ref": "#/definitions/severityType" }
+  },
+  "required": ["version", "vectorString", "baseScore", "baseSeverity"]
+}

--- a/client/specs/cvss-v3.1.json
+++ b/client/specs/cvss-v3.1.json
@@ -1,0 +1,173 @@
+{
+  "license": [
+    "Copyright (c) 2021, FIRST.ORG, INC.",
+    "All rights reserved.",
+    "",
+    "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+    "following conditions are met:",
+    "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+    "   disclaimer.",
+    "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+    "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+    "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+    "   products derived from this software without specific prior written permission.",
+    "",
+    "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+    "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+    "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+    "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+    "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+    "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+    "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+  ],
+
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON Schema for Common Vulnerability Scoring System version 3.1",
+  "$id": "https://www.first.org/cvss/cvss-v3.1.json?20211103",
+  "type": "object",
+  "definitions": {
+    "attackVectorType": {
+      "type": "string",
+      "enum": ["NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL"]
+    },
+    "modifiedAttackVectorType": {
+      "type": "string",
+      "enum": [
+        "NETWORK",
+        "ADJACENT_NETWORK",
+        "LOCAL",
+        "PHYSICAL",
+        "NOT_DEFINED"
+      ]
+    },
+    "attackComplexityType": {
+      "type": "string",
+      "enum": ["HIGH", "LOW"]
+    },
+    "modifiedAttackComplexityType": {
+      "type": "string",
+      "enum": ["HIGH", "LOW", "NOT_DEFINED"]
+    },
+    "privilegesRequiredType": {
+      "type": "string",
+      "enum": ["HIGH", "LOW", "NONE"]
+    },
+    "modifiedPrivilegesRequiredType": {
+      "type": "string",
+      "enum": ["HIGH", "LOW", "NONE", "NOT_DEFINED"]
+    },
+    "userInteractionType": {
+      "type": "string",
+      "enum": ["NONE", "REQUIRED"]
+    },
+    "modifiedUserInteractionType": {
+      "type": "string",
+      "enum": ["NONE", "REQUIRED", "NOT_DEFINED"]
+    },
+    "scopeType": {
+      "type": "string",
+      "enum": ["UNCHANGED", "CHANGED"]
+    },
+    "modifiedScopeType": {
+      "type": "string",
+      "enum": ["UNCHANGED", "CHANGED", "NOT_DEFINED"]
+    },
+    "ciaType": {
+      "type": "string",
+      "enum": ["NONE", "LOW", "HIGH"]
+    },
+    "modifiedCiaType": {
+      "type": "string",
+      "enum": ["NONE", "LOW", "HIGH", "NOT_DEFINED"]
+    },
+    "exploitCodeMaturityType": {
+      "type": "string",
+      "enum": [
+        "UNPROVEN",
+        "PROOF_OF_CONCEPT",
+        "FUNCTIONAL",
+        "HIGH",
+        "NOT_DEFINED"
+      ]
+    },
+    "remediationLevelType": {
+      "type": "string",
+      "enum": [
+        "OFFICIAL_FIX",
+        "TEMPORARY_FIX",
+        "WORKAROUND",
+        "UNAVAILABLE",
+        "NOT_DEFINED"
+      ]
+    },
+    "confidenceType": {
+      "type": "string",
+      "enum": ["UNKNOWN", "REASONABLE", "CONFIRMED", "NOT_DEFINED"]
+    },
+    "ciaRequirementType": {
+      "type": "string",
+      "enum": ["LOW", "MEDIUM", "HIGH", "NOT_DEFINED"]
+    },
+    "scoreType": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 10
+    },
+    "severityType": {
+      "type": "string",
+      "enum": ["NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL"]
+    }
+  },
+  "properties": {
+    "version": {
+      "description": "CVSS Version",
+      "type": "string",
+      "enum": ["3.1"]
+    },
+    "vectorString": {
+      "type": "string",
+      "pattern": "^CVSS:3[.]1/((AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+    },
+    "attackVector": { "$ref": "#/definitions/attackVectorType" },
+    "attackComplexity": { "$ref": "#/definitions/attackComplexityType" },
+    "privilegesRequired": { "$ref": "#/definitions/privilegesRequiredType" },
+    "userInteraction": { "$ref": "#/definitions/userInteractionType" },
+    "scope": { "$ref": "#/definitions/scopeType" },
+    "confidentialityImpact": { "$ref": "#/definitions/ciaType" },
+    "integrityImpact": { "$ref": "#/definitions/ciaType" },
+    "availabilityImpact": { "$ref": "#/definitions/ciaType" },
+    "baseScore": { "$ref": "#/definitions/scoreType" },
+    "baseSeverity": { "$ref": "#/definitions/severityType" },
+    "exploitCodeMaturity": { "$ref": "#/definitions/exploitCodeMaturityType" },
+    "remediationLevel": { "$ref": "#/definitions/remediationLevelType" },
+    "reportConfidence": { "$ref": "#/definitions/confidenceType" },
+    "temporalScore": { "$ref": "#/definitions/scoreType" },
+    "temporalSeverity": { "$ref": "#/definitions/severityType" },
+    "confidentialityRequirement": {
+      "$ref": "#/definitions/ciaRequirementType"
+    },
+    "integrityRequirement": { "$ref": "#/definitions/ciaRequirementType" },
+    "availabilityRequirement": { "$ref": "#/definitions/ciaRequirementType" },
+    "modifiedAttackVector": {
+      "$ref": "#/definitions/modifiedAttackVectorType"
+    },
+    "modifiedAttackComplexity": {
+      "$ref": "#/definitions/modifiedAttackComplexityType"
+    },
+    "modifiedPrivilegesRequired": {
+      "$ref": "#/definitions/modifiedPrivilegesRequiredType"
+    },
+    "modifiedUserInteraction": {
+      "$ref": "#/definitions/modifiedUserInteractionType"
+    },
+    "modifiedScope": { "$ref": "#/definitions/modifiedScopeType" },
+    "modifiedConfidentialityImpact": {
+      "$ref": "#/definitions/modifiedCiaType"
+    },
+    "modifiedIntegrityImpact": { "$ref": "#/definitions/modifiedCiaType" },
+    "modifiedAvailabilityImpact": { "$ref": "#/definitions/modifiedCiaType" },
+    "environmentalScore": { "$ref": "#/definitions/scoreType" },
+    "environmentalSeverity": { "$ref": "#/definitions/severityType" }
+  },
+  "required": ["version", "vectorString", "baseScore", "baseSeverity"]
+}


### PR DESCRIPTION
Problem:
The csaf schema json file is referring to resources on the web. In Hermetic builds it will fails.
The problematic online resource is `https://www.first.org/cvss/*`

Solution:
Make all online resources available locally

## Summary by Sourcery

Make the CSAF schema generation independent of online CVSS resources by referencing local schema files instead.

Build:
- Adjust the generate script to run json2ts with a cwd of the local specs directory for CSAF schema generation.

Chores:
- Add local CVSS v2.0, v3.0, and v3.1 schema JSON files to replace external web references.