### PR TITLE
[0.6.z] fix: decode encoded PURLs (#1190)

### DIFF
--- a/client/src/app/pages/package-list/package-table.tsx
+++ b/client/src/app/pages/package-list/package-table.tsx
@@ -19,6 +19,7 @@ import {
   TableRowContentWithControls,
 } from "@app/components/TableControls";
 import { Paths } from "@app/Routes";
+import { decodePurl } from "@app/utils/utils";
 import { PackageSearchContext } from "./package-context";
 import { PackageVulnerabilities } from "./components/PackageVulnerabilities";
 import { List, ListItem } from "@patternfly/react-core";
@@ -89,7 +90,7 @@ export const PackageTable: React.FC = () => {
                           >
                             {item.decomposedPurl
                               ? item.decomposedPurl?.name
-                              : item.purl}
+                              : decodePurl(item.purl)}
                           </NavLink>
                         </Td>
                         <Td

--- a/client/src/app/pages/sbom-details/models-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/models-by-sbom.tsx
@@ -32,6 +32,7 @@ import {
   useTableControlState,
 } from "@app/hooks/table-controls";
 import { useFetchModelsBySbomId } from "@app/queries/sboms";
+import { decodePurl } from "@app/utils/utils";
 
 interface ModelsProps {
   sbomId: string;
@@ -139,7 +140,9 @@ export const ModelsBySbom: React.FC<ModelsProps> = ({ sbomId }) => {
                           </FlexItem>
                           <FlexItem>
                             <small>
-                              {model?.purls.map((e) => e.purl).join(",")}
+                              {model?.purls
+                                .map((e) => decodePurl(e.purl))
+                                .join(",")}
                             </small>
                           </FlexItem>
                           <FlexItem>

--- a/client/src/app/pages/sbom-details/overview.tsx
+++ b/client/src/app/pages/sbom-details/overview.tsx
@@ -24,7 +24,7 @@ import PenIcon from "@patternfly/react-icons/dist/esm/icons/pen-icon";
 import type { SbomSummary } from "@app/client";
 import { LabelsAsList } from "@app/components/LabelsAsList";
 import { ReadOnlyButton } from "@app/components/ReadOnlyButton";
-import { formatDate } from "@app/utils/utils";
+import { decodePurl, formatDate } from "@app/utils/utils";
 
 import { SBOMEditLabelsForm } from "../sbom-list/components/SBOMEditLabelsForm";
 
@@ -169,7 +169,7 @@ export const Overview: React.FC<InfoProps> = ({ sbom }) => {
                       {sbom.described_by
                         .flatMap((e) => e.purl)
                         .map((e) => (
-                          <ListItem key={e.uuid}>{e.purl}</ListItem>
+                          <ListItem key={e.uuid}>{decodePurl(e.purl)}</ListItem>
                         ))}
                     </List>
                   </DescriptionListDescription>

--- a/client/src/app/pages/sbom-details/packages-by-sbom.tsx
+++ b/client/src/app/pages/sbom-details/packages-by-sbom.tsx
@@ -36,6 +36,7 @@ import {
 import { useFetchPackagesBySbomId } from "@app/queries/packages";
 import { useFetchSbomsLicenseIds } from "@app/queries/sboms";
 import { Paths } from "@app/Routes";
+import { decodePurl } from "@app/utils/utils";
 
 import { PackageVulnerabilities } from "../package-list/components/PackageVulnerabilities";
 import { WithPackage } from "@app/components/WithPackage";
@@ -243,7 +244,7 @@ export const PackagesBySbom: React.FC<PackagesProps> = ({ sbomId }) => {
                             packageId: item.purl[0].uuid,
                           })}
                         >
-                          {item.purl[0].purl}
+                          {decodePurl(item.purl[0].purl)}
                         </Link>
                       ) : (
                         `${item.purl.length} PURLs`
@@ -297,7 +298,7 @@ export const PackagesBySbom: React.FC<PackagesProps> = ({ sbomId }) => {
                                         packageId: e.uuid,
                                       })}
                                     >
-                                      {e.purl}
+                                      {decodePurl(e.purl)}
                                     </Link>
                                   </ListItem>
                                 );

--- a/client/src/app/pages/sbom-scan/components/VulnerabilityTable.tsx
+++ b/client/src/app/pages/sbom-scan/components/VulnerabilityTable.tsx
@@ -40,7 +40,7 @@ import { VulnerabilityStatusLabel } from "@app/components/VulnerabilityStatusLab
 import { useLocalTableControls } from "@app/hooks/table-controls";
 import { Paths } from "@app/Routes";
 import { useWithUiId } from "@app/utils/query-utils";
-import { decomposePurl, formatDate } from "@app/utils/utils";
+import { decodePurl, decomposePurl, formatDate } from "@app/utils/utils";
 
 import type { VulnerabilityOfSbomFromAnalysis } from "../hooks/useVulnerabilitiesOfSbom";
 import { extractImporterNameFromAdvisory } from "../scan-utils";
@@ -421,7 +421,7 @@ export const VulnerabilityTable: React.FC<IVulnerabilityTableProps> = ({
 
                                 return (
                                   <Tr key={purl}>
-                                    <Td colSpan={6}>{purl}</Td>
+                                    <Td colSpan={6}>{decodePurl(purl)}</Td>
                                   </Tr>
                                 );
                               })}

--- a/client/src/app/pages/search/components/SearchMenu.tsx
+++ b/client/src/app/pages/search/components/SearchMenu.tsx
@@ -21,6 +21,7 @@ import { useFetchAdvisories } from "@app/queries/advisories";
 import { useFetchPackages } from "@app/queries/packages";
 import { useFetchSBOMs } from "@app/queries/sboms";
 import { useFetchVulnerabilities } from "@app/queries/vulnerabilities";
+import { decodePurl } from "@app/utils/utils";
 
 export interface IEntity {
   id: string;
@@ -107,7 +108,7 @@ function useAllEntities(filterText: string, disableSearch: boolean) {
 
   const transformedPackages: IEntity[] = packages.map((item) => ({
     id: `package-${item.uuid}`,
-    title: item.purl,
+    title: decodePurl(item.purl),
     navLink: `/packages/${item.uuid}`,
     type: "Package",
     typeColor: "teal",

--- a/client/src/app/utils/utils.test.ts
+++ b/client/src/app/utils/utils.test.ts
@@ -1,6 +1,6 @@
 import type { AxiosError } from "axios";
 
-import { getAxiosErrorMessage, getToolbarChipKey } from "./utils";
+import { decodePurl, getAxiosErrorMessage, getToolbarChipKey } from "./utils";
 
 const createAxiosError = (
   overrides: Partial<AxiosError> = {},
@@ -123,5 +123,24 @@ describe("utils", () => {
       },
     });
     expect(getAxiosErrorMessage(error)).toBe("SomeError: Something happened");
+  });
+
+  // decodePurl
+
+  it("decodePurl: decodes percent-encoded qualifiers", () => {
+    const encoded =
+      "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12.redhat-00002?repository_url=https:%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar";
+    expect(decodePurl(encoded)).toBe(
+      "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12.redhat-00002?repository_url=https://maven.repository.redhat.com/ga/&type=jar",
+    );
+  });
+
+  it("decodePurl: returns original value for malformed URI sequences", () => {
+    expect(decodePurl("pkg:%")).toBe("pkg:%");
+  });
+
+  it("decodePurl: returns empty string for null or undefined", () => {
+    expect(decodePurl(null)).toBe("");
+    expect(decodePurl(undefined)).toBe("");
   });
 });

--- a/client/src/app/utils/utils.ts
+++ b/client/src/app/utils/utils.ts
@@ -117,6 +117,18 @@ export const decomposePurl = (purl: string) => {
   }
 };
 
+/** Decode a PURL for display. Falls back to the original value if decoding fails. */
+export const decodePurl = (purl: string | null | undefined): string => {
+  if (purl == null) {
+    return "";
+  }
+  try {
+    return decodeURIComponent(purl);
+  } catch {
+    return purl;
+  }
+};
+
 export const getString = (input: string | (() => string)) =>
   typeof input === "function" ? input() : input;
 

--- a/e2e/tests/api/features/analysis-relationship-ancestor-of.ts
+++ b/e2e/tests/api/features/analysis-relationship-ancestor-of.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "../fixtures";
+import { decodeAnalysisItemPurls } from "../helpers/general-helpers";
 
 // Effectively tests TC-2054 / TC-2055 - Denote upstream relationship.
 
@@ -19,7 +20,7 @@ test("Ancestor of / CDX / Upstream component has descendants that include downst
     `/api/v3/analysis/component/${urlEncodedUpstreamPurl}?descendants=10`,
   );
 
-  expect(response.data.items).toEqual(
+  expect(response.data.items.map(decodeAnalysisItemPurls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: expect.arrayContaining([cdxUpstreamPurl]),
@@ -42,7 +43,7 @@ test.skip("Ancestor of / CDX / Upstream component has descendants that include d
     `/api/v3/analysis/component?q=${query}?descendants=10`,
   );
 
-  expect(response.data.items).toEqual(
+  expect(response.data.items.map(decodeAnalysisItemPurls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: expect.arrayContaining([cdxUpstreamPurl]),
@@ -66,7 +67,7 @@ test("Ancestor of / CDX / Downstream component has ancestors that include upstre
     `/api/v3/analysis/component/${urlEncodedDownstreamPurl}?ancestors=10`,
   );
 
-  expect(response.data.items).toEqual(
+  expect(response.data.items.map(decodeAnalysisItemPurls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: expect.arrayContaining([cdxDownstreamPurl]),
@@ -89,7 +90,7 @@ test.skip("Ancestor of / CDX / Downstream component has ancestors that include u
     `/api/v3/analysis/component?q=${query}?descendants=10`,
   );
 
-  expect(response.data.items).toEqual(
+  expect(response.data.items.map(decodeAnalysisItemPurls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: expect.arrayContaining([cdxDownstreamPurl]),
@@ -113,7 +114,7 @@ test("Ancestor of / SPDX / Upstream component has descendants that include downs
     `/api/v3/analysis/component/${urlEncodedUpstreamPurl}?descendants=10`,
   );
 
-  expect(response.data.items).toEqual(
+  expect(response.data.items.map(decodeAnalysisItemPurls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: expect.arrayContaining([spdxUpstreamPurl]),
@@ -136,7 +137,7 @@ test.skip("Ancestor of / SPDX / Upstream component has descendants that include 
     `/api/v3/analysis/component?q=${query}?descendants=10`,
   );
 
-  expect(response.data.items).toEqual(
+  expect(response.data.items.map(decodeAnalysisItemPurls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: expect.arrayContaining([spdxUpstreamPurl]),
@@ -160,7 +161,7 @@ test("Ancestor of / SPDX / Downstream component has ancestors that include upstr
     `/api/v3/analysis/component/${urlEncodedDownstreamPurl}?ancestors=10`,
   );
 
-  expect(response.data.items).toEqual(
+  expect(response.data.items.map(decodeAnalysisItemPurls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: expect.arrayContaining([spdxDownstreamPurl]),
@@ -183,7 +184,7 @@ test.skip("Ancestor of / SPDX / Downstream component has ancestors that include 
     `/api/v3/analysis/component?q=${query}?descendants=10`,
   );
 
-  expect(response.data.items).toEqual(
+  expect(response.data.items.map(decodeAnalysisItemPurls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: expect.arrayContaining([spdxDownstreamPurl]),

--- a/e2e/tests/api/features/analysis-relationship-variant-of.ts
+++ b/e2e/tests/api/features/analysis-relationship-variant-of.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "../fixtures";
+import { decodeAnalysisItemPurls } from "../helpers/general-helpers";
 
 // Effectively tests TC-2052 / TC-2053 - Denote image index to arch image variants relationship.
 
@@ -20,7 +21,7 @@ test("Variant of / CDX / Binary image has ancestors that include index image / G
     `/api/v3/analysis/component/${urlEncodedBinaryImagePurl}?ancestors=10`,
   );
 
-  expect(response.data.items).toEqual(
+  expect(response.data.items.map(decodeAnalysisItemPurls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: expect.arrayContaining([cdxBinaryImagePurl]),
@@ -44,7 +45,7 @@ test("Variant of / CDX / Index image has descendants that include binary image /
     `/api/v3/analysis/component/${urlEncodedIndexImagePurl}?descendants=10`,
   );
 
-  expect(response.data.items).toEqual(
+  expect(response.data.items.map(decodeAnalysisItemPurls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: expect.arrayContaining([cdxIndexImagePurl]),
@@ -68,7 +69,7 @@ test("Variant of / SPDX / Binary image has ancestors that include index image / 
     `/api/v3/analysis/component/${urlEncodedBinaryImagePurl}?ancestors=10`,
   );
 
-  expect(response.data.items).toEqual(
+  expect(response.data.items.map(decodeAnalysisItemPurls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: expect.arrayContaining([spdxBinaryImagePurl]),
@@ -92,7 +93,7 @@ test("Variant of / SPDX / Index image has descendants that include binary image 
     `/api/v3/analysis/component/${urlEncodedIndexImagePurl}?descendants=10`,
   );
 
-  expect(response.data.items).toEqual(
+  expect(response.data.items.map(decodeAnalysisItemPurls)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         purl: expect.arrayContaining([spdxIndexImagePurl]),

--- a/e2e/tests/api/helpers/general-helpers.ts
+++ b/e2e/tests/api/helpers/general-helpers.ts
@@ -57,3 +57,15 @@ export function formatTimeElapsed(endTime: number, startTime: number) {
 
   return formattedTime;
 }
+
+/** Decode percent-encoded qualifier values in analysis component purls. */
+export function decodeAnalysisItemPurls<
+  T extends { purl: string[]; ancestors?: T[]; descendants?: T[] },
+>(item: T): T {
+  return {
+    ...item,
+    purl: item.purl.map(decodeURIComponent),
+    ancestors: item.ancestors?.map(decodeAnalysisItemPurls),
+    descendants: item.descendants?.map(decodeAnalysisItemPurls),
+  };
+}


### PR DESCRIPTION
Backport to release/0.6.z of https://github.com/guacsec/trustify-ui/pull/1190

## Summary
<!-- Describe what changed and why -->

## Related Issues
<!-- Fixes #123 or Relates to #456 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] Other (describe below)

## Testing
- [ ] All tests pass (`npm test`)
- [ ] No lint errors (`npm run lint`)
- [ ] No type errors (TypeScript compiles cleanly)
- [ ] New/changed UI behavior visually verified in browser
- [ ] Mock data updated if API types changed

## Screenshots
<!-- If UI changed, add before/after screenshots -->

## Summary by Sourcery

Decode percent-encoded PURLs before display and assertion across the UI and API tests.

New Features:
- Add a utility function to decode PURLs with graceful handling of null and malformed values.

Enhancements:
- Update SBOM- and package-related UI views and vulnerability tables to show human-readable, decoded PURLs in links and lists.
- Introduce a helper to recursively decode PURLs in analysis API response items for test assertions.

Tests:
- Add unit tests for the PURL decoding utility, including edge cases for malformed and null inputs.
- Adjust analysis relationship API end-to-end tests to assert against decoded PURLs rather than raw encoded values.